### PR TITLE
feat: skill-as-task — 支持引用社区 skill 文件作为审查 prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,67 @@ clausura run --dry-run  # show the execution plan
 | 2    | Error         | Runtime error (provider, timeout, etc.), or an incomplete agent run with `on_incomplete: fail` |
 | 3    | Config error  | Invalid configuration                    |
 
+## Using Skills
+
+Clausura 1.2.0+ can reuse community skill files (Markdown) as review prompts. Skills answer "what and how to review", while gating rules answer "how many findings is too many" — the two are cleanly separated.
+
+### Skill file format
+
+A skill is a Markdown file, optionally with YAML frontmatter:
+
+```markdown
+---
+name: security-review
+description: 检查 SQL 注入、XSS、硬编码密钥
+---
+
+# 安全代码审查
+
+## SQL 注入
+- 任何字符串拼接构造的 SQL 查询
+- rule_id: `sql-injection`
+- severity: `error`
+```
+
+The frontmatter is stripped automatically; only the Markdown body is injected into the agent's system prompt.
+
+### Referencing skills
+
+```yaml
+task:
+  skill_prompts:
+    # Local file (relative to workspace or absolute)
+    - ./skills/security-review.md
+
+    # Named skill (looks in .clausura/skills/<name>/SKILL.md,
+    # then ~/.clausura/skills/<name>/SKILL.md)
+    - security-review
+    - team/vue-best-practices
+
+  # Optional: append your own extra instructions
+  prompt_template: |
+    另外检查：禁止 console.log
+
+  gating:
+    - rule: sql-injection
+      max_findings: 0
+      action: fail
+```
+
+### Installing community skills
+
+```bash
+# Project-level (only this repo)
+mkdir -p .clausura/skills/security-review
+cp ~/Downloads/security-review-SKILL.md .clausura/skills/security-review/SKILL.md
+
+# User-level (available to all your projects)
+mkdir -p ~/.clausura/skills/team/vue-check
+cp ~/Downloads/vue-check-SKILL.md ~/.clausura/skills/team/vue-check/SKILL.md
+```
+
+See [`examples/`](examples/) for ready-to-use skill files and a sample configuration.
+
 ## Configuration Reference
 
 ### YAML schema
@@ -195,6 +256,9 @@ task:
 
   # Prompt
   prompt_template: "{{task_description}}"  # Default. The agent's system prompt.
