### PR TITLE
fix: stop conflating cumulative token usage with context budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,12 @@ task:
   prompt_template: "{{task_description}}"  # Default. The agent's system prompt.
 
   # Limits
-  token_budget: 32000                # Default. Max total tokens across all LLM calls.
+  token_budget: 32000                # Default. Context-window budget: older messages are
+                                     # truncated (and archived) when the conversation
+                                     # approaches this size.
+  max_total_tokens: 200000           # Optional. Cap on cumulative billed tokens across all
+                                     # LLM calls in one run; the run stops (marked incomplete)
+                                     # when reached. Unset means no cap.
   timeout_secs: 300                  # Default. Max wall-clock time in seconds.
   max_iterations: 10                 # Default. Max agent loop iterations.
   shell_timeout_secs: 120            # Default. Per-command timeout for shell_exec.
@@ -246,6 +251,7 @@ task:
 | `CLAUSURA_AMBIGUITY_POLICY` | `task.ambiguity_policy` |
 | `CLAUSURA_ON_INCOMPLETE` | `task.on_incomplete` |
 | `CLAUSURA_TOKEN_BUDGET` | `task.token_budget`  |
+| `CLAUSURA_MAX_TOTAL_TOKENS` | `task.max_total_tokens` |
 | `CLAUSURA_TIMEOUT`      | `task.timeout_secs`  |
 | `CLAUSURA_SHELL_TIMEOUT` | `task.shell_timeout_secs` |
 | `CLAUSURA_MAX_ITERATIONS` | `task.max_iterations` |
@@ -383,7 +389,7 @@ On successful completion (exit code 0), archive files are automatically cleaned 
 
 ### Incomplete runs fail closed
 
-If the agent loop ends without a clean stop — the context could not be truncated further, the model hit a length limit, or `max_iterations` was exhausted — the extracted findings may be partial. By default (`on_incomplete: fail`) Clausura fails closed: the run exits with code 2 and a clear error message, so an incomplete review can never silently pass a `max_findings: 0` gate. With `on_incomplete: pass`, the previous behavior is kept (gating rules evaluate the partial findings), but a warning is logged and the SARIF output is annotated with `"properties": {"incomplete": true}` on the run.
+If the agent loop ends without a clean stop — the context could not be truncated further, the model hit a length limit, the `max_total_tokens` cap was reached, or `max_iterations` was exhausted — the extracted findings may be partial. By default (`on_incomplete: fail`) Clausura fails closed: the run exits with code 2 and a clear error message, so an incomplete review can never silently pass a `max_findings: 0` gate. With `on_incomplete: pass`, the previous behavior is kept (gating rules evaluate the partial findings), but a warning is logged and the SARIF output is annotated with `"properties": {"incomplete": true}` on the run.
 
 ### Deterministic rule engine
 

--- a/crates/clausura-cli/src/commands/run.rs
+++ b/crates/clausura-cli/src/commands/run.rs
@@ -138,6 +138,9 @@ pub async fn execute(args: RunArgs) -> i32 {
             config.task.vendor.effective_base_url()
         );
         eprintln!("  {} {}", "Token budget:".bold(), config.task.token_budget);
+        if let Some(max_total) = config.task.max_total_tokens {
+            eprintln!("  {} {}", "Max total tokens:".bold(), max_total);
+        }
         eprintln!("  {} {}s", "Timeout:".bold(), config.task.timeout_secs);
         eprintln!(
             "  {} {}",

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -59,7 +59,17 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
             return Err(ProviderError::Timeout("Task timeout exceeded".into()));
         }
 
