### PR TITLE
fix: preserve assistant-tool pairs during truncation and add tool serialization to CustomProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clausura-cli"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "clausura-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/clausura-cli/Cargo.toml
+++ b/crates/clausura-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clausura-cli"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 description = "CI-native agent CLI for deterministic pipeline gating"
 license = "MIT"
@@ -8,7 +8,7 @@ repository = "https://github.com/liuyanghejerry/Clausura"
 readme = "../../README.md"
 
 [dependencies]
-clausura-core = { path = "../clausura-core", version = "1.0.3" }
+clausura-core = { path = "../clausura-core", version = "1.0.4" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"

--- a/crates/clausura-core/Cargo.toml
+++ b/crates/clausura-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clausura-core"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 description = "Core library for Clausura — a CI-native agent for deterministic pipeline gating"
 license = "MIT"

--- a/crates/clausura-core/src/context.rs
+++ b/crates/clausura-core/src/context.rs
@@ -175,8 +175,8 @@ impl<'a> ContextManager<'a> {
                     // Check if it would have been omitted.
                     let tail_count = n - 1;
                     let before_tail_start = messages.len().saturating_sub(tail_count);
-                    if orig_idx < before_tail_start {
-                        // The Assistant was omitted; include one more message
+                    if orig_idx > 0 && (orig_idx - 1) < before_tail_start {
+                        // The preceding Assistant was omitted; include one more message
                         let expanded: Vec<Message> = messages[1..]
                             .iter()
                             .rev()

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -59,6 +59,62 @@ impl Default for OpenAIProviderConfig {
     }
 }
 
+/// Serialize messages in OpenAI-compatible format, including tool_call_id and tool_calls.
+pub(crate) fn serialize_messages_openai(messages: &[Message]) -> Vec<serde_json::Value> {
+    messages
+        .iter()
+        .map(|m| {
+            let mut obj = serde_json::json!({
+                "role": serde_json::to_value(&m.role).unwrap_or_default(),
+            });
+            if m.role == Role::Assistant {
+                if let Some(ref tc_vec) = m.tool_calls {
+                    obj["content"] = serde_json::Value::Null;
+                    let tool_calls_json: Vec<serde_json::Value> = tc_vec
+                        .iter()
+                        .map(|tc| {
+                            serde_json::json!({
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.name,
+                                    "arguments": serde_json::to_string(&tc.arguments).unwrap_or_default(),
+                                }
+                            })
+                        })
+                        .collect();
+                    obj["tool_calls"] = serde_json::json!(tool_calls_json);
+                } else {
+                    obj["content"] = serde_json::json!(m.content);
+                }
+            } else {
+                obj["content"] = serde_json::json!(m.content);
+            }
+            if m.role == Role::Tool {
+                if let Some(ref tcid) = m.tool_call_id {
+                    obj["tool_call_id"] = serde_json::json!(tcid);
+                }
+            }
+            obj
+        })
+        .collect()
+}
+
+/// Serialize tool definitions in OpenAI function-calling format.
+pub(crate) fn serialize_tool_defs(tools: &[ToolDef]) -> serde_json::Value {
+    serde_json::json!(tools
+        .iter()
+        .map(|t| serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters,
+            }
+        }))
+        .collect::<Vec<_>>())
+}
+
 /// Provider that calls any OpenAI-compatible chat completions API.
 ///
 /// Works with OpenAI, DeepSeek, Groq, Ollama (via openai proxy), etc.
@@ -75,68 +131,18 @@ impl OpenAICompatibleProvider {
             .map_err(ProviderError::NetworkError)?;
         Ok(Self { config, client })
     }
