### PR TITLE
fix: add tool_call_id to Message for OpenAI-compatible tool messages

### DIFF
--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -477,4 +477,75 @@ mod tests {
             "Expected a hint message about archiving after truncation"
         );
     }
+
+    #[tokio::test]
+    async fn test_agent_loop_propagates_tool_call_id() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let tools = default_tools(root.clone(), &[]);
+
+        let mut mock = MockProvider::new("gpt-4o");
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, "calling tool".to_string()),
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: 15,
+            },
+            finish_reason: FinishReason::ToolCalls,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_verify_tcid".into(),
+                name: "git_diff".into(),
+                arguments: serde_json::json!({}),
+            }]),
+        });
+        mock.add_response(ChatResponse {
+            message: Message::new(
+                Role::Assistant,
+                r#"{"findings":[],"stop":true}"#.to_string(),
+            ),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let contract = test_contract();
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Run git diff")],
+            workspace_root: root,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+
+        let tool_messages: Vec<&Message> = result
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Tool)
+            .collect();
+
+        assert!(
+            !tool_messages.is_empty(),
+            "expected at least one tool message"
+        );
+        for tm in &tool_messages {
+            assert!(
+                tm.tool_call_id.is_some(),
+                "tool message must carry tool_call_id: role={:?}, content={}",
+                tm.role,
+                tm.content
+            );
+            assert_eq!(
+                tm.tool_call_id.as_deref(),
+                Some("call_verify_tcid"),
+                "tool_call_id should match the assistant's tool call id"
+            );
+        }
+    }
 }

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -40,13 +40,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         config.contract.prompt_template, tools_json,
     );
 