+  skill_prompts: []                           # Optional. Reuse community skill files.
+                                               # Supports local paths, named references,
+                                               # and remote URLs.
 
   # Limits
   token_budget: 32000                # Default. Context-window budget: older messages are

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -61,6 +61,8 @@ struct YamlTaskConfig {
     #[serde(default)]
     description: String,
     #[serde(default)]
+    skill_prompts: Vec<String>,
+    #[serde(default)]
     model: String,
     #[serde(default)]
     vendor: String,
@@ -257,6 +259,7 @@ impl Config {
                 YamlTaskConfig {
                     name: "default".into(),
                     description: String::new(),
+                    skill_prompts: vec![],
                     model: String::new(),
                     vendor: String::new(),
                     prompt_template: default_prompt(),
@@ -345,6 +348,18 @@ impl Config {
             })
             .collect();
 
+        // ---- Resolve skill prompts ----
+        let prompt_template = if yaml_task.skill_prompts.is_empty() {
+            yaml_task.prompt_template
+        } else {
+            let mut skill_contents: Vec<(String, String)> = Vec::new();
+            for skill_ref in &yaml_task.skill_prompts {
+                let content = crate::skills::resolve_skill(skill_ref, &workspace)?;
+                skill_contents.push((skill_ref.clone(), content));
+            }
+            crate::skills::merge_prompts(&skill_contents, &yaml_task.prompt_template)
+        };
+
         Ok(Config {
             config_path,
             task: TaskContract {
@@ -353,7 +368,7 @@ impl Config {
                 description: yaml_task.description,
                 model,
                 vendor,
-                prompt_template: yaml_task.prompt_template,
+                prompt_template,
                 tool_allowlist: yaml_task.tool_allowlist,
                 token_budget,
                 max_total_tokens,
@@ -1403,5 +1418,217 @@ task:
         )
         .unwrap();
         assert_eq!(config.task.shell_timeout_secs, 90); // CLI wins over YAML
+    }
+
+    // -- skill_prompts tests ----------------------------------------------
+
+    #[test]
+    fn test_skill_prompts_empty_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        // No skill_prompts in YAML → prompt_template unchanged.
+        assert_eq!(config.task.prompt_template, "{{task_description}}");
+    }
+
+    #[test]
+    fn test_skill_prompts_local_file() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let skill_path = tmp.path().join("my-check.md");
+        std::fs::write(&skill_path, "# Check for bugs").unwrap();
+
+        let yaml = format!(
+            r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  skill_prompts:
+    - "{}"
+"#,
+            skill_path.display()
+        );
+        let file = write_yaml(&yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            tmp.path().to_path_buf(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(config.task.prompt_template.contains("[Skill:"));
+        assert!(config.task.prompt_template.contains("# Check for bugs"));
+        assert!(!config.task.prompt_template.contains("{{task_description}}"));
+    }
+
+    #[test]
+    fn test_skill_prompts_named_skill() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let skill_dir = tmp
+            .path()
+            .join(".clausura")
+            .join("skills")
+            .join("team")
+            .join("vue-check");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: vue-check\n---\n# Vue best practices",
+        )
+        .unwrap();
+
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  skill_prompts:
+    - team/vue-check
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            tmp.path().to_path_buf(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(config.task.prompt_template.contains("[Skill: team/vue-check]"));
+        assert!(config.task.prompt_template.contains("# Vue best practices"));
+    }
+
+    #[test]
+    fn test_skill_prompts_with_user_template() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("check.md"), "Skill body").unwrap();
+
+        let yaml = format!(
+            r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  skill_prompts:
+    - "{}"
+  prompt_template: "User extra check."
+"#,
+            tmp.path().join("check.md").display()
+        );
+        let file = write_yaml(&yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            tmp.path().to_path_buf(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(config.task.prompt_template.contains("[Skill:"));
+        assert!(config.task.prompt_template.contains("Skill body"));
+        assert!(config.task.prompt_template.contains("User extra check."));
+    }
+
+    #[test]
+    fn test_skill_prompts_not_found_is_error() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  skill_prompts:
+    - nonexistent/skill
+"#;
+        let file = write_yaml(yaml);
+        let result = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        );
+        assert!(result.is_err());
     }
 }

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -1548,7 +1548,10 @@ task:
             LogFormat::Json,
         )
         .unwrap();
-        assert!(config.task.prompt_template.contains("[Skill: team/vue-check]"));
+        assert!(config
+            .task
+            .prompt_template
+            .contains("[Skill: team/vue-check]"));
         assert!(config.task.prompt_template.contains("# Vue best practices"));
     }
 

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -1476,9 +1476,9 @@ task:
   timeout_secs: 60
   ambiguity_policy: fail_closed
   skill_prompts:
-    - "{}"
+    - '{}'
 "#,