-        if running_tokens >= config.contract.token_budget || cm.should_truncate(&messages) {
+        // Cumulative cost cap (only when configured): total billed tokens
+        // across all LLM calls. Independent of `token_budget`, which governs
+        // context-window truncation only.
+        if let Some(max_total) = config.contract.max_total_tokens {
+            if running_tokens >= max_total {
+                // Fall-through below marks the result truncated.
+                break;
+            }
+        }
+
+        if cm.should_truncate(&messages) {
             let snapshot = messages.clone();
             let (was_truncated, count) = cm.truncate_to_budget(&mut messages);
             if was_truncated && count > 0 {
@@ -104,10 +114,9 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                     }
                 }
 
-                running_tokens = cm.count_tokens(&messages);
-
-                if cm.should_truncate(&messages) || running_tokens >= config.contract.token_budget {
-                    // Fall-through below marks the result truncated.
+                if cm.should_truncate(&messages) {
+                    // Context cannot be reduced far enough to fit the budget;
+                    // fall-through below marks the result truncated.
                     break;
                 }
                 continue;
@@ -372,6 +381,7 @@ mod tests {
             prompt_template: "Review the code and return findings as JSON.".into(),
             tool_allowlist: vec!["git".into()],
             token_budget: 100000,
+            max_total_tokens: None,
             timeout_secs: 60,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],
@@ -567,6 +577,117 @@ mod tests {
         assert!(
             result.truncated,
             "Expected truncated=true when context cannot be reduced further"
+        );
+    }
+
+    /// Regression test: cumulative billed tokens may exceed `token_budget`
+    /// (the context-window budget) without the run being marked incomplete.
+    /// Previously the loop conflated the two and broke out as soon as
+    /// cumulative usage crossed `token_budget`, failing otherwise-healthy CI
+    /// runs closed.
+    #[tokio::test]
+    async fn test_agent_loop_ignores_cumulative_tokens_for_context_budget() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut contract = test_contract();
+        contract.token_budget = 100000;
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        let mut mock = MockProvider::new("test-model");
+        for _ in 0..2 {
+            mock.add_response(ChatResponse {
+                message: Message::new(Role::Assistant, "Running tool..."),
+                usage: Usage {
+                    input_tokens: 55000,
+                    output_tokens: 5000,
+                    total_tokens: 60000,
+                },
+                finish_reason: FinishReason::ToolCalls,
+                tool_calls: Some(vec![tool_call.clone()]),
+            });
+        }
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "test finding", "evidence": "test"}]}"#),
+            usage: Usage {
+                input_tokens: 55000,
+                output_tokens: 5000,
+                total_tokens: 60000,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        // Cumulative billed tokens (180000) far exceed token_budget (100000),
+        // but the context itself always fit, so the run completes cleanly.
+        assert_eq!(result.usage.total_tokens, 180000);
+        assert!(
+            !result.truncated,
+            "Cumulative token usage must not mark the run incomplete"
+        );
+        assert!(!result.findings.is_empty());
+    }
+
+    /// The optional `max_total_tokens` cap still stops the loop (marked
+    /// incomplete) when cumulative billed tokens reach it.
+    #[tokio::test]
+    async fn test_agent_loop_breaks_on_max_total_tokens() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut contract = test_contract();
+        contract.token_budget = 100000;
+        contract.max_total_tokens = Some(100000);
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        let mut mock = MockProvider::new("test-model");
+        for _ in 0..2 {
+            mock.add_response(ChatResponse {
+                message: Message::new(Role::Assistant, "Running tool..."),
+                usage: Usage {
+                    input_tokens: 55000,
+                    output_tokens: 5000,
+                    total_tokens: 60000,
+                },
+                finish_reason: FinishReason::ToolCalls,
+                tool_calls: Some(vec![tool_call.clone()]),
+            });
+        }
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert_eq!(result.usage.total_tokens, 120000);
+        assert!(
+            result.truncated,
+            "Expected truncated=true once cumulative tokens reach max_total_tokens"
         );
     }
 

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -70,6 +70,8 @@ struct YamlTaskConfig {
     tool_allowlist: Vec<String>,
     #[serde(default = "default_token_budget")]
     token_budget: u64,
+    #[serde(default)]
+    max_total_tokens: Option<u64>,
     #[serde(default = "default_timeout")]
     timeout_secs: u64,
     #[serde(default = "default_shell_timeout")]
@@ -182,6 +184,11 @@ fn validate_yaml(yaml: &YamlConfig) -> Result<(), ConfigError> {
             "task.token_budget must be > 0".into(),
         ));
     }