-
-    /// Internal helper: build the JSON request body.
     fn build_request_body(
         &self,
         messages: &[Message],
         tools: Option<&[ToolDef]>,
     ) -> serde_json::Value {
-        let serialized_messages: Vec<serde_json::Value> = messages
-            .iter()
-            .map(|m| {
-                let mut obj = serde_json::json!({
-                    "role": serde_json::to_value(&m.role).unwrap_or_default(),
-                });
-                if m.role == Role::Assistant {
-                    if let Some(ref tc_vec) = m.tool_calls {
-                        obj["content"] = serde_json::Value::Null;
-                        let tool_calls_json: Vec<serde_json::Value> = tc_vec
-                            .iter()
-                            .map(|tc| {
-                                serde_json::json!({
-                                    "id": tc.id,
-                                    "type": "function",
-                                    "function": {
-                                        "name": tc.name,
-                                        "arguments": serde_json::to_string(&tc.arguments).unwrap_or_default(),
-                                    }
-                                })
-                            })
-                            .collect();
-                        obj["tool_calls"] = serde_json::json!(tool_calls_json);
-                    } else {
-                        obj["content"] = serde_json::json!(m.content);
-                    }
-                } else {
-                    obj["content"] = serde_json::json!(m.content);
-                }
-                if m.role == Role::Tool {
-                    if let Some(ref tcid) = m.tool_call_id {
-                        obj["tool_call_id"] = serde_json::json!(tcid);
-                    }
-                }
-                obj
-            })
-            .collect();
-
         let mut body = serde_json::json!({
             "model": self.config.model,
-            "messages": serialized_messages,
+            "messages": serialize_messages_openai(messages),
         });
 
         if let Some(tools) = tools {
-            body["tools"] = serde_json::json!(tools
-                .iter()
-                .map(|t| serde_json::json!({
-                    "type": "function",
-                    "function": {
-                        "name": t.name,
-                        "description": t.description,
-                        "parameters": t.parameters,
-                    }
-                }))
-                .collect::<Vec<_>>());
+            body["tools"] = serialize_tool_defs(tools);
         }
 
         body
@@ -656,24 +662,11 @@ impl Provider for CustomProvider {
 
         let mut body = serde_json::json!({
             "model": self.config.model,
-            "messages": messages.iter().map(|m| serde_json::json!({
-                "role": serde_json::to_value(&m.role).unwrap_or_default(),
-                "content": m.content,
-            })).collect::<Vec<_>>(),
+            "messages": serialize_messages_openai(messages),
         });
 
         if !tools.is_empty() {
-            body["tools"] = serde_json::json!(tools
-                .iter()
-                .map(|t| serde_json::json!({
-                    "type": "function",
-                    "function": {
-                        "name": t.name,
-                        "description": t.description,
-                        "parameters": t.parameters,
-                    }
-                }))
-                .collect::<Vec<_>>());
+            body["tools"] = serialize_tool_defs(tools);
         }
 
         let mut last_error = None;


### PR DESCRIPTION
## Summary

Fixes two bugs that cause the Claude/DeepSeek API error `Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`.

## Root Cause

### Bug 1: Context truncation breaks assistant-tool pairs (`context.rs`)

The `keep_last_n` method tries to preserve assistant-tool message pairs during context truncation, but has a boundary condition bug: when a Tool message lands exactly at the truncation boundary, the condition `orig_idx < before_tail_start` checks whether the **Tool** was dropped instead of whether the **preceding Assistant** was dropped. This results in orphaned tool messages that cause API rejections.

**Fix**: Change condition to `(orig_idx - 1) < before_tail_start` to check whether the preceding Assistant was dropped.

### Bug 2: CustomProvider missing tool serialization (`provider.rs`)

The `CustomProvider::chat_with_tools` only serialized `role` and `content` fields in messages, omitting `tool_call_id` and `tool_calls`. This breaks tool calling for any custom provider.

**Fix**: Extract `serialize_messages_openai()` and `serialize_tool_defs()` as shared functions, and have both `OpenAICompatibleProvider` and `CustomProvider` use them.

## Verification

- [x] `cargo test --workspace` — 160 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace` — compiles

## Related

- CI failure: https://github.com/liuyanghejerry/painttyServer/actions/runs/26902476889/job/79358275022
- This is a real production bug affecting DeepSeek-based Clausura tasks in CI pipelines with large conversations.