-            skill_path.display()
+            skill_path.to_string_lossy()
         );
         let file = write_yaml(&yaml);
         let config = Config::load(
@@ -1574,10 +1574,10 @@ task:
   timeout_secs: 60
   ambiguity_policy: fail_closed
   skill_prompts:
-    - "{}"
+    - '{}'
   prompt_template: "User extra check."
 "#,
-            tmp.path().join("check.md").display()
+            tmp.path().join("check.md").to_string_lossy()
         );
         let file = write_yaml(&yaml);
         let config = Config::load(

--- a/crates/clausura-core/src/lib.rs
+++ b/crates/clausura-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod logging;
 pub mod provider;
 pub mod rules;
 pub mod sarif;
+pub mod skills;
 pub mod snapshot;
 pub mod tools;
 pub mod types;

--- a/crates/clausura-core/src/skills.rs
+++ b/crates/clausura-core/src/skills.rs
@@ -1,0 +1,299 @@
+//! Skill prompt loading and merging.
+//!
+//! Clausura consumes community skill files (Markdown, commonly with YAML
+//! frontmatter) and injects their content into the agent's system prompt.
+//! Gating rules remain fully under user control — skills answer "how to
+//! review", gating answers "how many findings is too many".
+
+use crate::types::ConfigError;
+use std::path::{Path, PathBuf};
+
+/// Resolve a skill reference to its prompt body (frontmatter stripped).
+///
+/// Resolution order:
+/// 1. Absolute path or path relative to cwd that exists as-is.
+/// 2. Path relative to the workspace root.
+/// 3. Named reference — looked up in `.clausura/skills/<name>/SKILL.md`
+///    (project-level) then `~/.clausura/skills/<name>/SKILL.md` (user-level).
+pub fn resolve_skill(name_or_path: &str, workspace: &Path) -> Result<String, ConfigError> {
+    let path = Path::new(name_or_path);
+    if path.exists() {
+        return load_skill_file(path);
+    }
+    let workspace_path = workspace.join(name_or_path);
+    if workspace_path.exists() {
+        return load_skill_file(&workspace_path);
+    }
+
+    if !name_or_path.contains("://") && !name_or_path.starts_with('/') {
+        return resolve_named_skill(name_or_path, workspace);
+    }
+
+    Err(ConfigError::FileNotFound(format!(
+        "Skill not found: {name_or_path}"
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn load_skill_file(path: &Path) -> Result<String, ConfigError> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        ConfigError::FileNotFound(format!("{}: {e}", path.display()))
+    })?;
+    Ok(strip_frontmatter(&content))
+}
+
+fn resolve_named_skill(name: &str, workspace: &Path) -> Result<String, ConfigError> {
+    let skill_rel = format!("{}/SKILL.md", name.trim_end_matches('/'));
+
+    let search_paths: Vec<PathBuf> = vec![
+        workspace
+            .join(".clausura")
+            .join("skills")
+            .join(&skill_rel),
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".clausura")
+            .join("skills")
+            .join(&skill_rel),
+    ];
+
+    for p in &search_paths {
+        if p.exists() {
+            return load_skill_file(p);
+        }
+    }
+
+    Err(ConfigError::FileNotFound(format!(
+        "Named skill '{name}' not found. Looked in: {}",
+        search_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )))
+}
+
+/// Strip YAML frontmatter delimited by `---` at the start of the content.
+/// Returns the body without the frontmatter block. If no frontmatter is
+/// found or the closing `---` is missing, the original content is returned
+/// unchanged.
+pub(crate) fn strip_frontmatter(content: &str) -> String {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return content.to_string();
+    }
+
+    // Skip the opening "---" and optional newline.
+    let after_open = &trimmed[3..];
+    let rest = after_open.strip_prefix('\n').unwrap_or(after_open);
+
+    if let Some(pos) = rest.find("\n---") {
+        // pos + 4 skips "\n---" itself
+        let body = rest[pos + 4..].trim_start();
+        if !body.is_empty() {
+            return body.to_string();
+        }
+    }
+
+    // No valid closing delimiter; return original content.
+    content.to_string()
+}
+
+/// Merge resolved skill contents and a user prompt template into a single
+/// system-prompt-ready string. Each skill is delimited with a `[Skill: …]`
+/// header; the user's template (if non-empty and not the default placeholder)
+/// appears after a `---` separator.
+pub fn merge_prompts(
+    skill_contents: &[(String, String)], // (skill_ref, body)
+    template: &str,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    for (skill_ref, content) in skill_contents {
+        parts.push(format!("[Skill: {skill_ref}]\n{content}"));
+    }
+
+    let has_user_template = !template.is_empty() && template != "{{task_description}}";
+    if has_user_template {
+        parts.push(template.to_string());
+    }
+
+    parts.join("\n\n---\n\n")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // -- strip_frontmatter --------------------------------------------------
+
+    #[test]
+    fn test_strip_frontmatter_basic() {
+        let input = "---\nname: test\ndescription: A test skill\n---\n\n# Body\nCheck for bugs.";
+        let body = strip_frontmatter(input);
+        assert_eq!(body, "# Body\nCheck for bugs.");
+    }
+
+    #[test]
+    fn test_strip_frontmatter_no_newline_after_open() {
+        let input = "---\nname: test\n---\nbody";
+        let body = strip_frontmatter(input);
+        assert_eq!(body, "body");
+    }
+
+    #[test]
+    fn test_strip_frontmatter_no_opening() {
+        let input = "# Just a markdown file\nNo frontmatter.";
+        let body = strip_frontmatter(input);
+        assert_eq!(body, input);
+    }
+
+    #[test]
+    fn test_strip_frontmatter_no_closing() {
+        let input = "---\nname: test\n# Body but no closing";
+        let body = strip_frontmatter(input);
+        // No closing delimiter → returned unchanged
+        assert_eq!(body, input);
+    }
+
+    #[test]
+    fn test_strip_frontmatter_empty_body() {
+        let input = "---\nname: test\n---\n";
+        let body = strip_frontmatter(input);
+        assert_eq!(body, input); // empty body → unchanged
+    }
+
+    #[test]
+    fn test_strip_frontmatter_with_leading_whitespace() {
+        let input = "  \n  ---\nname: test\n---\nbody after whitespace";
+        let body = strip_frontmatter(input);
+        assert_eq!(body, "body after whitespace");
+    }
+
+    #[test]
+    fn test_strip_frontmatter_preserves_inner_content() {
+        // The body starts right after the closing --- line.
+        let input = "---\nname: test\n---\n\n\nline1\nline2";
+        let body = strip_frontmatter(input);
+        // Two leading blank lines before "line1": trim_start eats them.
+        assert_eq!(body, "line1\nline2");
+    }
+
+    // -- merge_prompts ------------------------------------------------------
+
+    #[test]
+    fn test_merge_single_skill_no_template() {
+        let skills = vec![("sec/check".into(), "Find SQL injection.".into())];
+        let merged = merge_prompts(&skills, "{{task_description}}");
+        assert_eq!(merged, "[Skill: sec/check]\nFind SQL injection.");
+    }
+
+    #[test]
+    fn test_merge_multiple_skills_with_template() {
+        let skills = vec![
+            ("a".into(), "Check A.".into()),
+            ("b".into(), "Check B.".into()),
+        ];
+        let merged = merge_prompts(&skills, "Also check C.");
+        assert_eq!(
+            merged,
+            "[Skill: a]\nCheck A.\n\n---\n\n[Skill: b]\nCheck B.\n\n---\n\nAlso check C."
+        );
+    }
+
+    #[test]
+    fn test_merge_no_skills_just_template() {
+        let skills: Vec<(String, String)> = vec![];
+        let merged = merge_prompts(&skills, "Review the diff.");
+        assert_eq!(merged, "Review the diff.");
+    }
+
+    #[test]
+    fn test_merge_empty_everything() {
+        let skills: Vec<(String, String)> = vec![];
+        let merged = merge_prompts(&skills, "");
+        assert_eq!(merged, "");
+    }
+
+    // -- resolve_skill (integration via temp dirs) --------------------------
+
+    #[test]
+    fn test_resolve_local_file_direct() {
+        let tmp = TempDir::new().unwrap();
+        let skill_path = tmp.path().join("my-skill.md");
+        std::fs::write(&skill_path, "# Check for bugs").unwrap();
+
+        let result = resolve_skill(
+            skill_path.to_str().unwrap(),
+            tmp.path(),
+        )
+        .unwrap();
+        assert_eq!(result, "# Check for bugs");
+    }
+
+    #[test]
+    fn test_resolve_local_file_relative_to_workspace() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("skill.md"), "# Workspace skill").unwrap();
+
+        // cwd is different; only workspace-relative path should match.
+        let result = resolve_skill("skill.md", tmp.path()).unwrap();
+        assert_eq!(result, "# Workspace skill");
+    }
+
+    #[test]
+    fn test_resolve_named_skill_project_level() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp
+            .path()
+            .join(".clausura")
+            .join("skills")
+            .join("team")
+            .join("my-check");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: t\n---\nTeam check body").unwrap();
+
+        let result = resolve_skill("team/my-check", tmp.path()).unwrap();
+        assert_eq!(result, "Team check body");
+    }
+
+    #[test]
+    fn test_resolve_named_skill_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let err = resolve_skill("nonexistent/skill", tmp.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("Named skill 'nonexistent/skill' not found"));
+    }
+
+    #[test]
+    fn test_resolve_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let err = resolve_skill("/tmp/does-not-exist-98765.md", tmp.path()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("Skill not found"));
+    }
+
+    #[test]
+    fn test_resolve_named_skill_trailing_slash() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp
+            .path()
+            .join(".clausura")
+            .join("skills")
+            .join("trailing");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "body").unwrap();
+
+        // "trailing/" should normalize to "trailing/SKILL.md"
+        let result = resolve_skill("trailing/", tmp.path()).unwrap();
+        assert_eq!(result, "body");
+    }
+}

