### PR TITLE
fix: close shell injection, fail closed on incomplete runs, harden CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# Configuration for `cargo audit`.
+#
+# To ignore a specific advisory (e.g. one with no fix available yet),
+# add its RUSTSEC id to the list below:
+#
+#   ignore = [
+#       "RUSTSEC-2023-0001",
+#   ]
+#
+# See https://rustsec.org/advisories/ for the advisory database.
+[advisories]
+ignore = []

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,11 @@ on:
 
 jobs:
   test:
-    name: Test & Lint
-    runs-on: ubuntu-latest
+    name: Test & Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +36,30 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-main-audit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-main-audit-
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit
 
   build:
     name: Build (${{ matrix.os }})

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,8 +6,11 @@ on:
 
 jobs:
   test:
-    name: Test & Lint
-    runs-on: ubuntu-latest
+    name: Test & Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +36,30 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-audit-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-audit-
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit
 
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,15 @@ jobs:
           find artifacts -name '*.tar.gz' -exec mv {} . \;
           rm -rf artifacts
 
+      - name: Generate checksums
+        run: sha256sum clausura-*.tar.gz > checksums.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: clausura-*.tar.gz
+          files: |
+            clausura-*.tar.gz
+            checksums.txt
           generate_release_notes: true
 
   docker:

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ target/
 *.db
 *.sarif
 .sisyphus/
+.codegraph/
 .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +353,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -606,29 +626,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1277,14 +1286,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -1321,12 +1331,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1338,18 +1342,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1363,16 +1368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,11 +1378,17 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1581,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,34 @@
-# Stage 1: Build
-FROM rust:alpine AS build
+# Stage 1: Chef (base image with cargo-chef installed)
+FROM lukemathwalker/cargo-chef:latest-rust-alpine AS chef
 
-# Install build dependencies
 RUN apk add --no-cache musl-dev git
 RUN rustup target add x86_64-unknown-linux-musl
 
 WORKDIR /app
 
-# Copy manifests for dependency caching
+# Stage 2: Planner — compute the dependency recipe from the workspace
+FROM chef AS planner
+
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ ./crates/
 
-# Build the binary as a static musl binary
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 3: Build — cook dependencies first (cached layer), then build source
+FROM chef AS build
+
+COPY --from=planner /app/recipe.json recipe.json
+
+# Build dependencies only; this layer is cached unless Cargo.toml/Cargo.lock change
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --package clausura-cli --recipe-path recipe.json
+
+# Copy the actual source and build the binary as a static musl binary
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
+
 RUN cargo build --release --target x86_64-unknown-linux-musl --package clausura-cli
 
-# Stage 2: Runtime
+# Stage 4: Runtime
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates git

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clausura is a platform-agnostic agent CLI tool built for CI/CD pipelines. It run
 curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
 ```
 
-The script detects your OS and architecture, downloads the latest release from GitHub, and installs it to `/usr/local/bin` or `~/.local/bin`.
+The script detects your OS and architecture, downloads the latest release from GitHub, verifies the tarball against the release's `checksums.txt` (SHA256), and installs it to `/usr/local/bin` or `~/.local/bin`.
 
 ### Cargo
 
@@ -169,7 +169,7 @@ clausura run --dry-run  # show the execution plan
 |------|---------------|------------------------------------------|
 | 0    | Pass          | All gating rules satisfied               |
 | 1    | Fail          | A rule with `action: fail` was violated  |
-| 2    | Error         | Runtime error (provider, timeout, etc.)  |
+| 2    | Error         | Runtime error (provider, timeout, etc.), or an incomplete agent run with `on_incomplete: fail` |
 | 3    | Config error  | Invalid configuration                    |
 
 ## Configuration Reference
@@ -199,9 +199,14 @@ task:
   # Limits
   token_budget: 32000                # Default. Max total tokens across all LLM calls.
   timeout_secs: 300                  # Default. Max wall-clock time in seconds.
+  max_iterations: 10                 # Default. Max agent loop iterations.
 
   # Safety
   ambiguity_policy: fail_closed      # "fail_closed" or "proceed_with_caution".
+  on_incomplete: fail                # "fail" (exit 2, default) or "pass" (continue with
+                                     # partial results, marked incomplete in logs and SARIF).
+                                     # Applies when the agent loop ends without a clean stop
+                                     # (context truncated or iteration limit reached).
 
   # Optional tool allowlist
   tool_allowlist:                    # Restrict shell commands to these binaries.
@@ -234,8 +239,10 @@ task:
 | `CLAUSURA_MODEL`        | `task.model`         |
 | `CLAUSURA_VENDOR`       | `task.vendor`        |
 | `CLAUSURA_AMBIGUITY_POLICY` | `task.ambiguity_policy` |
+| `CLAUSURA_ON_INCOMPLETE` | `task.on_incomplete` |
 | `CLAUSURA_TOKEN_BUDGET` | `task.token_budget`  |
 | `CLAUSURA_TIMEOUT`      | `task.timeout_secs`  |
+| `CLAUSURA_MAX_ITERATIONS` | `task.max_iterations` |
 
 Config loading priority: YAML file < CLI flags < environment variables.
 
@@ -250,6 +257,7 @@ clausura run [OPTIONS]
       --api-key <KEY>       API key
       --token-budget <N>    Token budget override
       --timeout <SECS>      Timeout override
+      --max-iterations <N>  Max agent loop iterations  [default: 10]
       --workspace <PATH>    Workspace root            [default: cwd]
       --output <PATH>       SARIF output path          [default: clausura-output.sarif]
       --resume              Resume from last checkpoint
@@ -292,7 +300,10 @@ Use the composite action directly:
     vendor: openai
     token_budget: 32000
     timeout: 300
+    version: latest        # optional: release version to install (e.g. "1.0.8", default "latest")
 ```
+
+The action downloads the matching release binary for the runner's OS/arch (Linux and macOS, x86_64 and aarch64), verifies it against the release's SHA256 `checksums.txt`, and adds it to `PATH` before running.
 
 Or run via the binary:
 