+    if yaml.task.max_total_tokens == Some(0) {
+        return Err(ConfigError::ValidationError(
+            "task.max_total_tokens must be > 0 when set".into(),
+        ));
+    }
     if yaml.task.timeout_secs == 0 {
         return Err(ConfigError::ValidationError(
             "task.timeout_secs must be > 0".into(),
@@ -255,6 +262,7 @@ impl Config {
                     prompt_template: default_prompt(),
                     tool_allowlist: vec![],
                     token_budget: default_token_budget(),
+                    max_total_tokens: None,
                     timeout_secs: default_timeout(),
                     shell_timeout_secs: default_shell_timeout(),
                     shell_env_passthrough: vec![],
@@ -284,6 +292,11 @@ impl Config {
             .and_then(|v| v.parse().ok())
             .or(cli_token_budget)
             .unwrap_or(yaml_task.token_budget);
+
+        let max_total_tokens = std::env::var("CLAUSURA_MAX_TOTAL_TOKENS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .or(yaml_task.max_total_tokens);
 
         let timeout = std::env::var("CLAUSURA_TIMEOUT")
             .ok()
@@ -343,6 +356,7 @@ impl Config {
                 prompt_template: yaml_task.prompt_template,
                 tool_allowlist: yaml_task.tool_allowlist,
                 token_budget,
+                max_total_tokens,
                 timeout_secs: timeout,
                 shell_timeout_secs: shell_timeout,
                 shell_env_passthrough: yaml_task.shell_env_passthrough,
@@ -560,6 +574,7 @@ task:
             std::env::remove_var("CLAUSURA_MODEL");
             std::env::remove_var("CLAUSURA_VENDOR");
             std::env::remove_var("CLAUSURA_TOKEN_BUDGET");
+            std::env::remove_var("CLAUSURA_MAX_TOTAL_TOKENS");
             std::env::remove_var("CLAUSURA_TIMEOUT");
             std::env::remove_var("CLAUSURA_AMBIGUITY_POLICY");
             std::env::remove_var("CLAUSURA_ON_INCOMPLETE");
@@ -985,6 +1000,142 @@ task:
         .unwrap();
         assert_eq!(config.task.on_incomplete, OnIncompletePolicy::Pass);
         unsafe { std::env::remove_var("CLAUSURA_ON_INCOMPLETE") };
+    }
+
+    #[test]
+    fn test_max_total_tokens_from_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  max_total_tokens: 200000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.max_total_tokens, Some(200000));
+    }
+
+    #[test]
+    fn test_max_total_tokens_defaults_to_none() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.max_total_tokens, None);
+    }
+
+    #[test]
+    fn test_max_total_tokens_env_overrides_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        unsafe { std::env::set_var("CLAUSURA_MAX_TOTAL_TOKENS", "500000") };
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  max_total_tokens: 200000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.max_total_tokens, Some(500000));
+        unsafe { std::env::remove_var("CLAUSURA_MAX_TOTAL_TOKENS") };
+    }
+
+    #[test]
+    fn test_zero_max_total_tokens_is_error() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  max_total_tokens: 0
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let result = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -383,7 +383,13 @@ pub struct TaskContract {
     pub prompt_template: String,
     #[serde(default)]
     pub tool_allowlist: Vec<String>,
+    /// Context-window budget: drives truncation of the conversation.
     pub token_budget: u64,
+    /// Optional cap on cumulative tokens billed across all LLM calls in one
+    /// run. When reached, the agent loop stops and the run is marked
+    /// incomplete. `None` means no cap.
+    #[serde(default)]
+    pub max_total_tokens: Option<u64>,
     pub timeout_secs: u64,
     #[serde(default = "default_shell_timeout_secs")]
     pub shell_timeout_secs: u64,
@@ -624,6 +630,7 @@ mod tests {
             prompt_template: "Review: {{diff}}".into(),
             tool_allowlist: vec![],
             token_budget: 32000,
+            max_total_tokens: None,
             timeout_secs: 300,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],


### PR DESCRIPTION
## Problem

Observed in painttyServer CI ([failed run](https://github.com/liuyanghejerry/painttyServer/actions/runs/30166553802/job/89700477363)): the audit exited with code 2 after 13s / 118k tokens / 0 findings:

```
Error: Agent run incomplete (context truncated or iteration limit reached); failing closed (on_incomplete=fail)
```

Root cause: the agent loop compared `running_tokens` — **cumulative billed tokens across all LLM calls**, where each call re-sends the full conversation as input — against `token_budget`, which is also the **context-window truncation threshold** (`ContextManager`). A few fast iterations of a quick model easily exceed a 64000 budget; truncation was then a no-op (the context itself still fit), the loop broke out, the run was marked incomplete, and the default `on_incomplete=fail` failed CI closed even with zero findings.

## Fix

- `token_budget` now governs **only** context-window truncation (matching how `ContextManager` already uses it).
- New optional `task.max_total_tokens` (yaml / `CLAUSURA_MAX_TOTAL_TOKENS` env) caps cumulative billed tokens per run; reaching it still stops the loop and marks the run incomplete, preserving the cost-guard use case. Unset means no cap.
- The loop only stops when the context genuinely cannot be truncated far enough to fit the budget — a no-op truncation while the context fits no longer kills the run.

## Tests

- Regression: cumulative billed tokens (180k) exceeding `token_budget` (100k) with a fitting context now completes cleanly (`truncated=false`, findings extracted).
- `max_total_tokens` cap reached → loop stops, run marked incomplete.
- Config: yaml parsing, default `None`, env override, `Some(0)` validation error.
- Full workspace: 239 tests pass, `cargo fmt --check` and `cargo clippy -D warnings` clean.

Docs: README updated (`token_budget` semantics, new `max_total_tokens` field, env var table, incomplete-run causes).