### PR TITLE
fix: serialize assistant tool_calls as structured field for DeepSeek compatibility

### DIFF
--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -128,8 +128,12 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
             }
             FinishReason::ToolCalls => {
                 if let Some(tool_calls) = response.tool_calls {
-                    let tool_call_content = serde_json::to_string(&tool_calls).unwrap_or_default();
-                    messages.push(Message::new(Role::Assistant, tool_call_content));
+                    messages.push(Message {
+                        role: Role::Assistant,
+                        content: String::new(),
+                        tool_call_id: None,
+                        tool_calls: Some(tool_calls.clone()),
+                    });
 
                     for tc in &tool_calls {
                         match config.tools.get(&tc.name) {

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -88,25 +88,26 @@ impl OpenAICompatibleProvider {
                 let mut obj = serde_json::json!({
                     "role": serde_json::to_value(&m.role).unwrap_or_default(),
                 });
-                if m.role == Role::Assistant && m.tool_calls.is_some() {
-                    obj["content"] = serde_json::Value::Null;
-                    let tool_calls_json: Vec<serde_json::Value> = m
-                        .tool_calls
-                        .as_ref()
-                        .unwrap()
-                        .iter()
-                        .map(|tc| {
-                            serde_json::json!({
-                                "id": tc.id,
-                                "type": "function",
-                                "function": {
-                                    "name": tc.name,
-                                    "arguments": serde_json::to_string(&tc.arguments).unwrap_or_default(),
-                                }
+                if m.role == Role::Assistant {
+                    if let Some(ref tc_vec) = m.tool_calls {
+                        obj["content"] = serde_json::Value::Null;
+                        let tool_calls_json: Vec<serde_json::Value> = tc_vec
+                            .iter()
+                            .map(|tc| {
+                                serde_json::json!({
+                                    "id": tc.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tc.name,
+                                        "arguments": serde_json::to_string(&tc.arguments).unwrap_or_default(),
+                                    }
+                                })
                             })
-                        })
-                        .collect();
-                    obj["tool_calls"] = serde_json::json!(tool_calls_json);
+                            .collect();
+                        obj["tool_calls"] = serde_json::json!(tool_calls_json);
+                    } else {
+                        obj["content"] = serde_json::json!(m.content);
+                    }
                 } else {
                     obj["content"] = serde_json::json!(m.content);
                 }

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -87,8 +87,29 @@ impl OpenAICompatibleProvider {
             .map(|m| {
                 let mut obj = serde_json::json!({
                     "role": serde_json::to_value(&m.role).unwrap_or_default(),
-                    "content": m.content,
                 });
+                if m.role == Role::Assistant && m.tool_calls.is_some() {
+                    obj["content"] = serde_json::Value::Null;
+                    let tool_calls_json: Vec<serde_json::Value> = m
+                        .tool_calls
+                        .as_ref()
+                        .unwrap()
+                        .iter()
+                        .map(|tc| {
+                            serde_json::json!({
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.name,
+                                    "arguments": serde_json::to_string(&tc.arguments).unwrap_or_default(),
+                                }
+                            })
+                        })
+                        .collect();
+                    obj["tool_calls"] = serde_json::json!(tool_calls_json);
+                } else {
+                    obj["content"] = serde_json::json!(m.content);
+                }
                 if m.role == Role::Tool {
                     if let Some(ref tcid) = m.tool_call_id {
                         obj["tool_call_id"] = serde_json::json!(tcid);

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -22,6 +22,8 @@ pub struct Message {
     pub content: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
 }
 
 impl Message {
@@ -30,6 +32,7 @@ impl Message {
             role,
             content: content.into(),
             tool_call_id: None,
+            tool_calls: None,
         }
     }
 
@@ -38,6 +41,7 @@ impl Message {
             role,
             content: content.into(),
             tool_call_id: Some(tool_call_id),
+            tool_calls: None,
         }
     }
 }
@@ -483,6 +487,7 @@ mod tests {
             role: Role::User,
             content: "Hello".to_string(),
             tool_call_id: None,
+            tool_calls: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let deserialized: Message = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Problem

DeepSeek rejects multi-turn agent loops with:

```
HTTP 400: Messages with role 'tool' must be a response to
a preceding message with 'tool_calls'
```

The agent stored the assistant's tool calls as a JSON string in
`content` instead of the proper `tool_calls` API field.

## Root Cause

The OpenAI-compatible API expects assistant messages with tool
calls to use the `tool_calls` array field, with `content: null`.
Clausura was serializing them as a JSON string in `content`, which
DeepSeek and other strict providers reject.

## Fix

### types.rs
- Added `tool_calls: Option<Vec<ToolCall>>` to `Message` struct

### agent.rs
- Assistant messages now store tool_calls as structured data

### provider.rs
- `build_request_body` emits `tool_calls` as proper API field
- Sets `content: null` for assistant tool-call messages
- Serializes `arguments` as JSON strings (API requirement)

## Verification

- [x] cargo test --workspace: 160 passed
- [x] cargo fmt --all -- --check: passes
- [x] E2E: Rust code quality scan (60K tokens)
- [x] E2E: Architecture compliance (42K tokens)
- [x] E2E: Git diff review (154K tokens)