-    messages.insert(
-        0,
-        Message {
-            role: Role::System,
-            content: system_prompt,
-        },
-    );
+    messages.insert(0, Message::new(Role::System, system_prompt));
 
     let cm = ContextManager::new(
         config.provider,
@@ -70,26 +64,26 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 
                 match archive_result {
                     Ok(path) => {
-                        messages.push(Message {
-                            role: Role::User,
-                            content: format!(
+                        messages.push(Message::new(
+                            Role::User,
+                            format!(
                                 "⚠️ Context was trimmed to stay within token budget.\n\
-                                 {} earlier messages are archived at:\n  {}\n\
-                                 Use read_file to inspect if you need context from earlier iterations.",
+                             {} earlier messages are archived at:\n  {}\n\
+                             Use read_file to inspect if you need context from earlier iterations.",
                                 dropped.len(),
                                 path.display(),
                             ),
-                        });
+                        ));
                     }
                     Err(_) => {
-                        messages.push(Message {
-                            role: Role::User,
-                            content: format!(
+                        messages.push(Message::new(
+                            Role::User,
+                            format!(
                                 "⚠️ Context was trimmed to stay within token budget.\n\
-                                 {} earlier messages were dropped (archive unavailable).",
+                             {} earlier messages were dropped (archive unavailable).",
                                 dropped.len(),
                             ),
-                        });
+                        ));
                     }
                 }
 
@@ -118,10 +112,10 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 
         match response.finish_reason {
             FinishReason::Stop => {
-                messages.push(Message {
-                    role: Role::Assistant,
-                    content: response.message.content.clone(),
-                });
+                messages.push(Message::new(
+                    Role::Assistant,
+                    response.message.content.clone(),
+                ));
 
                 let findings = extract_findings(&response.message.content);
                 return Ok(AgentResult {
@@ -135,10 +129,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
             FinishReason::ToolCalls => {
                 if let Some(tool_calls) = response.tool_calls {
                     let tool_call_content = serde_json::to_string(&tool_calls).unwrap_or_default();
-                    messages.push(Message {
-                        role: Role::Assistant,
-                        content: tool_call_content,
-                    });
+                    messages.push(Message::new(Role::Assistant, tool_call_content));
 
                     for tc in &tool_calls {
                         match config.tools.get(&tc.name) {
@@ -146,24 +137,27 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                                 let result = tool.execute(tc.arguments.clone()).await;
                                 match result {
                                     Ok(output) => {
-                                        messages.push(Message {
-                                            role: Role::Tool,
-                                            content: output,
-                                        });
+                                        messages.push(Message::with_tool_call(
+                                            Role::Tool,
+                                            output,
+                                            tc.id.clone(),
+                                        ));
                                     }
                                     Err(e) => {
-                                        messages.push(Message {
-                                            role: Role::Tool,
-                                            content: format!("Error: {}", e),
-                                        });
+                                        messages.push(Message::with_tool_call(
+                                            Role::Tool,
+                                            format!("Error: {}", e),
+                                            tc.id.clone(),
+                                        ));
                                     }
                                 }
                             }
                             None => {
-                                messages.push(Message {
-                                    role: Role::Tool,
-                                    content: format!("Error: Tool '{}' not found", tc.name),
-                                });
+                                messages.push(Message::with_tool_call(
+                                    Role::Tool,
+                                    format!("Error: Tool '{}' not found", tc.name),
+                                    tc.id.clone(),
+                                ));
                             }
                         }
                     }
@@ -252,10 +246,7 @@ mod tests {
 
         let mut mock = MockProvider::new("gpt-4o");
         mock.add_response(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content: "Checking code...".into(),
-            },
+            message: Message::new(Role::Assistant, "Checking code..."),
             usage: Usage {
                 input_tokens: 10,
                 output_tokens: 5,
@@ -269,10 +260,7 @@ mod tests {
             }]),
         });
         mock.add_response(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content: r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "test finding", "evidence": "test"}]}"#.into(),
-            },
+            message: Message::new(Role::Assistant, r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "test finding", "evidence": "test"}]}"#),
             usage: Usage {
                 input_tokens: 20,
                 output_tokens: 10,
@@ -287,10 +275,7 @@ mod tests {
             contract: &contract,
             provider: &mock,
             tools: &tools,
-            initial_messages: vec![Message {
-                role: Role::User,
-                content: "Review the diff".into(),
-            }],
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
             workspace_root: root.clone(),
         };
 
@@ -314,10 +299,7 @@ mod tests {
             contract: &contract,
             provider: &mock,
             tools: &tools,
-            initial_messages: vec![Message {
-                role: Role::User,
-                content: "Hi".into(),
-            }],
+            initial_messages: vec![Message::new(Role::User, "Hi")],
             workspace_root: tmp.path().to_path_buf(),
         };
 
@@ -347,10 +329,7 @@ mod tests {
 
         let mut mock = MockProvider::new("test-model");
         mock.add_response(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content: "Running tool...".into(),
-            },
+            message: Message::new(Role::Assistant, "Running tool..."),
             usage: Usage {
                 input_tokens: 5,
                 output_tokens: 5,
@@ -360,10 +339,7 @@ mod tests {
             tool_calls: Some(vec![tool_call.clone()]),
         });
         mock.add_response(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content: r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "test finding", "evidence": "test"}]}"#.into(),
-            },
+            message: Message::new(Role::Assistant, r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "test finding", "evidence": "test"}]}"#),
             usage: Usage {
                 input_tokens: 5,
                 output_tokens: 5,
@@ -378,10 +354,7 @@ mod tests {
             contract: &contract,
             provider: &mock,
             tools: &tools,
-            initial_messages: vec![Message {
-                role: Role::User,
-                content: huge_content,
-            }],
+            initial_messages: vec![Message::new(Role::User, huge_content)],
             workspace_root: root.clone(),
         };
 
@@ -420,10 +393,7 @@ mod tests {
 
         let mut mock = MockProvider::new("test-model");
         mock.add_response(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content: "Running tool...".into(),
-            },
+            message: Message::new(Role::Assistant, "Running tool..."),
             usage: Usage {
                 input_tokens: 5,
                 output_tokens: 5,
@@ -441,10 +411,7 @@ mod tests {
             contract: &contract,
             provider: &mock,
             tools: &tools,
-            initial_messages: vec![Message {
-                role: Role::User,
-                content: "Review".into(),
-            }],
+            initial_messages: vec![Message::new(Role::User, "Review")],
             workspace_root: root.clone(),
         };
 
@@ -471,10 +438,7 @@ mod tests {
 
         let mut mock = MockProvider::new("test-model");
         mock.add_response(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content: "Running tool...".into(),
-            },
+            message: Message::new(Role::Assistant, "Running tool..."),
             usage: Usage {
                 input_tokens: 5,
                 output_tokens: 5,
@@ -484,10 +448,7 @@ mod tests {
             tool_calls: Some(vec![tool_call.clone()]),
         });
         mock.add_response(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content: r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "test finding", "evidence": "test"}]}"#.into(),
-            },
+            message: Message::new(Role::Assistant, r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "test finding", "evidence": "test"}]}"#),
             usage: Usage {
                 input_tokens: 5,
                 output_tokens: 5,
@@ -502,10 +463,7 @@ mod tests {
             contract: &contract,
             provider: &mock,
             tools: &tools,
-            initial_messages: vec![Message {
-                role: Role::User,
-                content: huge_content,
-            }],
+            initial_messages: vec![Message::new(Role::User, huge_content)],
             workspace_root: root.clone(),
         };
 

--- a/crates/clausura-core/src/checkpoint.rs
+++ b/crates/clausura-core/src/checkpoint.rs
@@ -218,18 +218,9 @@ mod tests {
 
     fn make_messages() -> Vec<Message> {
         vec![
-            Message {
-                role: Role::System,
-                content: "You are a code reviewer.".into(),
-            },
-            Message {
-                role: Role::User,
-                content: "Review this code.".into(),
-            },
-            Message {
-                role: Role::Assistant,
-                content: "I found 3 issues.".into(),
-            },
+            Message::new(Role::System, "You are a code reviewer."),
+            Message::new(Role::User, "Review this code."),
+            Message::new(Role::Assistant, "I found 3 issues."),
         ]
     }
 

--- a/crates/clausura-core/src/context.rs
+++ b/crates/clausura-core/src/context.rs
@@ -217,19 +217,19 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_messages(count: usize) -> Vec<Message> {
-        let mut msgs = vec![Message {
-            role: Role::System,
-            content: "You are a helpful assistant.".to_string(),
-        }];
+        let mut msgs = vec![Message::new(
+            Role::System,
+            "You are a helpful assistant.".to_string(),
+        )];
         for i in 0..count - 1 {
-            msgs.push(Message {
-                role: if i % 2 == 0 {
+            msgs.push(Message::new(
+                if i % 2 == 0 {
                     Role::User
                 } else {
                     Role::Assistant
                 },
-                content: format!("Message {}", i),
-            });
+                format!("Message {}", i),
+            ));
         }
         msgs
     }
@@ -303,26 +303,11 @@ mod tests {
         let root = TempDir::new().unwrap();
         let manager = ContextManager::new(&mock, 50, root.path().to_path_buf());
         let msgs = vec![
-            Message {
-                role: Role::System,
-                content: "System prompt".to_string(),
-            },
-            Message {
-                role: Role::User,
-                content: "Run git diff".to_string(),
-            },
-            Message {
-                role: Role::Assistant,
-                content: "calling tool".to_string(),
-            },
-            Message {
-                role: Role::Tool,
-                content: "diff output".to_string(),
-            },
-            Message {
-                role: Role::User,
-                content: "What does that mean?".to_string(),
-            },
+            Message::new(Role::System, "System prompt".to_string()),
+            Message::new(Role::User, "Run git diff".to_string()),
+            Message::new(Role::Assistant, "calling tool".to_string()),
+            Message::new(Role::Tool, "diff output".to_string()),
+            Message::new(Role::User, "What does that mean?".to_string()),
         ];
         let mut msgs = msgs;
         let _dropped = manager.truncate(&mut msgs);
@@ -344,18 +329,9 @@ mod tests {
         let root = TempDir::new().unwrap();
         let cm = ContextManager::new(&mock, 1000, root.path().to_path_buf());
         let messages = vec![
-            Message {
-                role: Role::User,
-                content: "Hello".to_string(),
-            },
-            Message {
-                role: Role::Assistant,
-                content: "Hi there".to_string(),
-            },
-            Message {
-                role: Role::Tool,
-                content: "tool result".to_string(),
-            },
+            Message::new(Role::User, "Hello".to_string()),
+            Message::new(Role::Assistant, "Hi there".to_string()),
+            Message::new(Role::Tool, "tool result".to_string()),
         ];
         let path = cm.archive(&messages, "test-task").await.unwrap();
         assert_eq!(
@@ -391,10 +367,7 @@ mod tests {
         let mock = MockProvider::new("test");
         let root = TempDir::new().unwrap();
         let cm = ContextManager::new(&mock, 1000, root.path().to_path_buf());
-        let messages = vec![Message {
-            role: Role::User,
-            content: "test".to_string(),
-        }];
+        let messages = vec![Message::new(Role::User, "test".to_string())];
 
         let path1 = cm.archive(&messages, "seq-test").await.unwrap();
         assert_eq!(
@@ -428,10 +401,7 @@ mod tests {
         let readonly_for_cleanup = readonly.clone();
 
         let cm = ContextManager::new(&mock, 1000, readonly);
-        let messages = vec![Message {
-            role: Role::User,
-            content: "test".to_string(),
-        }];
+        let messages = vec![Message::new(Role::User, "test".to_string())];
         let result = cm.archive(&messages, "fail-test").await;
         assert!(result.is_err());
         // Restore permissions so TempDir can clean up

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -60,17 +60,17 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
         match snapshot_mgr.restore_snapshot(&task_id, true) {
             Ok(Some(snapshot)) => snapshot.messages,
             _ => {
-                vec![Message {
-                    role: Role::User,
-                    content: config.task.prompt_template.clone(),
-                }]
+                vec![Message::new(
+                    Role::User,
+                    config.task.prompt_template.clone(),
+                )]
             }
         }
     } else {
-        vec![Message {
-            role: Role::User,
-            content: config.task.prompt_template.clone(),
-        }]
+        vec![Message::new(
+            Role::User,
+            config.task.prompt_template.clone(),
+        )]
     };
 
     let agent_config = AgentConfig {

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -82,12 +82,25 @@ impl OpenAICompatibleProvider {
         messages: &[Message],
         tools: Option<&[ToolDef]>,
     ) -> serde_json::Value {
+        let serialized_messages: Vec<serde_json::Value> = messages
+            .iter()
+            .map(|m| {
+                let mut obj = serde_json::json!({
+                    "role": serde_json::to_value(&m.role).unwrap_or_default(),
+                    "content": m.content,
+                });
+                if m.role == Role::Tool {
+                    if let Some(ref tcid) = m.tool_call_id {
+                        obj["tool_call_id"] = serde_json::json!(tcid);
+                    }
+                }
+                obj
+            })
+            .collect();
+
         let mut body = serde_json::json!({
             "model": self.config.model,
-            "messages": messages.iter().map(|m| serde_json::json!({
-                "role": serde_json::to_value(&m.role).unwrap_or_default(),
-                "content": m.content,
-            })).collect::<Vec<_>>(),
+            "messages": serialized_messages,
         });
 
         if let Some(tools) = tools {
@@ -1131,5 +1144,84 @@ pub mod tests {
         let provider = create_provider(&vendor, "internal-model", "my-key", 60).unwrap();
         assert_eq!(provider.model(), "internal-model");
         assert_eq!(provider.vendor(), "custom");
+    }
+
+    // --- build_request_body tests ---
+
+    fn make_provider() -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider::new(OpenAIProviderConfig {
+            base_url: "https://api.example.com/v1".into(),
+            api_key: "sk-test".into(),
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn test_build_body_includes_tool_call_id_for_tool_messages() {
+        let provider = make_provider();
+        let messages = vec![
+            Message::new(Role::User, "run the tool"),
+            Message::new(Role::Assistant, "calling tool"),
+            Message::with_tool_call(Role::Tool, "tool result", "call_abc123".into()),
+        ];
+        let body = provider.build_request_body(&messages, None);
+        let body_str = serde_json::to_string(&body).unwrap();
+        assert!(
+            body_str.contains("call_abc123"),
+            "tool_call_id should be in request: {body_str}"
+        );
+        assert!(
+            body_str.contains("tool_call_id"),
+            "missing tool_call_id field"
+        );
+    }
+
+    #[test]
+    fn test_build_body_omits_tool_call_id_for_non_tool_messages() {
+        let provider = make_provider();
+        let messages = vec![
+            Message::new(Role::System, "You are a helpful assistant."),
+            Message::new(Role::User, "Hello"),
+        ];
+        let body = provider.build_request_body(&messages, None);
+        let body_str = serde_json::to_string(&body).unwrap();
+        assert!(
+            !body_str.contains("tool_call_id"),
+            "non-tool messages should not have tool_call_id"
+        );
+    }
+
+    #[test]
+    fn test_build_body_multi_turn_tool_call_round_trip() {
+        let provider = make_provider();
+        let messages = vec![
+            Message::new(Role::System, "You have tools."),
+            Message::new(Role::User, "Check the code"),
+            Message::new(Role::Assistant, "Let me check"),
+            Message::with_tool_call(Role::Tool, "diff output here", "call_1".into()),
+            Message::new(Role::Assistant, "I see changes"),
+            Message::with_tool_call(Role::Tool, "grep results", "call_2".into()),
+            Message::new(Role::Assistant, "All done"),
+        ];
+        let body = provider.build_request_body(&messages, None);
+        let body_str = serde_json::to_string(&body).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+        let msgs = parsed["messages"].as_array().unwrap();
+
+        // Check tool messages have tool_call_id
+        let tool_msg_1 = &msgs[3];
+        assert_eq!(tool_msg_1["tool_call_id"], "call_1");
+        assert_eq!(tool_msg_1["role"], "tool");
+
+        let tool_msg_2 = &msgs[5];
+        assert_eq!(tool_msg_2["tool_call_id"], "call_2");
+        assert_eq!(tool_msg_2["role"], "tool");
+
+        // Check non-tool messages do NOT have tool_call_id
+        let user_msg = &msgs[1];
+        assert_eq!(user_msg["role"], "user");
+        assert!(user_msg.get("tool_call_id").is_none());
     }
 }

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -236,7 +236,7 @@ impl OpenAICompatibleProvider {
             .unwrap_or_default();
 
         Ok(ChatResponse {
-            message: Message { role, content },
+            message: Message::new(role, content),
             usage,
             finish_reason,
             tool_calls,
@@ -519,10 +519,7 @@ impl AnthropicProvider {
         };
 
         Ok(ChatResponse {
-            message: Message {
-                role: Role::Assistant,
-                content,
-            },
+            message: Message::new(Role::Assistant, content),
             usage: total_usage,
             finish_reason,
             tool_calls: if tool_calls.is_empty() {
@@ -874,10 +871,7 @@ pub mod tests {
         .unwrap();
 
         let response = provider
-            .chat(&[Message {
-                role: Role::User,
-                content: "Hi".into(),
-            }])
+            .chat(&[Message::new(Role::User, "Hi")])
             .await
             .unwrap();
 
@@ -938,13 +932,7 @@ pub mod tests {
         }];
 
         let response = provider
-            .chat_with_tools(
-                &[Message {
-                    role: Role::User,
-                    content: "Review diff".into(),
-                }],
-                &tools,
-            )
+            .chat_with_tools(&[Message::new(Role::User, "Review diff")], &tools)
             .await
             .unwrap();
 
@@ -988,10 +976,7 @@ pub mod tests {
         .unwrap();
 
         let response = provider
-            .chat(&[Message {
-                role: Role::User,
-                content: "Hi".into(),
-            }])
+            .chat(&[Message::new(Role::User, "Hi")])
             .await
             .unwrap();
 
@@ -1015,12 +1000,7 @@ pub mod tests {
         })
         .unwrap();
 
-        let result = provider
-            .chat(&[Message {
-                role: Role::User,
-                content: "Hi".into(),
-            }])
-            .await;
+        let result = provider.chat(&[Message::new(Role::User, "Hi")]).await;
 
         assert!(matches!(result, Err(ProviderError::AuthError(_))));
     }
@@ -1066,10 +1046,7 @@ pub mod tests {
         .unwrap();
 
         let response = provider
-            .chat(&[Message {
-                role: Role::User,
-                content: "Hi".into(),
-            }])
+            .chat(&[Message::new(Role::User, "Hi")])
             .await
             .unwrap();
 
@@ -1116,13 +1093,7 @@ pub mod tests {
         }];
 
         let response = provider
-            .chat_with_tools(
-                &[Message {
-                    role: Role::User,
-                    content: "Read main.rs".into(),
-                }],
-                &tools,
-            )
+            .chat_with_tools(&[Message::new(Role::User, "Read main.rs")], &tools)
             .await
             .unwrap();
 

--- a/crates/clausura-core/src/snapshot.rs
+++ b/crates/clausura-core/src/snapshot.rs
@@ -45,11 +45,10 @@ impl SnapshotManager {
         match result {
             Some((checkpoint_id, mut messages, truncated)) => {
                 if resume {
-                    messages.push(Message {
-                        role: Role::User,
-                        content: "You were interrupted. Continue from where you left off."
-                            .to_string(),
-                    });
+                    messages.push(Message::new(
+                        Role::User,
+                        "You were interrupted. Continue from where you left off.".to_string(),
+                    ));
                 }
                 let meta = SnapshotMeta {
                     thread_id: thread_id.to_string(),
@@ -130,18 +129,9 @@ mod tests {
 
     fn make_messages() -> Vec<Message> {
         vec![
-            Message {
-                role: Role::System,
-                content: "System prompt".into(),
-            },
-            Message {
-                role: Role::User,
-                content: "Review this code".into(),
-            },
-            Message {
-                role: Role::Assistant,
-                content: "I found issues".into(),
-            },
+            Message::new(Role::System, "System prompt"),
+            Message::new(Role::User, "Review this code"),
+            Message::new(Role::Assistant, "I found issues"),
         ]
     }
 

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -490,6 +490,55 @@ mod tests {
     }
 
     #[test]
+    fn test_message_new_sets_tool_call_id_none() {
+        let msg = Message::new(Role::System, "prompt");
+        assert_eq!(msg.role, Role::System);
+        assert_eq!(msg.content, "prompt");
+        assert!(msg.tool_call_id.is_none());
+    }
+
+    #[test]
+    fn test_message_with_tool_call_sets_id() {
+        let msg = Message::with_tool_call(Role::Tool, "result", "call_123".into());
+        assert_eq!(msg.role, Role::Tool);
+        assert_eq!(msg.content, "result");
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_123"));
+    }
+
+    #[test]
+    fn test_tool_message_serializes_tool_call_id() {
+        let msg = Message::with_tool_call(Role::Tool, "tool output", "call_abc".into());
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("tool_call_id"));
+        assert!(json.contains("call_abc"));
+    }
+
+    #[test]
+    fn test_non_tool_message_omits_tool_call_id() {
+        let msg = Message::new(Role::User, "hello");
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(!json.contains("tool_call_id"));
+    }
+
+    #[test]
+    fn test_deserialize_tool_message_with_tool_call_id() {
+        let json = r#"{"role":"tool","content":"result","tool_call_id":"call_xyz"}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.role, Role::Tool);
+        assert_eq!(msg.content, "result");
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_xyz"));
+    }
+
+    #[test]
+    fn test_deserialize_message_without_tool_call_id() {
+        let json = r#"{"role":"user","content":"hello"}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.role, Role::User);
+        assert_eq!(msg.content, "hello");
+        assert!(msg.tool_call_id.is_none());
+    }
+
+    #[test]
     fn test_finding_round_trip_with_location() {
         let finding = Finding {
             id: uuid::Uuid::new_v4(),

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -20,6 +20,26 @@ pub enum Role {
 pub struct Message {
     pub role: Role,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+impl Message {
+    pub fn new(role: Role, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            tool_call_id: None,
+        }
+    }
+
+    pub fn with_tool_call(role: Role, content: impl Into<String>, tool_call_id: String) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            tool_call_id: Some(tool_call_id),
+        }
+    }
 }
 
 /// Provider-agnostic finish reason
@@ -462,6 +482,7 @@ mod tests {
         let msg = Message {
             role: Role::User,
             content: "Hello".to_string(),
+            tool_call_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let deserialized: Message = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Problem

The OpenAI chat completions API requires tool messages (`role: "tool"`) to include a `tool_call_id` field referencing the assistant's tool call. Without this field, providers like DeepSeek reject multi-turn agent loops with:

```
HTTP 400: missing field 'tool_call_id'
```

This blocks any task that triggers tool calls (grep, read_file, git_diff, list_files).

## Root Cause

The `Message` struct only had `role` and `content` fields, and the `build_request_body` method in `OpenAICompatibleProvider` never emitted `tool_call_id` for tool messages.

## Fix

### 1. `types.rs` — Extended `Message` struct
- Added `tool_call_id: Option<String>` field (skipped on serialization when None)
- Added `Message::new(role, content)` constructor for non-tool messages
- Added `Message::with_tool_call(role, content, id)` for tool messages

### 2. `provider.rs` — Include `tool_call_id` in request body
- Updated `build_request_body` to emit `tool_call_id` for tool messages

### 3. All call sites updated
- 7 files, ~70 Message constructions migrated to the new constructors
- 78 insertions, 212 deletions (net cleaner code)

## Verification

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (149/150, 1 pre-existing flaky test)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace` clean