@@ -344,7 +355,7 @@ Custom context variables for Generic CI: `CI_REPO`, `CI_PR_NUMBER`, `CI_COMMIT_S
 
 ### Agent loop (reason -> act -> observe)
 
-Clausura runs a bounded agent loop of up to 10 iterations. Each iteration:
+Clausura runs a bounded agent loop of up to `max_iterations` iterations (default 10, configurable via YAML, `--max-iterations`, or `CLAUSURA_MAX_ITERATIONS`). Each iteration:
 
 1. Sends the conversation (system prompt + accumulated messages) to the LLM
 2. If the LLM calls a tool, executes it and feeds the result back
@@ -358,6 +369,10 @@ The system prompt is built from `prompt_template` plus available tool definition
 When the conversation exceeds the configured `token_budget`, Clausura automatically truncates older messages to stay within limits. Dropped messages are not silently discarded — they are archived to `.clausura/archives/context-dump-{task_id}-{seq}.log` inside the workspace as JSON lines. A hint message is injected into the conversation telling the LLM where to find the archived context, so it can retrieve earlier findings via the `read_file` tool if needed.
 
 On successful completion (exit code 0), archive files are automatically cleaned up. On failure (exit code 1-3), they are preserved for debugging and audit.
+
+### Incomplete runs fail closed
+
+If the agent loop ends without a clean stop — the context could not be truncated further, the model hit a length limit, or `max_iterations` was exhausted — the extracted findings may be partial. By default (`on_incomplete: fail`) Clausura fails closed: the run exits with code 2 and a clear error message, so an incomplete review can never silently pass a `max_findings: 0` gate. With `on_incomplete: pass`, the previous behavior is kept (gating rules evaluate the partial findings), but a warning is logged and the SARIF output is annotated with `"properties": {"incomplete": true}` on the run.
 
 ### Deterministic rule engine
 
@@ -374,6 +389,8 @@ No LLM calls, no heuristics. Just deterministic logic your pipeline can trust.
 
 Three vendor categories: OpenAI-compatible (works with OpenAI, DeepSeek, Groq, Ollama, vLLM, Mistral), Anthropic-compatible (native Claude Messages API), and Custom (configurable enterprise endpoints). Factory function `create_provider()` dispatches on vendor type.
 
+Each LLM request has its own per-request timeout (default 120s), independent of the task's overall wall-clock `timeout_secs`. Failed requests are retried with exponential backoff (up to 3 retries by default) on HTTP 429, 5xx, and network errors — the `Retry-After` response header is honored when present. Other 4xx responses (e.g. 401, 400) fail immediately without retrying.
+
 ### Tool sandboxing
 
 Five built-in tools:
@@ -384,13 +401,17 @@ Five built-in tools:
 | `list_files`  | List directory contents, with recursive depth, glob filtering, and optional file sizes | Sandboxed to workspace; skips `.clausura/` |
 | `grep`        | Search text patterns across files with literal or regex mode, extension filtering, and binary-skip | Auto-excludes `.git`, `target`, `.clausura`, `node_modules` |
 | `git_diff`    | Run `git diff` with optional base ref or staged  | Operates inside workspace only         |
-| `shell_exec`  | Execute allowed shell commands                   | Restricted to `tool_allowlist` entries |
+| `shell_exec`  | Execute an allowed command (argv form, no shell) | Restricted to `tool_allowlist` entries |
 
-The `shell_exec` tool is locked by default (empty allowlist = no commands). Explicitly list allowed binaries to enable it. Commands run with `current_dir` set to the workspace root, but allowed commands can access paths outside the workspace via arguments.
+The `shell_exec` tool is locked by default (empty allowlist = no commands). Explicitly list allowed binaries to enable it. It takes an `argv` array (e.g. `{"argv": ["git", "status"]}`) and executes `argv[0]` directly **without a shell** — shell metacharacters like `;`, `|`, `$()` or `>` are passed through as literal arguments and have no effect, so they cannot be used to bypass the allowlist. The allowlist is matched against `argv[0]` (both the raw value and its basename). Commands run with `current_dir` set to the workspace root, but allowed commands can access paths outside the workspace via arguments.
+
+Tool outputs are truncated at 32 KB or 1000 lines (whichever comes first) to stay within token budgets; a `[output truncated ...]` marker is appended when this happens — narrow the query or use `read_file`'s `offset`/`limit` to page through large outputs.
 
 ### Memory snapshots (SQLite checkpoints)
 
 On every run, the agent's message history is serialized (MessagePack) and saved to `~/.clausura/checkpoints.db`. You can resume a truncated or interrupted run with `--resume`. Snapshots include a thread ID, version number, and truncation flag.
+
+Note that checkpoints live under the user's home directory (`~/.clausura/`), not the workspace. In ephemeral CI containers without a persistent home/volume, checkpoints do not survive between runs, so `--resume` has nothing to restore from.
 
 Use `clausura snapshot list` and `clausura snapshot show` to inspect saved state.
 

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,10 @@ description: 'AI-powered code review agent for CI pipelines'
 author: 'liuyanghejerry'
 
 inputs:
+  version:
+    description: 'Clausura version to install (e.g. "1.0.8" or "latest")'
+    required: false
+    default: 'latest'
   config:
     description: 'Path to .clausura.yaml config file'
     required: false
@@ -26,6 +30,61 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Install clausura
+      shell: bash
+      env:
+        CLAUSURA_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        # Map runner OS/arch to release target triple
+        case "${{ runner.os }}" in
+          Linux) os_part="unknown-linux-gnu" ;;
+          macOS) os_part="apple-darwin" ;;
+          *)     echo "::error::Unsupported runner OS: ${{ runner.os }}"; exit 1 ;;
+        esac
+
+        case "${{ runner.arch }}" in
+          X64)   arch_part="x86_64" ;;
+          ARM64) arch_part="aarch64" ;;
+          *)     echo "::error::Unsupported runner arch: ${{ runner.arch }}"; exit 1 ;;
+        esac
+
+        TARGET="${arch_part}-${os_part}"
+        TARBALL="clausura-${TARGET}.tar.gz"
+
+        if [ "$CLAUSURA_VERSION" = "latest" ]; then
+          BASE_URL="https://github.com/liuyanghejerry/Clausura/releases/latest/download"
+        else
+          BASE_URL="https://github.com/liuyanghejerry/Clausura/releases/download/v${CLAUSURA_VERSION}"
+        fi
+
+        TMP_DIR="$(mktemp -d)"
+        echo "Downloading ${TARBALL} from ${BASE_URL}..."
+        curl -fsSL -o "$TMP_DIR/$TARBALL" "$BASE_URL/$TARBALL"
+        curl -fsSL -o "$TMP_DIR/checksums.txt" "$BASE_URL/checksums.txt"
+
+        # Verify SHA256 checksum (Linux has sha256sum, macOS has shasum)
+        cd "$TMP_DIR"
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          grep " $TARBALL\$" checksums.txt | shasum -a 256 --check
+        else
+          grep " $TARBALL\$" checksums.txt | sha256sum --check
+        fi
+        cd - >/dev/null
+
+        BIN_DIR="$RUNNER_TEMP/clausura-bin"
+        mkdir -p "$BIN_DIR"
+        tar xzf "$TMP_DIR/$TARBALL" -C "$BIN_DIR"
+        rm -rf "$TMP_DIR"
+
+        echo "$BIN_DIR" >> "$GITHUB_PATH"
+        echo "Installed clausura $CLAUSURA_VERSION ($TARGET) to $BIN_DIR"
+
+    - name: Verify clausura installation
+      shell: bash
+      run: clausura --version
+
     - run: clausura run --config ${{ inputs.config }}
       shell: bash
       env:

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -13,6 +13,10 @@ pub struct AgentResult {
     pub findings: Vec<Finding>,
     pub usage: Usage,
     pub duration_ms: u64,
+    /// True when the loop ended without a clean `Stop`: context truncation,
+    /// `FinishReason::Length`, an abnormal finish reason, or exhaustion of
+    /// `max_iterations`. Signals to the caller that the result may be
+    /// incomplete (see `TaskContract::on_incomplete`).
     pub truncated: bool,
 }
 
@@ -66,38 +70,48 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 
                 match archive_result {
                     Ok(path) => {
-                        messages.push(Message::new(
-                            Role::User,
-                            format!(
-                                "⚠️ Context was trimmed to stay within token budget.\n\
-                             {} earlier messages are archived at:\n  {}\n\
-                             Use read_file to inspect if you need context from earlier iterations.",
-                                dropped.len(),
-                                path.display(),
+                        // Insert at the truncation boundary (right after the
+                        // system message), not at the end: appending a User
+                        // message after an assistant message with tool_calls
+                        // would leave those calls without results, which the
+                        // OpenAI/Anthropic APIs reject.
+                        messages.insert(
+                            1,
+                            Message::new(
+                                Role::User,
+                                format!(
+                                    "⚠️ Context was trimmed to stay within token budget.\n\
+                                 {} earlier messages are archived at:\n  {}\n\
+                                 Use read_file to inspect if you need context from earlier iterations.",
+                                    dropped.len(),
+                                    path.display(),
+                                ),
                             ),
-                        ));
+                        );
                     }
                     Err(_) => {
-                        messages.push(Message::new(
-                            Role::User,
-                            format!(
-                                "⚠️ Context was trimmed to stay within token budget.\n\
-                             {} earlier messages were dropped (archive unavailable).",
-                                dropped.len(),
+                        messages.insert(
+                            1,
+                            Message::new(
+                                Role::User,
+                                format!(
+                                    "⚠️ Context was trimmed to stay within token budget.\n\
+                                 {} earlier messages were dropped (archive unavailable).",
+                                    dropped.len(),
+                                ),
                             ),
-                        ));
+                        );
                     }
                 }
 
                 running_tokens = cm.count_tokens(&messages);
 
                 if cm.should_truncate(&messages) || running_tokens >= config.contract.token_budget {
-                    truncated = true;
+                    // Fall-through below marks the result truncated.
                     break;
                 }
                 continue;
             } else {
-                truncated = true;
                 break;
             }
         }
@@ -173,7 +187,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                 }
             }
             FinishReason::Length => {
-                truncated = true;
+                // Fall-through below marks the result truncated.
                 break;
             }
             FinishReason::ContentFilter | FinishReason::Other(_) => {
@@ -199,8 +213,11 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 
     // The loop exited without a clean `Stop` (timeout/truncation/iteration cap),
     // so there is no complete final answer to hold to the strict schema below.
-    // Best-effort extraction with a warning is appropriate here; `truncated`
-    // already signals to the caller that this result may be incomplete.
+    // Best-effort extraction with a warning is appropriate here. Mark the
+    // result as truncated (incomplete): this fall-through path is reached on
+    // Length, failed truncation, ContentFilter/Other breaks, and iteration
+    // exhaustion, none of which produced a complete final answer.
+    truncated = true;
     let findings = extract_findings_lenient(&last_content);
 
     Ok(AgentResult {
@@ -342,7 +359,7 @@ mod tests {
     use super::*;
     use crate::provider::tests::MockProvider;
     use crate::tools::default_tools;
-    use crate::types::{AmbiguityPolicy, ChatResponse, ToolCall, VendorConfig};
+    use crate::types::{AmbiguityPolicy, ChatResponse, OnIncompletePolicy, ToolCall, VendorConfig};
     use tempfile::TempDir;
 
     fn test_contract() -> TaskContract {
@@ -359,6 +376,7 @@ mod tests {
             ambiguity_policy: AmbiguityPolicy::FailClosed,
             gating_rules: vec![],
             max_iterations: 10,
+            on_incomplete: OnIncompletePolicy::Fail,
         }
     }
 
@@ -597,14 +615,70 @@ mod tests {
         };
 
         let result = run_agent_loop(config).await.unwrap();
-        let hint = result
-            .messages
-            .iter()
-            .any(|m| m.role == Role::User && m.content.contains("archived at"));
-        assert!(
-            hint,
-            "Expected a hint message about archiving after truncation"
+
+        // (a) The hint sits at index 1 — immediately after the system
+        // message, at the truncation boundary, not appended at the end.
+        assert_eq!(
+            result.messages[0].role,
+            Role::System,
+            "system message must stay at index 0"
         );
+        let hint = &result.messages[1];
+        assert_eq!(hint.role, Role::User, "hint message must be a user message");
+        assert!(
+            hint.content.contains("archived at"),
+            "expected a hint message about archiving at index 1, got: {}",
+            hint.content
+        );
+
+        // (b) Every assistant message with tool_calls is immediately
+        // followed by Role::Tool messages with matching tool_call_ids.
+        // (c) A Role::Tool message only ever appears right after an
+        // assistant-with-tool_calls group.
+        let msgs = &result.messages;
+        assert!(
+            msgs.iter()
+                .any(|m| m.role == Role::Assistant && m.tool_calls.is_some()),
+            "test setup: retained tail must contain an assistant message with tool_calls"
+        );
+        let mut i = 0;
+        while i < msgs.len() {
+            let m = &msgs[i];
+            if m.role == Role::Assistant {
+                if let Some(tool_calls) = &m.tool_calls {
+                    let mut j = i + 1;
+                    for tc in tool_calls {
+                        let tm = msgs.get(j).unwrap_or_else(|| {
+                            panic!("tool_call '{}' has no tool result message", tc.id)
+                        });
+                        assert_eq!(
+                            tm.role,
+                            Role::Tool,
+                            "tool_call '{}' must be followed by a tool message, found {:?} at index {}",
+                            tc.id,
+                            tm.role,
+                            j
+                        );
+                        assert_eq!(
+                            tm.tool_call_id.as_deref(),
+                            Some(tc.id.as_str()),
+                            "tool message at index {} must carry matching tool_call_id",
+                            j
+                        );
+                        j += 1;
+                    }
+                    i = j;
+                    continue;
+                }
+            }
+            assert_ne!(
+                m.role,
+                Role::Tool,
+                "tool message at index {} does not follow an assistant-with-tool_calls group",
+                i
+            );
+            i += 1;
+        }
     }
 
     #[tokio::test]

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -8,7 +8,8 @@
 /// The API key is NEVER read from the YAML file — it must come from
 /// a CLI flag or the `CLAUSURA_API_KEY` environment variable.
 use crate::types::{
-    AmbiguityPolicy, ConfigError, GateAction, GateRule, Severity, TaskContract, VendorConfig,
+    AmbiguityPolicy, ConfigError, GateAction, GateRule, OnIncompletePolicy, Severity, TaskContract,
+    VendorConfig,
 };
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -77,6 +78,8 @@ struct YamlTaskConfig {
     gating: Vec<YamlGateRule>,
     #[serde(default = "default_max_iterations")]
     max_iterations: u32,
+    #[serde(default = "default_on_incomplete")]
+    on_incomplete: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -112,6 +115,10 @@ fn default_ambiguity() -> String {
     "fail_closed".to_string()
 }
 
+fn default_on_incomplete() -> String {
+    "fail".to_string()
+}
+
 // ---------------------------------------------------------------------------
 // Parsing helpers
 // ---------------------------------------------------------------------------
@@ -132,6 +139,14 @@ fn parse_gate_action(s: &str) -> GateAction {
         "warn" => GateAction::Warn,
         "ignore" => GateAction::Ignore,
         _ => GateAction::Warn,
+    }
+}
+
+fn parse_on_incomplete(s: &str) -> OnIncompletePolicy {
+    match s.to_lowercase().as_str() {
+        "pass" => OnIncompletePolicy::Pass,
+        // Unknown values fail closed, matching the default.
+        _ => OnIncompletePolicy::Fail,
     }
 }
 
@@ -235,6 +250,7 @@ impl Config {
                     ambiguity_policy: default_ambiguity(),
                     gating: vec![],
                     max_iterations: default_max_iterations(),
+                    on_incomplete: default_on_incomplete(),
                 },
                 None,
             )
@@ -283,6 +299,10 @@ impl Config {
             _ => AmbiguityPolicy::FailClosed,
         };
 
+        let on_incomplete_str =
+            std::env::var("CLAUSURA_ON_INCOMPLETE").unwrap_or(yaml_task.on_incomplete);
+        let on_incomplete = parse_on_incomplete(&on_incomplete_str);
+
         let gating_rules = yaml_task
             .gating
             .iter()
@@ -310,6 +330,7 @@ impl Config {
                 ambiguity_policy,
                 gating_rules,
                 max_iterations,
+                on_incomplete,
             },
             api_key,
             workspace,
@@ -518,6 +539,7 @@ task:
             std::env::remove_var("CLAUSURA_TOKEN_BUDGET");
             std::env::remove_var("CLAUSURA_TIMEOUT");
             std::env::remove_var("CLAUSURA_AMBIGUITY_POLICY");
+            std::env::remove_var("CLAUSURA_ON_INCOMPLETE");
         }
     }
 
@@ -793,6 +815,139 @@ task:
         )
         .unwrap();
         assert_eq!(config.task.max_iterations, 10);
+    }
+
+    #[test]
+    fn test_on_incomplete_default_is_fail() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.on_incomplete, OnIncompletePolicy::Fail);
+    }
+
+    #[test]
+    fn test_on_incomplete_pass_from_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  on_incomplete: pass
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.on_incomplete, OnIncompletePolicy::Pass);
+    }
+
+    #[test]
+    fn test_on_incomplete_unknown_value_fails_closed() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  on_incomplete: banana
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.on_incomplete, OnIncompletePolicy::Fail);
+    }
+
+    #[test]
+    fn test_on_incomplete_env_overrides_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        unsafe { std::env::set_var("CLAUSURA_ON_INCOMPLETE", "pass") };
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  on_incomplete: fail
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.on_incomplete, OnIncompletePolicy::Pass);
+        unsafe { std::env::remove_var("CLAUSURA_ON_INCOMPLETE") };
     }
 
     #[test]

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -6,7 +6,7 @@ use crate::rules::RuleEngine;
 use crate::sarif::SarifFormatter;
 use crate::snapshot::SnapshotManager;
 use crate::tools::default_tools;
-use crate::types::{ExecutionReport, Message, ProviderError, Role, Usage};
+use crate::types::{ExecutionReport, Message, OnIncompletePolicy, ProviderError, Role, Usage};
 use std::path::Path;
 use std::time::Instant;
 
@@ -118,11 +118,33 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
 
     let gate_result = RuleEngine::evaluate(&agent_result.findings, &config.task.gating_rules);
 
-    if let Err(e) = SarifFormatter::write_to_file(&agent_result.findings, &config.output) {
+    // Fail closed on incomplete runs (context truncated or iteration limit
+    // reached): a partial sweep with zero findings must not pass gates like
+    // `max_findings: 0`.
+    let mut errors = Vec::new();
+    let exit_code = apply_incomplete_policy(
+        gate_result.exit_code,
+        agent_result.truncated,
+        config.task.on_incomplete,
+        &mut errors,
+    );
+
+    if agent_result.truncated && config.task.on_incomplete == OnIncompletePolicy::Pass {
+        eprintln!(
+            "Warning: agent run incomplete (context truncated or iteration limit reached); \
+             continuing with partial results (on_incomplete=pass)"
+        );
+    }
+
+    if let Err(e) = SarifFormatter::write_to_file_with_status(
+        &agent_result.findings,
+        &config.output,
+        agent_result.truncated,
+    ) {
         eprintln!("Warning: Failed to write SARIF: {}", e);
     }
 
-    if gate_result.exit_code == 0 {
+    if exit_code == 0 {
         cleanup_archives(&config.workspace, &task_id);
     }
 
@@ -137,13 +159,45 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
 
     ExecutionReport {
         task_id,
-        exit_code: gate_result.exit_code,
+        exit_code,
         findings: agent_result.findings,
         token_usage: agent_result.usage,
         duration_ms: agent_result.duration_ms,
         snapshot_id,
-        errors: vec![],
+        errors,
         violations: gate_result.violations,
+    }
+}
+
+/// Decide the final exit code when the agent run may be incomplete.
+///
+/// A complete run is returned unchanged. For an incomplete run (context
+/// truncated or iteration limit reached without a clean `Stop`):
+/// - `OnIncompletePolicy::Fail` fails closed: returns 2 (error) and pushes a
+///   diagnostic to `errors`, regardless of the gate result — an incomplete
+///   sweep must not pass gates, and a runtime error outranks a rule
+///   violation.
+/// - `OnIncompletePolicy::Pass` keeps the gate result unchanged; the caller
+///   warns and annotates the SARIF output instead.
+fn apply_incomplete_policy(
+    gate_exit_code: u32,
+    incomplete: bool,
+    policy: OnIncompletePolicy,
+    errors: &mut Vec<String>,
+) -> u32 {
+    if !incomplete {
+        return gate_exit_code;
+    }
+    match policy {
+        OnIncompletePolicy::Fail => {
+            errors.push(
+                "Agent run incomplete (context truncated or iteration limit reached); \
+                 failing closed (on_incomplete=fail)"
+                    .to_string(),
+            );
+            2
+        }
+        OnIncompletePolicy::Pass => gate_exit_code,
     }
 }
 
@@ -251,5 +305,65 @@ mod tests {
         cleanup_archives(tmp.path(), "different-task-id");
 
         assert!(archives_dir.join("context-dump-other-task-1.log").exists());
+    }
+
+    #[test]
+    fn test_incomplete_fail_policy_returns_exit_2_with_error() {
+        let mut errors = Vec::new();
+        let code = apply_incomplete_policy(0, true, OnIncompletePolicy::Fail, &mut errors);
+        assert_eq!(code, 2);
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("Agent run incomplete"),
+            "got: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains("on_incomplete=fail"),
+            "got: {}",
+            errors[0]
+        );
+    }
+
+    #[test]
+    fn test_incomplete_pass_policy_keeps_gate_result() {
+        let mut errors = Vec::new();
+        assert_eq!(
+            apply_incomplete_policy(0, true, OnIncompletePolicy::Pass, &mut errors),
+            0
+        );
+        assert_eq!(
+            apply_incomplete_policy(1, true, OnIncompletePolicy::Pass, &mut errors),
+            1
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_incomplete_fail_policy_error_outranks_violation() {
+        // gate=1 + incomplete + Fail → 2: the run itself is untrustworthy,
+        // so the runtime error takes precedence over the rule violation.
+        let mut errors = Vec::new();
+        let code = apply_incomplete_policy(1, true, OnIncompletePolicy::Fail, &mut errors);
+        assert_eq!(code, 2);
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn test_complete_run_unchanged_by_policy() {
+        let mut errors = Vec::new();
+        assert_eq!(
+            apply_incomplete_policy(0, false, OnIncompletePolicy::Fail, &mut errors),
+            0
+        );
+        assert_eq!(
+            apply_incomplete_policy(1, false, OnIncompletePolicy::Fail, &mut errors),
+            1
+        );
+        assert_eq!(
+            apply_incomplete_policy(0, false, OnIncompletePolicy::Pass, &mut errors),
+            0
+        );
+        assert!(errors.is_empty());
     }
 }

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -34,6 +34,56 @@ pub trait Provider: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
+// Retry helpers
+// ---------------------------------------------------------------------------
+
+/// Parse the `Retry-After` response header as integer seconds.
+/// Missing or unparseable values are ignored.
+fn retry_after_secs(resp: &reqwest::Response) -> Option<u64> {
+    resp.headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok())
+}
+
+/// Delay before the next retry attempt: exponential backoff (1s, 2s, 4s, ...)
+/// with jitter, raised to at least the server-provided `Retry-After` hint.
+fn retry_delay(attempt: u32, retry_after: Option<u64>) -> Duration {
+    // Tests use a short fixed backoff to keep the suite fast.
+    #[cfg(not(test))]
+    let backoff = {
+        let base = Duration::from_secs(1 << (attempt - 1));
+        base + Duration::from_millis(rand::random::<u64>() % 500)
+    };
+    #[cfg(test)]
+    let backoff = Duration::from_millis(10 * (1 << (attempt - 1)));
+
+    match retry_after {
+        Some(secs) => backoff.max(Duration::from_secs(secs)),
+        None => backoff,
+    }
+}
+
+/// Log a failed attempt that will be retried.
+fn log_retry(attempt: u32, max_retries: u32, reason: &str) {
+    tracing::warn!(
+        attempt = attempt + 1,
+        max_retries,
+        reason = %reason,
+        "LLM request failed, retrying"
+    );
+}
+
+/// Log when all retry attempts are exhausted.
+fn log_retries_exhausted(max_retries: u32, err: &ProviderError) {
+    tracing::warn!(
+        max_retries,
+        reason = %err,
+        "LLM request failed, retries exhausted"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // OpenAI-compatible provider
 // ---------------------------------------------------------------------------
 
@@ -54,7 +104,7 @@ impl Default for OpenAIProviderConfig {
             api_key: String::new(),
             base_url: "https://api.openai.com/v1".to_string(),
             max_retries: 3,
-            timeout_secs: 60,
+            timeout_secs: 120,
         }
     }
 }
@@ -158,12 +208,11 @@ impl OpenAICompatibleProvider {
         let body = self.build_request_body(messages, tools);
 
         let mut last_error = None;
+        let mut retry_after = None;
         for attempt in 0..=self.config.max_retries {
             if attempt > 0 {
-                // Exponential backoff with jitter: 1s, 2s, 4s, ...
-                let base_delay = Duration::from_secs(1 << (attempt - 1));
-                let jitter_ms: u64 = rand::random::<u64>() % 500;
-                tokio::time::sleep(base_delay + Duration::from_millis(jitter_ms)).await;
+                // Exponential backoff with jitter, honoring `Retry-After`.
+                tokio::time::sleep(retry_delay(attempt, retry_after.take())).await;
             }
 
             let response = self
@@ -184,9 +233,23 @@ impl OpenAICompatibleProvider {
                             serde_json::from_str(&text).map_err(ProviderError::JsonError)?;
                         return Self::parse_response(data);
                     } else if status.as_u16() == 429 {
+                        retry_after = retry_after_secs(&resp);
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            &format!("rate limited (HTTP {status})"),
+                        );
                         last_error = Some(ProviderError::RateLimited("Rate limited".into()));
                         continue;
                     } else if status.is_server_error() {
+                        if status.as_u16() == 503 {
+                            retry_after = retry_after_secs(&resp);
+                        }
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            &format!("server error (HTTP {status})"),
+                        );
                         last_error = Some(ProviderError::ServerError(format!("HTTP {}", status)));
                         continue;
                     } else if status.as_u16() == 401 {
@@ -201,9 +264,11 @@ impl OpenAICompatibleProvider {
                 }
                 Err(e) => {
                     if e.is_timeout() {
+                        log_retry(attempt, self.config.max_retries, "request timed out");
                         last_error = Some(ProviderError::Timeout("Request timed out".into()));
                         continue;
                     } else if e.is_connect() {
+                        log_retry(attempt, self.config.max_retries, "connection error");
                         last_error = Some(ProviderError::NetworkError(e));
                         continue;
                     } else {
@@ -213,7 +278,10 @@ impl OpenAICompatibleProvider {
             }
         }
 
-        Err(last_error.unwrap_or_else(|| ProviderError::ServerError("Max retries exceeded".into())))
+        let err =
+            last_error.unwrap_or_else(|| ProviderError::ServerError("Max retries exceeded".into()));
+        log_retries_exhausted(self.config.max_retries, &err);
+        Err(err)
     }
 
     /// Parse the OpenAI-style JSON response into our `ChatResponse`.
@@ -342,7 +410,7 @@ impl Default for AnthropicProviderConfig {
             api_key: String::new(),
             base_url: "https://api.anthropic.com".to_string(),
             max_retries: 3,
-            timeout_secs: 60,
+            timeout_secs: 120,
         }
     }
 }
@@ -454,11 +522,11 @@ impl AnthropicProvider {
         }
 
         let mut last_error = None;
+        let mut retry_after = None;
         for attempt in 0..=self.config.max_retries {
             if attempt > 0 {
-                let base_delay = Duration::from_secs(1 << (attempt - 1));
-                let jitter = Duration::from_millis(rand::random::<u64>() % 500);
-                tokio::time::sleep(base_delay + jitter).await;
+                // Exponential backoff with jitter, honoring `Retry-After`.
+                tokio::time::sleep(retry_delay(attempt, retry_after.take())).await;
             }
 
             let response = self
@@ -480,9 +548,23 @@ impl AnthropicProvider {
                             serde_json::from_str(&text).map_err(ProviderError::JsonError)?;
                         return Self::parse_response(&data);
                     } else if status.as_u16() == 429 {
+                        retry_after = retry_after_secs(&resp);
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            &format!("rate limited (HTTP {status})"),
+                        );
                         last_error = Some(ProviderError::RateLimited("Rate limited".into()));
                         continue;
                     } else if status.is_server_error() {
+                        if status.as_u16() == 503 {
+                            retry_after = retry_after_secs(&resp);
+                        }
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            &format!("server error (HTTP {status})"),
+                        );
                         last_error = Some(ProviderError::ServerError(format!("HTTP {}", status)));
                         continue;
                     } else if status.as_u16() == 401 || status.as_u16() == 403 {
@@ -497,6 +579,11 @@ impl AnthropicProvider {
                 }
                 Err(e) => {
                     if e.is_timeout() || e.is_connect() {
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            "timeout or connection error",
+                        );
                         last_error = Some(ProviderError::NetworkError(e));
                         continue;
                     }
@@ -505,7 +592,10 @@ impl AnthropicProvider {
             }
         }
 
-        Err(last_error.unwrap_or_else(|| ProviderError::ServerError("Max retries exceeded".into())))
+        let err =
+            last_error.unwrap_or_else(|| ProviderError::ServerError("Max retries exceeded".into()));
+        log_retries_exhausted(self.config.max_retries, &err);
+        Err(err)
     }
 
     fn parse_response(data: &serde_json::Value) -> Result<ChatResponse, ProviderError> {
@@ -629,7 +719,7 @@ impl Default for CustomProviderConfig {
             base_url: String::new(),
             auth_header: "Authorization".to_string(),
             max_retries: 3,
-            timeout_secs: 60,
+            timeout_secs: 120,
         }
     }
 }
@@ -670,11 +760,11 @@ impl Provider for CustomProvider {
         }
 
         let mut last_error = None;
+        let mut retry_after = None;
         for attempt in 0..=self.config.max_retries {
             if attempt > 0 {
-                let base_delay = Duration::from_secs(1 << (attempt - 1));
-                let jitter = Duration::from_millis(rand::random::<u64>() % 500);
-                tokio::time::sleep(base_delay + jitter).await;
+                // Exponential backoff with jitter, honoring `Retry-After`.
+                tokio::time::sleep(retry_delay(attempt, retry_after.take())).await;
             }
 
             let mut request = self
@@ -703,9 +793,23 @@ impl Provider for CustomProvider {
                             serde_json::from_str(&text).map_err(ProviderError::JsonError)?;
                         return OpenAICompatibleProvider::parse_response(data);
                     } else if status.as_u16() == 429 {
+                        retry_after = retry_after_secs(&resp);
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            &format!("rate limited (HTTP {status})"),
+                        );
                         last_error = Some(ProviderError::RateLimited("Rate limited".into()));
                         continue;
                     } else if status.is_server_error() {
+                        if status.as_u16() == 503 {
+                            retry_after = retry_after_secs(&resp);
+                        }
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            &format!("server error (HTTP {status})"),
+                        );
                         last_error = Some(ProviderError::ServerError(format!("HTTP {}", status)));
                         continue;
                     } else if status.as_u16() == 401 || status.as_u16() == 403 {
@@ -720,6 +824,11 @@ impl Provider for CustomProvider {
                 }
                 Err(e) => {
                     if e.is_timeout() || e.is_connect() {
+                        log_retry(
+                            attempt,
+                            self.config.max_retries,
+                            "timeout or connection error",
+                        );
                         last_error = Some(ProviderError::NetworkError(e));
                         continue;
                     }
@@ -728,7 +837,10 @@ impl Provider for CustomProvider {
             }
         }
 
-        Err(last_error.unwrap_or_else(|| ProviderError::ServerError("Max retries exceeded".into())))
+        let err =
+            last_error.unwrap_or_else(|| ProviderError::ServerError("Max retries exceeded".into()));
+        log_retries_exhausted(self.config.max_retries, &err);
+        Err(err)
     }
 
     fn count_tokens(&self, text: &str) -> u64 {
@@ -1009,6 +1121,135 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(response.message.content, "OK after retry");
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_500_then_success() {
+        let mock_server = MockServer::start().await;
+
+        // First call: 500, subsequent calls: 200
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "OK after server error"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let provider = OpenAICompatibleProvider::new(OpenAIProviderConfig {
+            base_url: mock_server.uri(),
+            api_key: "sk-test".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let response = provider
+            .chat(&[Message::new(Role::User, "Hi")])
+            .await
+            .unwrap();
+
+        assert_eq!(response.message.content, "OK after server error");
+    }
+
+    #[tokio::test]
+    async fn test_retry_429_exhausted() {
+        let mock_server = MockServer::start().await;
+
+        // Always 429: 1 initial request + 2 retries = 3 requests total.
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(429))
+            .expect(3)
+            .mount(&mock_server)
+            .await;
+
+        let provider = OpenAICompatibleProvider::new(OpenAIProviderConfig {
+            base_url: mock_server.uri(),
+            api_key: "sk-test".into(),
+            max_retries: 2,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let result = provider.chat(&[Message::new(Role::User, "Hi")]).await;
+
+        assert!(matches!(result, Err(ProviderError::RateLimited(_))));
+    }
+
+    #[tokio::test]
+    async fn test_no_retry_on_400() {
+        let mock_server = MockServer::start().await;
+
+        // 400 is not retryable: exactly one request.
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let provider = OpenAICompatibleProvider::new(OpenAIProviderConfig {
+            base_url: mock_server.uri(),
+            api_key: "sk-test".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let result = provider.chat(&[Message::new(Role::User, "Hi")]).await;
+
+        assert!(matches!(result, Err(ProviderError::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn test_retry_after_header_still_succeeds() {
+        let mock_server = MockServer::start().await;
+
+        // First call: 429 with a Retry-After hint, subsequent calls: 200
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(matchers::method("POST"))
+            .and(matchers::path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "OK after retry-after"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let provider = OpenAICompatibleProvider::new(OpenAIProviderConfig {
+            base_url: mock_server.uri(),
+            api_key: "sk-test".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let response = provider
+            .chat(&[Message::new(Role::User, "Hi")])
+            .await
+            .unwrap();
+
+        assert_eq!(response.message.content, "OK after retry-after");
     }
 
     #[tokio::test]

--- a/crates/clausura-core/src/sarif.rs
+++ b/crates/clausura-core/src/sarif.rs
@@ -8,7 +8,16 @@ pub struct SarifFormatter;
 impl SarifFormatter {
     /// Convert findings to SARIF JSON string.
     pub fn to_string(findings: &[Finding]) -> Result<String, serde_json::Error> {
-        let sarif = Self::build_sarif(findings);
+        Self::to_string_with_status(findings, false)
+    }
+
+    /// Convert findings to SARIF JSON string, marking the run as incomplete
+    /// (agent loop truncated or iteration limit reached) when requested.
+    pub fn to_string_with_status(
+        findings: &[Finding],
+        incomplete: bool,
+    ) -> Result<String, serde_json::Error> {
+        let sarif = Self::build_sarif(findings, incomplete);
         serde_json::to_string_pretty(&sarif)
     }
 
@@ -17,27 +26,49 @@ impl SarifFormatter {
         findings: &[Finding],
         path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let content = Self::to_string(findings)?;
+        Self::write_to_file_with_status(findings, path, false)
+    }
+
+    /// Write SARIF output to a file, marking the run as incomplete when
+    /// requested (see [`SarifFormatter::to_string_with_status`]).
+    pub fn write_to_file_with_status(
+        findings: &[Finding],
+        path: &Path,
+        incomplete: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let content = Self::to_string_with_status(findings, incomplete)?;
         fs::write(path, content)?;
         Ok(())
     }
 
-    fn build_sarif(findings: &[Finding]) -> serde_json::Value {
+    fn build_sarif(findings: &[Finding], incomplete: bool) -> serde_json::Value {
         let results: Vec<serde_json::Value> =
             findings.iter().map(Self::finding_to_result).collect();
+
+        let mut run = serde_json::json!({
+            "tool": {
+                "driver": {
+                    "name": "Clausura",
+                    "informationUri": "https://github.com/liuyanghejerry/Clausura"
+                }
+            },
+            "results": results
+        });
+
+        if incomplete {
+            run["properties"] = serde_json::json!({ "incomplete": true });
+            run["invocations"] = serde_json::json!([{
+                "executionSuccessful": false,
+                "properties": {
+                    "incompleteReason": "context truncated or iteration limit reached"
+                }
+            }]);
+        }
 
         serde_json::json!({
             "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
             "version": "2.1.0",
-            "runs": [{
-                "tool": {
-                    "driver": {
-                        "name": "Clausura",
-                        "informationUri": "https://github.com/liuyanghejerry/Clausura"
-                    }
-                },
-                "results": results
-            }]
+            "runs": [run]
         })
     }
 
@@ -180,5 +211,30 @@ mod tests {
         assert!(path.exists());
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("Clausura"));
+    }
+
+    #[test]
+    fn test_incomplete_run_annotated() {
+        let sarif = SarifFormatter::to_string_with_status(&[], true).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&sarif).unwrap();
+        assert_eq!(parsed["runs"][0]["properties"]["incomplete"], true);
+        assert_eq!(
+            parsed["runs"][0]["invocations"][0]["executionSuccessful"],
+            false
+        );
+    }
+
+    #[test]
+    fn test_complete_run_not_annotated() {
+        // Both the default to_string and an explicit incomplete=false must
+        // omit the annotation entirely (not emit "incomplete": false).
+        for sarif in [
+            SarifFormatter::to_string(&[]).unwrap(),
+            SarifFormatter::to_string_with_status(&[], false).unwrap(),
+        ] {
+            let parsed: serde_json::Value = serde_json::from_str(&sarif).unwrap();
+            assert!(parsed["runs"][0].get("properties").is_none());
+            assert!(parsed["runs"][0].get("invocations").is_none());
+        }
     }
 }

--- a/crates/clausura-core/src/tools.rs
+++ b/crates/clausura-core/src/tools.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 // ---------------------------------------------------------------------------
 // Tool trait
@@ -23,6 +24,39 @@ pub trait Tool: Send + Sync {
     fn parameters(&self) -> Value;
     /// Execute the tool with given arguments
     async fn execute(&self, args: Value) -> Result<String, ToolError>;
+}
+
+// ---------------------------------------------------------------------------
+// Output truncation
+// ---------------------------------------------------------------------------
+
+/// Max bytes of tool output before truncation.
+const MAX_OUTPUT_BYTES: usize = 32 * 1024;
+/// Max lines of tool output before truncation.
+const MAX_OUTPUT_LINES: usize = 1000;
+
+/// Truncate tool output to at most 32 KB or 1000 lines, whichever comes first.
+/// Appends a marker when truncation occurs.
+pub(crate) fn truncate_output(output: String) -> String {
+    let mut keep_end = output.len();
+    let mut offset = 0usize;
+    for (lines_kept, line) in output.split_inclusive('\n').enumerate() {
+        if lines_kept >= MAX_OUTPUT_LINES || offset + line.len() > MAX_OUTPUT_BYTES {
+            keep_end = offset;
+            break;
+        }
+        offset += line.len();
+    }
+
+    if keep_end == output.len() {
+        return output;
+    }
+    let mut truncated = output[..keep_end].to_string();
+    truncated.truncate(truncated.trim_end_matches('\n').len());
+    truncated.push_str(
+        "\n... [output truncated: limit is 32KB or 1000 lines, use offset/limit or a narrower query]",
+    );
+    truncated
 }
 
 // ---------------------------------------------------------------------------
@@ -162,27 +196,42 @@ impl Tool for ReadFileTool {
             .as_str()
             .ok_or_else(|| ToolError::ExecutionFailed("Missing 'path' argument".into()))?;
         let resolved = self.resolve_path(path_str)?;
-        let content = tokio::fs::read_to_string(&resolved)
-            .await
-            .map_err(|e| ToolError::ExecutionFailed(format!("Read error: {}", e)))?;
 
         let offset = args["offset"].as_u64().unwrap_or(1) as usize;
         let limit = args["limit"].as_u64().map(|l| l as usize);
 
+        if limit == Some(0) {
+            return Ok(String::new());
+        }
+
+        let file = tokio::fs::File::open(&resolved)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Read error: {}", e)))?;
+        let mut lines = BufReader::new(file).lines();
+
+        // When no limit is given, cap at the 1000-line output limit. Read one
+        // extra line so truncate_output appends its truncation marker.
+        let max_take = limit.unwrap_or(MAX_OUTPUT_LINES + 1);
+
         // offset is 1-based: offset=1 means no skip
-        let lines: Vec<&str> = content.lines().skip(offset.saturating_sub(1)).collect();
-
-        let result = if let Some(limit) = limit {
-            if limit == 0 {
-                String::new()
-            } else {
-                lines.into_iter().take(limit).collect::<Vec<_>>().join("\n")
+        let mut to_skip = offset.saturating_sub(1);
+        let mut result_lines: Vec<String> = Vec::new();
+        while let Some(line) = lines
+            .next_line()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Read error: {}", e)))?
+        {
+            if to_skip > 0 {
+                to_skip -= 1;
+                continue;
             }
-        } else {
-            lines.join("\n")
-        };
+            result_lines.push(line);
+            if result_lines.len() >= max_take {
+                break;
+            }
+        }
 
-        Ok(result)
+        Ok(truncate_output(result_lines.join("\n")))
     }
 }
 
@@ -258,7 +307,8 @@ impl Tool for GitDiffTool {
             &["diff"]
         };
 
-        self.run_git(git_args).await
+        let output = self.run_git(git_args).await?;
+        Ok(truncate_output(output))
     }
 }
 
@@ -266,7 +316,7 @@ impl Tool for GitDiffTool {
 // ShellExecTool
 // ---------------------------------------------------------------------------
 
-/// Executes shell commands from a configured allowlist.
+/// Executes commands from a configured allowlist, directly (no shell).
 pub struct ShellExecTool {
     workspace_root: PathBuf,
     allowlist: Vec<String>,
@@ -280,24 +330,23 @@ impl ShellExecTool {
         }
     }
 
-    fn check_allowed(&self, command: &str) -> Result<(), ToolError> {
-        let cmd_name = command.split_whitespace().next().unwrap_or("");
+    fn check_allowed(&self, program: &str) -> Result<(), ToolError> {
         if self.allowlist.is_empty() {
             return Err(ToolError::SandboxViolation(
                 "No commands allowed (empty allowlist)".into(),
             ));
         }
         // Check both the raw token and its basename to support "/usr/bin/git" style
-        let basename = Path::new(cmd_name)
+        let basename = Path::new(program)
             .file_name()
             .and_then(|n| n.to_str())
-            .unwrap_or(cmd_name);
-        let allowed = self.allowlist.contains(&cmd_name.to_string())
+            .unwrap_or(program);
+        let allowed = self.allowlist.contains(&program.to_string())
             || self.allowlist.contains(&basename.to_string());
         if !allowed {
             return Err(ToolError::SandboxViolation(format!(
                 "Command not in allowlist: {} (basename: {}). Allowed: {:?}",
-                cmd_name, basename, self.allowlist
+                program, basename, self.allowlist
             )));
         }
         Ok(())
@@ -311,32 +360,43 @@ impl Tool for ShellExecTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a shell command from the allowed list."
+        "Execute a command from the allowed list. The command is executed directly WITHOUT a shell, so shell metacharacters like ';', '|', '$()' or '>' have no effect."
     }
 
     fn parameters(&self) -> Value {
         serde_json::json!({
             "type": "object",
             "properties": {
-                "command": {
-                    "type": "string",
-                    "description": "Shell command to execute"
+                "argv": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Command and arguments to execute directly, e.g. [\"git\", \"status\"]"
                 }
             },
-            "required": ["command"]
+            "required": ["argv"]
         })
     }
 
     async fn execute(&self, args: Value) -> Result<String, ToolError> {
-        let command = args["command"]
-            .as_str()
-            .ok_or_else(|| ToolError::ExecutionFailed("Missing 'command' argument".into()))?;
+        let argv: Vec<String> = args["argv"]
+            .as_array()
+            .ok_or_else(|| ToolError::ExecutionFailed("Missing 'argv' argument".into()))?
+            .iter()
+            .map(|v| {
+                v.as_str().map(String::from).ok_or_else(|| {
+                    ToolError::ExecutionFailed("'argv' elements must be strings".into())
+                })
+            })
+            .collect::<Result<_, ToolError>>()?;
 
-        self.check_allowed(command)?;
+        let (program, rest) = argv
+            .split_first()
+            .ok_or_else(|| ToolError::ExecutionFailed("'argv' must not be empty".into()))?;
 
-        let output = tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg(command)
+        self.check_allowed(program)?;
+
+        let output = tokio::process::Command::new(program)
+            .args(rest)
             .current_dir(&self.workspace_root)
             .output()
             .await
@@ -346,14 +406,14 @@ impl Tool for ShellExecTool {
         let stderr = String::from_utf8_lossy(&output.stderr);
 
         if output.status.success() {
-            Ok(stdout.to_string())
+            Ok(truncate_output(stdout.to_string()))
         } else {
             // Return stderr as the output even on failure (tool result, not error)
-            Ok(format!(
+            Ok(truncate_output(format!(
                 "Exit code: {}\nStderr: {}",
                 output.status.code().unwrap_or(-1),
                 stderr
-            ))
+            )))
         }
     }
 }
@@ -537,7 +597,7 @@ impl Tool for ListFilesTool {
             include_size,
         );
 
-        Ok(lines.join("\n"))
+        Ok(truncate_output(lines.join("\n")))
     }
 }
 
@@ -594,19 +654,20 @@ fn search_file(
     };
     let rel = path.strip_prefix(cfg.root).unwrap_or(path);
     for (line_num, line) in content.lines().enumerate() {
-        if *max_results > 0 && results.len() >= *max_results {
-            *remaining += 1;
-            continue;
-        }
         let matched = if cfg.is_regex {
             cfg.regex.is_some_and(|re| re.is_match(line))
         } else {
             line.contains(cfg.pattern)
         };
-        if matched {
-            let truncated = if line.len() > 200 { &line[..200] } else { line };
-            results.push(format!("{}:{}: {}", rel.display(), line_num + 1, truncated));
+        if !matched {
+            continue;
         }
+        if *max_results > 0 && results.len() >= *max_results {
+            *remaining += 1;
+            continue;
+        }
+        let truncated = if line.len() > 200 { &line[..200] } else { line };
+        results.push(format!("{}:{}: {}", rel.display(), line_num + 1, truncated));
     }
     true
 }
@@ -791,7 +852,7 @@ impl Tool for GrepTool {
             ));
         }
 
-        Ok(output)
+        Ok(truncate_output(output))
     }
 }
 
@@ -945,6 +1006,47 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result, "");
+    }
+
+    #[tokio::test]
+    async fn test_read_file_limit_from_large_file() {
+        let (_tmp, root) = setup_workspace();
+        let test_file = root.join("large.txt");
+        let mut content = String::new();
+        for i in 1..=10000 {
+            content.push_str(&format!("line {}\n", i));
+        }
+        std::fs::write(&test_file, content).unwrap();
+
+        let tool = ReadFileTool::new(root);
+        let result = tool
+            .execute(serde_json::json!({"path": "large.txt", "offset": 5000, "limit": 3}))
+            .await
+            .unwrap();
+        assert_eq!(result, "line 5000\nline 5001\nline 5002");
+    }
+
+    #[tokio::test]
+    async fn test_read_file_output_truncation() {
+        let (_tmp, root) = setup_workspace();
+        let test_file = root.join("big.txt");
+        let mut content = String::new();
+        for i in 1..=1500 {
+            content.push_str(&format!("line {}\n", i));
+        }
+        std::fs::write(&test_file, content).unwrap();
+
+        let tool = ReadFileTool::new(root);
+        // No limit: capped at the 1000-line output limit with a marker
+        let result = tool
+            .execute(serde_json::json!({"path": "big.txt"}))
+            .await
+            .unwrap();
+        let lines: Vec<&str> = result.lines().collect();
+        assert_eq!(lines.len(), 1001, "Expected 1000 lines + marker");
+        assert!(result.contains("[output truncated:"));
+        assert!(result.contains("line 1000"));
+        assert!(!result.contains("line 1001"));
     }
 
     // -----------------------------------------------------------------------
@@ -1103,6 +1205,49 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_git_diff_output_truncation() {
+        let (_tmp, root) = setup_workspace();
+        init_git_repo(&root).await;
+
+        let mut content = String::new();
+        for i in 1..=1500 {
+            content.push_str(&format!("line {}\n", i));
+        }
+        std::fs::write(root.join("big.txt"), &content).unwrap();
+        tokio::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(&root)
+            .output()
+            .await
+            .unwrap();
+        tokio::process::Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(&root)
+            .output()
+            .await
+            .unwrap();
+
+        // Change every line → diff well over 1000 lines
+        let mut updated = String::new();
+        for i in 1..=1500 {
+            updated.push_str(&format!("changed {}\n", i));
+        }
+        std::fs::write(root.join("big.txt"), &updated).unwrap();
+
+        let tool = GitDiffTool::new(root);
+        let result = tool.execute(serde_json::json!({})).await.unwrap();
+        assert!(
+            result.contains("[output truncated:"),
+            "Expected truncation marker, got {} bytes",
+            result.len()
+        );
+        assert!(
+            result.lines().count() <= 1001,
+            "Expected at most 1000 lines + marker"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // ShellExecTool tests
     // -----------------------------------------------------------------------
@@ -1114,7 +1259,7 @@ mod tests {
         let tool = ShellExecTool::new(root, allowlist);
 
         let result = tool
-            .execute(serde_json::json!({"command": "git status"}))
+            .execute(serde_json::json!({"argv": ["git", "status"]}))
             .await;
         assert!(result.is_ok());
     }
@@ -1126,7 +1271,7 @@ mod tests {
         let tool = ShellExecTool::new(root, allowlist);
 
         let result = tool
-            .execute(serde_json::json!({"command": "rm -rf /"}))
+            .execute(serde_json::json!({"argv": ["rm", "-rf", "/"]}))
             .await;
         assert!(matches!(result, Err(ToolError::SandboxViolation(_))));
     }
@@ -1137,7 +1282,7 @@ mod tests {
         let allowlist: Vec<String> = vec![];
         let tool = ShellExecTool::new(root, allowlist);
 
-        let result = tool.execute(serde_json::json!({"command": "ls"})).await;
+        let result = tool.execute(serde_json::json!({"argv": ["ls"]})).await;
         assert!(matches!(result, Err(ToolError::SandboxViolation(_))));
     }
 
@@ -1149,6 +1294,63 @@ mod tests {
 
         let result = tool.execute(serde_json::json!({})).await;
         assert!(matches!(result, Err(ToolError::ExecutionFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_shell_exec_empty_argv() {
+        let (_tmp, root) = setup_workspace();
+        let allowlist = vec!["git".into()];
+        let tool = ShellExecTool::new(root, allowlist);
+
+        let result = tool.execute(serde_json::json!({"argv": []})).await;
+        assert!(matches!(result, Err(ToolError::ExecutionFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_shell_exec_no_shell_injection() {
+        let (_tmp, root) = setup_workspace();
+        let allowlist = vec!["echo".into()];
+        let tool = ShellExecTool::new(root.clone(), allowlist);
+
+        // Metacharacters must be passed through as literal argv elements,
+        // not interpreted by a shell.
+        let result = tool
+            .execute(serde_json::json!({"argv": ["echo", "hello; touch INJECTION_MARKER"]}))
+            .await
+            .unwrap();
+        assert!(
+            result.contains("hello; touch INJECTION_MARKER"),
+            "Expected literal metacharacters in output, got: {}",
+            result
+        );
+        assert!(
+            !root.join("INJECTION_MARKER").exists(),
+            "Injection marker file must not be created"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_shell_exec_output_truncation() {
+        let (_tmp, root) = setup_workspace();
+        let allowlist = vec!["echo".into()];
+        let tool = ShellExecTool::new(root, allowlist);
+
+        // 40 KB single argument → output exceeds the 32KB limit
+        let big = "x".repeat(40 * 1024);
+        let result = tool
+            .execute(serde_json::json!({"argv": ["echo", big]}))
+            .await
+            .unwrap();
+        assert!(
+            result.contains("[output truncated:"),
+            "Expected truncation marker, got {} bytes",
+            result.len()
+        );
+        assert!(
+            result.len() <= 32 * 1024 + 128,
+            "Output should be bounded near 32KB, got {}",
+            result.len()
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1305,6 +1507,29 @@ mod tests {
             !result.contains("a/b/c/d/deep.txt"),
             "Did not expect a/b/c/d/deep.txt (depth > 3) in output:\n{}",
             result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_files_output_truncation() {
+        let (_tmp, root) = setup_workspace();
+        for i in 0..1500 {
+            std::fs::write(root.join(format!("file{:04}.txt", i)), "").unwrap();
+        }
+
+        let tool = ListFilesTool::new(root);
+        let result = tool
+            .execute(serde_json::json!({"path": ".", "recursive": false}))
+            .await
+            .unwrap();
+        assert!(
+            result.contains("[output truncated:"),
+            "Expected truncation marker, got {} lines",
+            result.lines().count()
+        );
+        assert!(
+            result.lines().count() <= 1001,
+            "Expected at most 1000 lines + marker"
         );
     }
 
@@ -1532,13 +1757,45 @@ mod tests {
             .await
             .unwrap();
         let lines: Vec<&str> = result.lines().collect();
-        let match_lines = lines.iter().filter(|l| l.contains(":")).count();
-        let truncation_line = lines.iter().find(|l| l.starts_with("... and "));
+        // The truncation line also contains ":", so count real match lines by prefix
+        let match_lines = lines.iter().filter(|l| l.starts_with("big.txt:")).count();
         assert_eq!(match_lines, 20, "Expected 20 match lines, got: {}", result);
-        assert!(
-            truncation_line.is_some(),
-            "Expected truncation notice, got: {}",
+        let truncation_line = lines.iter().find(|l| l.starts_with("... and "));
+        assert_eq!(
+            truncation_line,
+            Some(&"... and 80 more matches (use more specific pattern or narrower path)"),
+            "Expected exact remaining count, got: {}",
             result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_grep_output_truncation() {
+        let (_tmp, root) = setup_workspace();
+        // 200 matching lines of ~250 chars each → results exceed the 32KB limit
+        let long_line = format!("match {}", "x".repeat(250));
+        let content = (0..200)
+            .map(|_| long_line.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(root.join("wide.txt"), content).unwrap();
+
+        let tool = GrepTool::new(root);
+        let result = tool
+            .execute(
+                serde_json::json!({"path": "wide.txt", "pattern": "match", "max_results": 200}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.contains("[output truncated:"),
+            "Expected truncation marker, got {} bytes",
+            result.len()
+        );
+        assert!(
+            result.len() <= 32 * 1024 + 128,
+            "Output should be bounded near 32KB, got {}",
+            result.len()
         );
     }
 
@@ -1572,6 +1829,7 @@ mod tests {
     // Symlink security tests (P2-4, P2-5)
     // -----------------------------------------------------------------------
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_list_files_symlink_metadata_no_leak() {
         let (_tmp, root) = setup_workspace();
@@ -1597,6 +1855,7 @@ mod tests {
         let _ = std::fs::remove_file(&outside);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_grep_skips_symlink_outside_workspace() {
         let (_tmp, root) = setup_workspace();
@@ -1640,7 +1899,7 @@ mod tests {
 
         // /usr/bin/git should match because basename is "git"
         let result = tool
-            .execute(serde_json::json!({"command": "git status"}))
+            .execute(serde_json::json!({"argv": ["git", "status"]}))
             .await;
         assert!(result.is_ok(), "git should be allowed: {:?}", result.err());
     }
@@ -1655,7 +1914,7 @@ mod tests {
         // by the shell's own sandboxing (workspace root). But the allowlist check
         // should at minimum not match "/etc/passwd" as "cat".
         let result = tool
-            .execute(serde_json::json!({"command": "/etc/passwd"}))
+            .execute(serde_json::json!({"argv": ["/etc/passwd"]}))
             .await;
         assert!(
             matches!(result, Err(ToolError::SandboxViolation(_))),

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -180,6 +180,19 @@ pub enum AmbiguityPolicy {
     ProceedWithCaution,
 }
 
+/// Policy for handling incomplete agent runs (context truncated or the
+/// iteration limit exhausted without a clean `Stop`).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OnIncompletePolicy {
+    /// Fail closed: treat the run as an error (exit code 2).
+    #[default]
+    Fail,
+    /// Continue with the partial result (warning + SARIF annotation).
+    Pass,
+}
+
 /// Supported LLM vendor API types.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -378,6 +391,8 @@ pub struct TaskContract {
     pub gating_rules: Vec<GateRule>,
     #[serde(default = "default_max_iterations")]
     pub max_iterations: u32,
+    #[serde(default)]
+    pub on_incomplete: OnIncompletePolicy,
 }
 
 fn default_max_iterations() -> u32 {
@@ -605,9 +620,11 @@ mod tests {
             ambiguity_policy: AmbiguityPolicy::FailClosed,
             gating_rules: vec![],
             max_iterations: 10,
+            on_incomplete: OnIncompletePolicy::Fail,
         };
         assert_eq!(contract.ambiguity_policy, AmbiguityPolicy::FailClosed);
         assert!(contract.gating_rules.is_empty());
+        assert_eq!(contract.on_incomplete, OnIncompletePolicy::Fail);
     }
 
     #[test]

--- a/install.sh
+++ b/install.sh
@@ -46,10 +46,12 @@ mkdir -p "$INSTALL_DIR"
 
 # --- Construct download URL ---
 if [ "$APP_VERSION" = "latest" ]; then
-    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/latest/download/${APP_NAME}-${ARCH}-${TARGET}.tar.gz"
+    BASE_URL="https://github.com/$GITHUB_REPO/releases/latest/download"
 else
-    DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v${APP_VERSION}/${APP_NAME}-${ARCH}-${TARGET}.tar.gz"
+    BASE_URL="https://github.com/$GITHUB_REPO/releases/download/v${APP_VERSION}"
 fi
+DOWNLOAD_URL="$BASE_URL/${APP_NAME}-${ARCH}-${TARGET}.tar.gz"
+CHECKSUMS_URL="$BASE_URL/checksums.txt"
 
 # --- Try prebuilt binary first ---
 download_binary() {
@@ -77,6 +79,32 @@ download_binary() {
         warn "Prebuilt binary not available (HTTP $http_code)"
         return 1
     fi
+
+    # Download checksums and verify the tarball's SHA256
+    if command -v curl &>/dev/null; then
+        curl -fsSL -o "$tmp_dir/checksums.txt" "$CHECKSUMS_URL" || true
+    else
+        wget -q -O "$tmp_dir/checksums.txt" "$CHECKSUMS_URL" || true
+    fi
+
+    if [ ! -s "$tmp_dir/checksums.txt" ]; then
+        warn "Checksum file not available, cannot verify download"
+        return 1
+    fi
+
+    local tarball_name="${APP_NAME}-${ARCH}-${TARGET}.tar.gz"
+    local verify_ok=1
+    if [ "$OS" = "darwin" ]; then
+        (cd "$tmp_dir" && grep " ${tarball_name}\$" checksums.txt | shasum -a 256 -c) && verify_ok=0
+    else
+        (cd "$tmp_dir" && grep " ${tarball_name}\$" checksums.txt | sha256sum -c) && verify_ok=0
+    fi
+
+    if [ "$verify_ok" != "0" ]; then
+        warn "Checksum verification failed for $tarball_name"
+        return 1
+    fi
+    info "Checksum verified."
 
     tar xzf "$tmp_dir/${APP_NAME}.tar.gz" -C "$tmp_dir"
     cp "$tmp_dir/${APP_NAME}" "$INSTALL_DIR/"


### PR DESCRIPTION
## Summary

Batch of security and reliability fixes:

**Security**
- `shell_exec` takes `argv: string[]` and executes without a shell — `;`, `|`, `$()` can no longer bypass the allowlist (checked against `argv[0]`, raw + basename)
- All tool outputs truncated at 32KB / 1000 lines with a visible marker, protecting the token budget
- `grep` "and N more matches" counter fixed to count only matching lines

**Reliability**
- LLM requests: honor `Retry-After`, `tracing::warn` on each retry, 120s default per-request timeout; wiremock tests (500→success, 429 exhaustion, 4xx no-retry)
- Truncation hint inserted at the truncation boundary (after system message) instead of appended — tool_calls/tool pairing stays valid for OpenAI/Anthropic APIs
- New `on_incomplete: fail|pass` config (default `fail`): truncated/iteration-exhausted runs exit 2 instead of silently passing `max_findings: 0` gates; `pass` mode annotates SARIF with `properties.incomplete`
- `ReadFileTool` streams the requested line range instead of loading whole files

**CI / release**
- `action.yml` now installs the clausura binary (new `version` input, OS/arch mapping, SHA256 check against `checksums.txt`) before running
- Release workflow attaches `checksums.txt`; `install.sh` verifies downloads against it
- Test matrix adds macOS; new `cargo audit` job with `.cargo/audit.toml`; symlink tests `#[cfg(unix)]`-gated
- Dockerfile switched to cargo-chef layering; `.gitignore` adds `.codegraph/`
- README synced (argv docs, `on_incomplete`, exit codes, `max_iterations`, checkpoint location / CI `--resume` caveat)

## Verification

- `cargo test --workspace` — 219 tests green (incl. new injection, truncation, retry, incomplete-policy, hint-position tests)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- action.yml/workflows YAML-validated; install.sh checksum path exercised locally on macOS; end-to-end action run on a real runner not yet done (checksums.txt will exist from the next tagged release)