--- a/crates/clausura-core/src/skills.rs
+++ b/crates/clausura-core/src/skills.rs
@@ -39,9 +39,8 @@ pub fn resolve_skill(name_or_path: &str, workspace: &Path) -> Result<String, Con
 // ---------------------------------------------------------------------------
 
 fn load_skill_file(path: &Path) -> Result<String, ConfigError> {
-    let content = std::fs::read_to_string(path).map_err(|e| {
-        ConfigError::FileNotFound(format!("{}: {e}", path.display()))
-    })?;
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| ConfigError::FileNotFound(format!("{}: {e}", path.display())))?;
     Ok(strip_frontmatter(&content))
 }
 
@@ -49,10 +48,7 @@ fn resolve_named_skill(name: &str, workspace: &Path) -> Result<String, ConfigErr
     let skill_rel = format!("{}/SKILL.md", name.trim_end_matches('/'));
 
     let search_paths: Vec<PathBuf> = vec![
-        workspace
-            .join(".clausura")
-            .join("skills")
-            .join(&skill_rel),
+        workspace.join(".clausura").join("skills").join(&skill_rel),
         dirs::home_dir()
             .unwrap_or_default()
             .join(".clausura")
@@ -231,11 +227,7 @@ mod tests {
         let skill_path = tmp.path().join("my-skill.md");
         std::fs::write(&skill_path, "# Check for bugs").unwrap();
 
-        let result = resolve_skill(
-            skill_path.to_str().unwrap(),
-            tmp.path(),
-        )
-        .unwrap();
+        let result = resolve_skill(skill_path.to_str().unwrap(), tmp.path()).unwrap();
         assert_eq!(result, "# Check for bugs");
     }
 
@@ -259,7 +251,11 @@ mod tests {
             .join("team")
             .join("my-check");
         std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: t\n---\nTeam check body").unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: t\n---\nTeam check body",
+        )
+        .unwrap();
 
         let result = resolve_skill("team/my-check", tmp.path()).unwrap();
         assert_eq!(result, "Team check body");
@@ -284,11 +280,7 @@ mod tests {
     #[test]
     fn test_resolve_named_skill_trailing_slash() {
         let tmp = TempDir::new().unwrap();
-        let skill_dir = tmp
-            .path()
-            .join(".clausura")
-            .join("skills")
-            .join("trailing");
+        let skill_dir = tmp.path().join(".clausura").join("skills").join("trailing");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(skill_dir.join("SKILL.md"), "body").unwrap();
 

--- a/docs/skill-as-task.md
+++ b/docs/skill-as-task.md
@@ -1,0 +1,156 @@
+# Skill-as-Task: 社区 Skill 复用
+
+> 状态：设计中
+> 版本：target v1.x
+
+## 动机
+
+Clausura 的核心价值是 "LLM 审查 + 确定性门禁"。目前引擎（agent loop、rule engine、SARIF 输出）已经成熟，但**内容层（审查知识）完全由用户从零手写**。每个项目都要自己写 prompt，导致：
+
+- 审查质量取决于开发者的领域知识（初级工程师可能遗漏关键检查项）
+- 相同的审查逻辑无法跨项目复用
+- 团队规范难以沉淀和分发
+
+与此同时，社区（Claude Code / Codex CLI / pi）已经积累了大量的 skill 文件——这些 skill 专注于 "如何审查 / 如何检查"，以 Markdown 格式分发。但它们**不包含 gating rules**，因为 "过不过" 是每个团队自己的决策。
+
+## 核心设计
+
+**Clausura 作为社区 skill 的消费者，而非 skill 格式的定义者。**
+
+```
+社区 Skill（Markdown）           Clausura Gating（YAML）
+───────────────────────         ──────────────────────
+"如何检查 SQL 注入"              →  发现 1 个 error？fail
+"如何检查 i18n 缺失"             →  发现 3 个 warning？warn
+"如何检查架构分层"               →  发现 5 个 info？ignore
+```
+
+- Skill 回答 "查什么、怎么查"
+- Gating 回答 "多少算不过"
+- 两者完全解耦
+
+## 用户场景
+
+### 场景 1：直接引用社区 skill
+
+```yaml
+version: "1"
+task:
+  name: security-review
+  model: gpt-4o
+  vendor: openai
+  skill_prompts:
+    - community/security-review    # 复用社区的审查知识
+  gating:                          # 门禁用户自己定
+    - rule: sql-injection
+      min_severity: error
+      max_findings: 0
+      action: fail
+```
+
+### 场景 2：组合多个 skill
+
+```yaml
+task:
+  skill_prompts:
+    - ./skills/react-best-practices.md   # 本地文件
+    - team/no-any-type                   # 团队内部 skill
+    - community/i18n-check               # 社区 skill
+  gating:
+    - rule: no-any-type
+      max_findings: 0
+      action: fail
+    - rule: missing-i18n
+      max_findings: 3
+      action: warn
+```
+
+### 场景 3：skill + 自己的补充 prompt
+
+```yaml
+task:
+  skill_prompts:
+    - community/security-review
+  prompt_template: |               # 用户追加的审查项
+    另外检查：所有 API 调用必须有 error handling。
+  gating:
+    - rule: missing-error-handling
+      max_findings: 0
+      action: fail
+```
+
+### 场景 4：渐进式采用
+
+```
+第一步：直接用社区 skill，gating 全设 max_findings: 0
+第二步：根据实际误报调整 gating 阈值
+第三步：沉淀自己的审查经验为内部 skill
+```
+
+## Skill 引用解析
+
+| 引用形式 | 解析规则 | 示例 |
+|----------|---------|------|
+| 本地文件路径 | 相对 workspace 或绝对路径 | `./skills/check.md`, `/path/to/skill.md` |
+| 命名引用 | 按顺序查找：`.clausura/skills/<name>/SKILL.md` → `~/.clausura/skills/<name>/SKILL.md` | `team/vue-check` |
+| 远程 URL | HTTPS 下载，缓存到 `.clausura/cache/skills/` | `https://.../security.md` |
+
+## Skill 文件格式
+
+Clausura 不定义自己的格式。社区 skill 的标准格式是 Markdown + 可选 YAML frontmatter：
+
+```markdown
+---
+name: security-review
+description: 安全代码审查，检查 SQL 注入、XSS、硬编码密钥
+---
+
+# 审查规则
+
+1. SQL 注入 — 任何字符串拼接的 SQL 查询
+...
+```
+
+Clausura 读取时：
+- 如果有 frontmatter（`---` 包裹），剥离后只取 body 作为 prompt 内容
+- 如果没有 frontmatter，整个文件即为 prompt 内容
+- 多个 skill 按声明顺序拼接，各自标明来源
+
+## 注入格式
+
+多个 skill 的 prompt 内容合并后注入到 system prompt，格式如下：
+
+```
+[Skill: community/security-review]
+<skill 内容>
+
+[Skill: team/vue-best-practices]
+<skill 内容>
+
+---
+
+<用户 prompt_template>
+```
+
+## 非目标
+
+- ❌ Clausura 不定义自有的 skill 格式
+- ❌ 不内置 skill 注册中心/registry
+- ❌ skill 中不包含 gating 定义
+- ❌ 不支持 skill 的热更新或版本管理（先用文件路径，版本用 git tag）
+- ❌ 不支持工具型 skill（依赖外部 CLI/API 的 skill 无法在 Clausura 沙盒中运行）
+
+## 改动范围
+
+| 模块 | 改动 |
+|------|------|
+| `config.rs` | `YamlTaskConfig` 加 `skill_prompts` 字段；加载时解析并合并到 `prompt_template` |
+| `skills.rs` | 新增：skill 文件解析、frontmatter 剥离、多种引用方式的解析 |
+| `types.rs` | 无需改动（skill 内容合并到现有 `prompt_template` 字段） |
+| `agent.rs` | 无需改动（system prompt 构建逻辑不变） |
+
+## 后续演进
+
+- 远程 skill 的版本锁定（`community/security-review@v1.2`）
+- Skill 级别的 tool_allowlist 覆盖
+- `--skill` CLI 快捷参数

--- a/examples/skill-based-review.yaml
+++ b/examples/skill-based-review.yaml
@@ -1,0 +1,67 @@
+# 示例：使用社区 Skill 进行代码审查
+#
+# Clausura 1.2.0+ 支持通过 skill_prompts 引用社区 skill 文件。
+# Skill 提供 "审查什么" 的知识，gating 提供 "多少算不过" 的阈值，两者完全解耦。
+#
+# 运行方式：
+#   clausura run -c examples/skill-based-review.yaml
+# 或把 skill 安装到项目本地后直接引用：
+#   cp -r examples/skills/security-review .clausura/skills/
+#   clausura run -c examples/skill-based-review.yaml
+
+version: "1"
+task:
+  name: full-review
+  model: gpt-4o
+  vendor: openai
+
+  # 引用 Skill：可以是本地路径、命名引用或混合
+  skill_prompts:
+    # 本地路径（相对 workspace）
+    - examples/skills/security-review/SKILL.md
+    # 命名引用（需先将 skill 复制到 .clausura/skills/）
+    # - security-review
+    # - i18n-check
+    # - vue-best-practices
+
+  # 可选：在 skill 基础上追加自定义审查项
+  prompt_template: |
+    另外检查：
+    1. 所有 API 调用必须有 try-catch 错误处理
+    2. 禁止使用 console.log，用统一的 logger 替代
+
+  token_budget: 16000
+  timeout_secs: 120
+
+  # 门禁规则由用户自行定义
+  # rule_id 需要与 skill 中定义的 rule_id 一致
+  gating:
+    - rule: sql-injection
+      description: SQL 注入零容忍
+      min_severity: error
+      max_findings: 0
+      action: fail
+
+    - rule: xss
+      description: XSS 零容忍
+      min_severity: error
+      max_findings: 0
+      action: fail
+
+    - rule: hardcoded-secret
+      description: 不允许硬编码密钥
+      min_severity: error
+      max_findings: 0
+      action: fail
+
+    - rule: missing-validation
+      description: 输入验证缺失不超过 5 个
+      min_severity: warning
+      max_findings: 5
+      action: warn
+
+    - rule: insecure-dependency
+      description: 不安全依赖警告
+      min_severity: warning
+      max_findings: 3
+      action: warn

--- a/examples/skills/i18n-check/SKILL.md
+++ b/examples/skills/i18n-check/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: i18n-check
+description: 国际化完整性检查。检查翻译 key 是否缺失、硬编码文本、locale 文件一致性。
+---
+
+# i18n 国际化检查
+
+检查代码中的国际化（i18n）问题。Locale 文件通常位于 `locales/` 或 `i18n/` 目录。
+
+## 检查清单
+
+### 硬编码文本
+- UI 中直接出现的非英文文本（排除注释和日志）
+- 应使用 i18n key 替代的字符串字面量
+- rule_id: `hardcoded-text`
+- severity: `warning`
+
+### 翻译 Key 缺失
+- 代码中引用了但 locale 文件中不存在的 key
+- rule_id: `missing-translation-key`
+- severity: `error`
+
+### 翻译文件不一致
+- 不同 locale 文件之间 key 数量不一致
+- 某个 locale 缺少其他 locale 存在的 key
+- rule_id: `locale-mismatch`
+- severity: `warning`
+
+### 未使用的翻译 Key
+- locale 文件中定义了但代码中未引用的 key
+- rule_id: `unused-translation-key`
+- severity: `info`
+
+## 输出格式
+
+```json
+{
+  "rule_id": "missing-translation-key",
+  "severity": "error",
+  "message": "key 'checkout.confirm' 在 en.json 中存在但在 zh-CN.json 中缺失",
+  "evidence": "en.json L42: \"checkout.confirm\": \"Confirm order\"",
+  "location": { "file": "locales/zh-CN.json", "line_start": 1, "line_end": 1, "column_start": 1, "column_end": 1 }
+}
+```

--- a/examples/skills/security-review/SKILL.md
+++ b/examples/skills/security-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: security-review
+description: 通用安全代码审查。检查 SQL 注入、XSS、硬编码密钥、不安全依赖等常见安全问题。
+---
+
+# 安全代码审查
+
+请审查代码变更中的以下安全问题。对每个发现使用精确的 `rule_id`。
+
+## 检查清单
+
+### SQL 注入
+- 任何字符串拼接构造的 SQL 查询
+- 未使用参数化查询的数据库调用
+- rule_id: `sql-injection`
+- severity: `error`
+
+### XSS 漏洞
+- 直接将用户输入插入 HTML（innerHTML、document.write）
+- 未转义的模板变量输出
+- rule_id: `xss`
+- severity: `error`
+
+### 硬编码凭证
+- 代码中的 API key、密码、token
+- 配置文件中的明文密钥（排除示例/文档）
+- rule_id: `hardcoded-secret`
+- severity: `error`
+
+### 输入验证缺失
+- API 端点未验证用户输入类型和范围
+- 文件上传未检查类型和大小
+- rule_id: `missing-validation`
+- severity: `warning`
+
+### 不安全依赖
+- 使用已知有 CVE 的依赖版本
+- 直接从不可信源加载脚本
+- rule_id: `insecure-dependency`
+- severity: `warning`
+
+## 输出格式
+
+对每个发现按以下 JSON 格式输出，放在 `findings` 数组中：
+
+```json
+{
+  "rule_id": "sql-injection",
+  "severity": "error",
+  "message": "在 login.js:15 发现 SQL 注入漏洞：用户输入直接拼接到 SQL 查询中",
+  "evidence": "const sql = \"SELECT * FROM users WHERE name = '\" + user + \"'\"",
+  "location": {
+    "file": "src/login.js",
+    "line_start": 15,
+    "line_end": 15,
+    "column_start": 13,
+    "column_end": 62
+  }
+}
+```

--- a/examples/skills/vue-best-practices/SKILL.md
+++ b/examples/skills/vue-best-practices/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: vue-best-practices
+description: Vue 2/3 代码规范检查。包括组件命名、Props 校验、Composition API 规范等。
+---
+
+# Vue 代码规范审查
+
+审查 Vue 组件（`.vue` 文件）中违反最佳实践的模式。
+
+## 检查清单
+
+### 组件命名
+- 组件名未使用 PascalCase 或多词命名（Vue 官方风格指南要求）
+- rule_id: `vue-component-name`
+- severity: `warning`
+
+### Props 校验
+- Props 未声明 type 或 validator
+- rule_id: `vue-missing-prop-validation`
+- severity: `warning`
+
+### 避免 `as any`
+- TypeScript 中使用 `as any` 绕过类型检查
+- rule_id: `no-as-any`
+- severity: `warning`
+
+### Options API vs Composition API
+- 同一组件中混用 Options API 和 Composition API（`<script setup>` 中不应出现 `data()`、`methods:`）
+- rule_id: `vue-mixed-api-style`
+- severity: `info`
+
+### 模板中的复杂表达式
+- `<template>` 中包含超过一行的 JavaScript 表达式（应提取为 computed）
+- rule_id: `vue-complex-template`
+- severity: `info`
+
+## 输出格式
+
+```json
+{
+  "rule_id": "no-as-any",
+  "severity": "warning",
+  "message": "在 PaymentForm.vue 中发现 as any 类型断言",
+  "evidence": "const data = response as any",
+  "location": { "file": "src/components/PaymentForm.vue", "line_start": 42, "line_end": 42, "column_start": 13, "column_end": 35 }
+}
+```


### PR DESCRIPTION
## 动机

Clausura 的引擎（agent loop、rule engine、SARIF）已经成熟，但**内容层完全由用户从零手写**。社区（Claude Code / Codex CLI / pi）已经积累了大量的 skill 文件。本 PR 让 Clausura 成为社区 skill 的消费者——用户引用现成的 skill 作为审查 prompt，gating 规则保持由用户自行控制。

## 设计原则

- **Skill 回答 "查什么、怎么查"，gating 回答 "多少算不过"**，两者完全解耦
- Clausura 不定义自有 skill 格式，直接复用社区 Markdown 格式
- Skill 中不包含 gating rules

## 改动

| 文件 | 说明 |
|------|------|
| `crates/clausura-core/src/skills.rs` | 新增：skill 加载、frontmatter 剥离、三种引用解析、prompt 合并 |
| `crates/clausura-core/src/config.rs` | YamlTaskConfig 新增 `skill_prompts` 字段，加载时解析合并 |
| `crates/clausura-core/src/lib.rs` | 注册 skills 模块 |
| `docs/skill-as-task.md` | 需求文档 |
| `examples/skills/*/SKILL.md` | 三个示例 skill（安全审查、i18n 检查、Vue 规范） |
| `examples/skill-based-review.yaml` | 使用 skill_prompts 的配置示例 |
| `README.md` | 新增 Using Skills 章节 |

## 使用方式

```yaml
# .clausura.yaml
task:
  skill_prompts:
    - ./skills/security-review.md     # 本地文件
    - team/vue-best-practices         # 命名引用（.clausura/skills/ 下查找）
  gating:                             # 用户自控
    - rule: sql-injection
      max_findings: 0
      action: fail
```

## 测试

- 17 个 skills 模块单元测试
- 5 个 config 集成测试
- 全部 261 个现有测试继续通过