### PR TITLE
docs: restructure user guide with dedicated topic files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,123 +1,46 @@
 # Clausura
 
-CI-native agent CLI tool for deterministic pipeline gating.
+CI-native agent CLI for deterministic pipeline gating.
 
 [![Build](https://img.shields.io/github/actions/workflow/status/liuyanghejerry/Clausura/main.yml?branch=main)](https://github.com/liuyanghejerry/Clausura/actions)
 [![Crates.io](https://img.shields.io/crates/v/clausura-cli)](https://crates.io/crates/clausura-cli)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## Overview
+## What is Clausura?
 
-Clausura is a platform-agnostic agent CLI tool built for CI/CD pipelines. It runs bounded LLM agent tasks against your codebase, extracts structured findings, evaluates them against deterministic gating rules, and exits with a clear pass/fail signal. No mid-process questions, no human in the loop.
+Clausura runs bounded LLM agent tasks against your codebase in CI/CD pipelines. It extracts structured findings, evaluates them against **deterministic gating rules**, and exits with a clear pass/fail signal — no mid-process questions, no human in the loop.
 
-**Key philosophy: closed-loop execution with deterministic gating.** The LLM finds issues. The rule engine decides if they matter. Your pipeline gets a binary answer.
+**The LLM finds issues. The rule engine decides if they matter. Your pipeline gets a binary answer.**
 
-**Use cases**
+## Design Philosophy
 
-- **Code review gating** -- flag violations in pull requests before merge
-- **Cross-repo consistency checks** -- enforce conventions across multiple repositories
-- **Smart gating** -- fail the pipeline only when findings exceed configured thresholds
-- **i18n extraction and translation** -- scan source files and validate locale coverage
-- **Architecture compliance** -- verify code structure against project conventions
+Clausura is built on three principles:
 
-## Installation
+1. **Closed-loop execution.** Every run is bounded by time, token budget, and iteration count. No interactive prompts. No indefinite loops. The agent either finishes cleanly or fails closed.
 
-### Shell script (Linux, macOS, WSL)
+2. **Deterministic gating.** Findings are evaluated by a pure counting engine — match by rule ID, filter by severity, compare against thresholds. No LLM in the decision path. No heuristics. Result is reproducible.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
-```
+3. **CI-native.** Auto-detects GitHub Actions, GitLab CI, Jenkins. Outputs SARIF v2.1.0. Exit codes 0/1/2/3 map directly to pipeline status. Designed to run unattended.
 
-The script detects your OS and architecture, downloads the latest release from GitHub, verifies the tarball against the release's `checksums.txt` (SHA256), and installs it to `/usr/local/bin` or `~/.local/bin`.
-
-### Cargo
-
-```bash
-cargo install clausura-cli
-```
-
-### Docker
-
-```bash
-docker pull ghcr.io/liuyanghejerry/clausura
-docker run --rm -v $(pwd):/workspace ghcr.io/liuyanghejerry/clausura run
-```
-
-### From source
-
-```bash
-git clone https://github.com/liuyanghejerry/Clausura.git
-cd clausura
-cargo build --release --package clausura-cli
-# binary at target/release/clausura
-```
-
-### Verify
-
-```bash
-clausura --version
-# clausura 1.0.0 (commit: abc1234, built: 2026-05-23)
-```
-
-## Supported LLM Providers
-
-Clausura supports three vendor categories out of the box:
-
-### 1. OpenAI-compatible
-
-Any LLM that exposes an OpenAI-compatible `/chat/completions` endpoint:
-
-| Shorthand | Base URL | Auth Header |
-|-----------|----------|-------------|
-| `openai` | `https://api.openai.com/v1` | `Authorization: Bearer` |
-| `deepseek` | `https://api.deepseek.com/v1` | `Authorization: Bearer` |
-| `groq` | `https://api.groq.com/openai/v1` | `Authorization: Bearer` |
-| `ollama` | `http://localhost:11434/v1` | `Authorization: Bearer` |
-| (custom) | User-defined | `Authorization: Bearer` |
-
-```yaml
-vendor: deepseek   # shorthand
-# or full config:
-vendor:
-  type: openai_compatible
-  base_url: "https://api.mistral.ai/v1"
-```
-
-### 2. Anthropic-compatible
-
-Claude models via Anthropic's native Messages API:
-
-| Shorthand | Base URL | Auth Header |
-|-----------|----------|-------------|
-| `anthropic` | `https://api.anthropic.com` | `x-api-key` |
-| `claude` | `https://api.anthropic.com` | `x-api-key` |
-
-```yaml
-vendor: anthropic
-model: claude-sonnet-4-20250514
-```
-
-Uses Anthropic's native Messages API (`/v1/messages`) with `x-api-key` auth and `anthropic-version: 2023-06-01`.
-
-### 3. Custom
-
-For enterprise-internal LLMs with non-standard authentication:
-
-```yaml
-vendor:
-  type: custom
-  base_url: "https://llm.internal.company.com/v1"
-  auth_header: "X-API-Key"
-  api_key_env: "INTERNAL_LLM_KEY"
-```
-
-Uses the OpenAI-compatible API format (`/chat/completions`) with configurable base URL and auth header. The `auth_header` defaults to `Authorization`; the `api_key_env` defaults to `CLAUSURA_API_KEY`.
+→ [Read more about the philosophy and architecture](docs/guide/overview.md)
 
 ## Quick Start
 
-### 1. Create a configuration file
+### 1. Install
 
-Create `.clausura.yaml` (or `.clausura.yml`) in your project root:
+```bash
+# macOS / Linux / WSL
+curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+
+# Or via Cargo
+cargo install clausura-cli
+```
+
+→ [All installation options](docs/guide/installation.md)
+
+### 2. Create a config
+
+Drop `.clausura.yaml` in your project root:
 
 ```yaml
 version: "1"
@@ -125,465 +48,107 @@ task:
   name: code-review
   model: gpt-4o
   vendor: openai
-  prompt_template: "Review the git diff and return findings as JSON."
+  prompt_template: |
+    Review the git diff for:
+    1. SQL injection — any string concatenation in SQL queries
+    2. Hardcoded credentials or secrets
+    3. Missing input validation
+
+    For each finding use:
+    - rule_id: "sql-injection" / "hardcoded-secret" / "missing-validation"
+    - severity: "error" or "warning"
   token_budget: 16000
-  timeout_secs: 120
-  ambiguity_policy: fail_closed
   gating:
-    - rule: no-critical
-      description: Block on any critical error
+    - rule: sql-injection
       min_severity: error
       max_findings: 0
       action: fail
-    - rule: warn-on-warnings
-      description: Warn on excessive warnings
-      min_severity: warning
-      max_findings: 10
-      action: warn
+    - rule: hardcoded-secret
+      min_severity: error
+      max_findings: 0
+      action: fail
 ```
 
-### 2. Set your API key
+### 3. Run
 
 ```bash
 export CLAUSURA_API_KEY=sk-...
-```
-
-The API key is never read from the YAML config file. It must come from this environment variable or the `--api-key` CLI flag.
-
-### 3. Run the task
-
-```bash
 clausura run
 ```
 
-### 4. Validate config without running
+That's it. Clausura calls the LLM, the LLM reviews your diff, the rule engine evaluates the findings, and you get a pass/fail exit code + SARIF report.
 
-```bash
-clausura run --validate-config
-clausura run --dry-run  # show the execution plan
-```
+## Documentation
 
-### Exit codes
+| Guide | Content |
+|-------|---------|
+| [Overview & Philosophy](docs/guide/overview.md) | How Clausura works, core concepts, design rationale |
+| [Installation](docs/guide/installation.md) | All install methods: script, Cargo, Docker, from source |
+| [Configuration Reference](docs/guide/configuration.md) | Every YAML field, CLI flag, and environment variable |
+| [LLM Providers](docs/guide/llm-providers.md) | Setting up OpenAI, Anthropic, DeepSeek, Ollama, custom endpoints |
+| [Gating Rules](docs/guide/gating.md) | How rules work, severity levels, designing effective gates |
+| [Skills](docs/guide/skills.md) | Reusing community review skills, composing multiple checks |
+| [Common Scenarios](docs/guide/scenarios.md) | Recipes: security review, i18n check, architecture compliance, Vue/React best practices |
+| [CI Integration](docs/guide/ci-integration.md) | GitHub Actions, GitLab CI, Jenkins, generic CI setup |
+| [Troubleshooting](docs/guide/troubleshooting.md) | Exit codes, common errors, debugging tips |
 
-| Code | Meaning       | Description                              |
-|------|---------------|------------------------------------------|
-| 0    | Pass          | All gating rules satisfied               |
-| 1    | Fail          | A rule with `action: fail` was violated  |
-| 2    | Error         | Runtime error (provider, timeout, etc.), or an incomplete agent run with `on_incomplete: fail` |
-| 3    | Config error  | Invalid configuration                    |
+## Use Cases
 
-## Using Skills
+- **Code review gating** — flag SQL injection, hardcoded secrets, missing validation before merge
+- **Cross-repo consistency** — enforce naming conventions, directory structure, dependency policies
+- **i18n completeness** — scan for hardcoded strings, missing translation keys, locale drift
+- **Architecture compliance** — verify layering, import direction, forbidden patterns
+- **Smart gating** — fail only when findings exceed configurable thresholds
 
-Clausura 1.2.0+ can reuse community skill files (Markdown) as review prompts. Skills answer "what and how to review", while gating rules answer "how many findings is too many" — the two are cleanly separated.
+→ [See all scenarios with complete configs](docs/guide/scenarios.md)
 
-### Skill file format
+## Exit Codes
 
-A skill is a Markdown file, optionally with YAML frontmatter:
+| Code | Meaning | When |
+|------|---------|------|
+| 0 | Pass | All gating rules satisfied |
+| 1 | Fail | A rule with `action: fail` was violated |
+| 2 | Error | Runtime error (timeout, provider failure, incomplete run) |
+| 3 | Config | Invalid configuration |
 
-```markdown
----
-name: security-review
-description: 检查 SQL 注入、XSS、硬编码密钥
----
+## Supported LLM Providers
 
-# 安全代码审查
+OpenAI · Anthropic (Claude) · DeepSeek · Groq · Ollama · Custom (any OpenAI-compatible endpoint)
 
-## SQL 注入
-- 任何字符串拼接构造的 SQL 查询
-- rule_id: `sql-injection`
-- severity: `error`
-```
-
-The frontmatter is stripped automatically; only the Markdown body is injected into the agent's system prompt.
-
-### Referencing skills
-
-```yaml
-task:
-  skill_prompts:
-    # Local file (relative to workspace or absolute)
-    - ./skills/security-review.md
-
-    # Named skill (looks in .clausura/skills/<name>/SKILL.md,
-    # then ~/.clausura/skills/<name>/SKILL.md)
-    - security-review
-    - team/vue-best-practices
-
-  # Optional: append your own extra instructions
-  prompt_template: |
-    另外检查：禁止 console.log
-
-  gating:
-    - rule: sql-injection
-      max_findings: 0
-      action: fail
-```
-
-### Installing community skills
-
-```bash
-# Project-level (only this repo)
-mkdir -p .clausura/skills/security-review
-cp ~/Downloads/security-review-SKILL.md .clausura/skills/security-review/SKILL.md
-
-# User-level (available to all your projects)
-mkdir -p ~/.clausura/skills/team/vue-check
-cp ~/Downloads/vue-check-SKILL.md ~/.clausura/skills/team/vue-check/SKILL.md
-```
-
-See [`examples/`](examples/) for ready-to-use skill files and a sample configuration.
-
-## Configuration Reference
-
-### YAML schema
-
-All fields for `.clausura.yaml`:
-
-```yaml
-version: "1"                         # Required. Schema version.
-task:
-  name: my-task                      # Required. Task name.
-
-  # LLM provider
-  model: gpt-4o                      # Required (or set CLAUSURA_MODEL).
-  vendor: openai                     # Shorthand (backward compatible).
-  # Or with full config:
-  vendor:
-    type: openai_compatible          # openai_compatible | anthropic_compatible | custom
-    base_url: "https://api.deepseek.com/v1"  # Optional. Override API endpoint.
-    auth_header: "X-API-Key"         # Optional. For custom auth (default: Authorization).
-    api_key_env: "MY_SECRET_KEY"     # Optional. Env var for API key (default: CLAUSURA_API_KEY).
-
-  # Prompt
-  prompt_template: "{{task_description}}"  # Default. The agent's system prompt.
-  skill_prompts: []                           # Optional. Reuse community skill files.
-                                               # Supports local paths, named references,
-                                               # and remote URLs.
-
-  # Limits
-  token_budget: 32000                # Default. Context-window budget: older messages are
-                                     # truncated (and archived) when the conversation
-                                     # approaches this size.
-  max_total_tokens: 200000           # Optional. Cap on cumulative billed tokens across all
-                                     # LLM calls in one run; the run stops (marked incomplete)
-                                     # when reached. Unset means no cap.
-  timeout_secs: 300                  # Default. Max wall-clock time in seconds.
-  max_iterations: 10                 # Default. Max agent loop iterations.
-  shell_timeout_secs: 120            # Default. Per-command timeout for shell_exec.
-
-  # Optional tool allowlist
-  tool_allowlist:                    # Restrict shell commands to these argv prefixes.
-    - git status                     # "git status" allows that subcommand tree only.
-    - cargo test                     # A bare name (e.g. "git") allows all subcommands.
-  shell_env_passthrough: []          # Default. Extra env vars forwarded to shell_exec
-                                     # commands (exact names only; secret-looking names
-                                     # like *_KEY / *_TOKEN are refused).
-
-  # Safety
-  ambiguity_policy: fail_closed      # "fail_closed" or "proceed_with_caution".
-  on_incomplete: fail                # "fail" (exit 2, default) or "pass" (continue with
-                                     # partial results, marked incomplete in logs and SARIF).
-                                     # Applies when the agent loop ends without a clean stop
-                                     # (context truncated or iteration limit reached).
-
-  # Gating rules
-  gating:                            # Optional. Evaluated in order.
-    - rule: no-critical
-      description: "No critical errors"
-      min_severity: error
-      max_findings: 0
-      action: fail
-```
-
-**Gating rule fields:**
-
-| Field         | Type   | Description                                      |
-|---------------|--------|--------------------------------------------------|
-| `rule`        | string | Rule ID. Findings with matching `rule_id` count. |
-| `description` | string | Human-readable description.                      |
-| `min_severity`| string | Minimum severity: `hint`, `info`, `warning`, `error`. |
-| `max_findings`| number | Maximum allowed findings at or above this severity. |
-| `action`      | string | `fail` (exit 1), `warn` (log only), `ignore` (skip). |
-
-### Environment variables
-
-| Variable                | Overrides            |
-|-------------------------|----------------------|
-| `CLAUSURA_API_KEY`      | API key (required)   |
-| `CLAUSURA_MODEL`        | `task.model`         |
-| `CLAUSURA_VENDOR`       | `task.vendor`        |
-| `CLAUSURA_AMBIGUITY_POLICY` | `task.ambiguity_policy` |
-| `CLAUSURA_ON_INCOMPLETE` | `task.on_incomplete` |
-| `CLAUSURA_TOKEN_BUDGET` | `task.token_budget`  |
-| `CLAUSURA_MAX_TOTAL_TOKENS` | `task.max_total_tokens` |
-| `CLAUSURA_TIMEOUT`      | `task.timeout_secs`  |
-| `CLAUSURA_SHELL_TIMEOUT` | `task.shell_timeout_secs` |
-| `CLAUSURA_MAX_ITERATIONS` | `task.max_iterations` |
-
-Config loading priority: YAML file < CLI flags < environment variables.
-
-### CLI flags
-
-```
-clausura run [OPTIONS]
-
-  -c, --config <PATH>       Config file path          [default: .clausura.yaml]
-      --model <MODEL>       Override LLM model
-      --vendor <VENDOR>     Override LLM vendor
-      --api-key <KEY>       API key
-      --token-budget <N>    Token budget override
-      --timeout <SECS>      Timeout override
-      --max-iterations <N>  Max agent loop iterations  [default: 10]
-      --shell-timeout <SECS>  Per-command shell_exec timeout  [default: 120]
-      --workspace <PATH>    Workspace root            [default: cwd]
-      --output <PATH>       SARIF output path          [default: clausura-output.sarif]
-      --resume              Resume from last checkpoint
-      --log-format <FMT>    Log format (json|pretty)   [default: json]
-      --dry-run             Validate config and print the execution plan
-      --validate-config     Validate config and exit
-```
-
-Checkpoint management:
-
-```
-clausura snapshot list [--thread <ID>] [--limit <N>]    List checkpoints (default: all threads, 10 max)
-clausura snapshot show [--thread <ID>]                  Show the latest checkpoint
-clausura snapshot show --id <UUID> [--thread <ID>]     Show a specific checkpoint
-clausura snapshot delete --thread <ID>                  Delete all checkpoints for a thread
-```
+→ [Full provider setup guide](docs/guide/llm-providers.md)
 
 ## CI Integration
 
-Clausura auto-detects your CI environment using well-known environment variables. It gathers repo, PR number, commit SHA, and branch context for template rendering and SARIF output.
-
-### Detection order
-
-1. `GITHUB_ACTIONS` -> GitHub Actions
-2. `GITLAB_CI` -> GitLab CI
-3. `JENKINS_URL` -> Jenkins
-4. `CI=true` or `CI=1` -> Generic CI
-5. Otherwise -> Local
-
-### GitHub Actions
-
-Use the composite action directly:
-
 ```yaml
+# GitHub Actions
 - uses: liuyanghejerry/Clausura@v1
   with:
     config: .clausura.yaml
     api_key: ${{ secrets.LLM_API_KEY }}
-    model: gpt-4o
-    vendor: openai
-    token_budget: 32000
-    timeout: 300
-    version: latest        # optional: release version to install (e.g. "1.0.8", default "latest")
 ```
 
-The action downloads the matching release binary for the runner's OS/arch (Linux and macOS, x86_64 and aarch64), verifies it against the release's SHA256 `checksums.txt`, and adds it to `PATH` before running.
+Also supports GitLab CI, Jenkins, and generic CI via environment variables.
 
-Or run via the binary:
-
-```yaml
-- name: Run Clausura
-  run: clausura run
-  env:
-    CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
-```
-
-### GitLab CI
-
-```yaml
-clausura-review:
-  image: ghcr.io/liuyanghejerry/clausura:latest
-  script:
-    - clausura run
-  variables:
-    CLAUSURA_API_KEY: $LLM_API_KEY
-    CLAUSURA_MODEL: "gpt-4o"
-```
-
-### Jenkins
-
-```groovy
-stage('Code Review') {
-    environment {
-        CLAUSURA_API_KEY = credentials('llm-api-key')
-    }
-    steps {
-        sh 'clausura run --model gpt-4o'
-    }
-}
-```
-
-### Generic CI
-
-Set `CI=true` and the relevant `CI_*` environment variables:
-
-```bash
-export CI=true
-export CLAUSURA_API_KEY=sk-...
-clausura run
-```
-
-Custom context variables for Generic CI: `CI_REPO`, `CI_PR_NUMBER`, `CI_COMMIT_SHA`, `CI_BRANCH`.
-
-### Supported platforms
-
-Clausura supports Linux and macOS. **Windows is not supported** (a documented non-goal, not "not yet") — on Windows, run Clausura under WSL2 or use the Docker image instead.
-
-## Architecture
-
-### Agent loop (reason -> act -> observe)
-
-Clausura runs a bounded agent loop of up to `max_iterations` iterations (default 10, configurable via YAML, `--max-iterations`, or `CLAUSURA_MAX_ITERATIONS`). Each iteration:
-
-1. Sends the conversation (system prompt + accumulated messages) to the LLM
-2. If the LLM calls a tool, executes it and feeds the result back
-3. If the LLM responds with structured findings and signals `stop`, the loop ends
-4. The loop also ends on token budget exhaustion, timeout, or content filter
-
-The system prompt is built from `prompt_template` plus available tool definitions. The LLM is instructed to respond in JSON with a `findings` array.
-
-### Context truncation and archiving
-
-When the conversation exceeds the configured `token_budget`, Clausura automatically truncates older messages to stay within limits. Dropped messages are not silently discarded — they are archived to `.clausura/archives/context-dump-{task_id}-{seq}.log` inside the workspace as JSON lines. A hint message is injected into the conversation telling the LLM where to find the archived context, so it can retrieve earlier findings via the `read_file` tool if needed.
-
-On successful completion (exit code 0), archive files are automatically cleaned up. On failure (exit code 1-3), they are preserved for debugging and audit.
-
-### Incomplete runs fail closed
-
-If the agent loop ends without a clean stop — the context could not be truncated further, the model hit a length limit, the `max_total_tokens` cap was reached, or `max_iterations` was exhausted — the extracted findings may be partial. By default (`on_incomplete: fail`) Clausura fails closed: the run exits with code 2 and a clear error message, so an incomplete review can never silently pass a `max_findings: 0` gate. With `on_incomplete: pass`, the previous behavior is kept (gating rules evaluate the partial findings), but a warning is logged and the SARIF output is annotated with `"properties": {"incomplete": true}` on the run.
-
-### Deterministic rule engine
-
-Findings from the agent are evaluated by the rule engine using pure counting:
-
-- Match findings to rules by `rule_id`
-- Filter by severity threshold
-- Count violations above `max_findings`
-- Apply action: `fail` exits 1, `warn` logs, `ignore` skips
-
-No LLM calls, no heuristics. Just deterministic logic your pipeline can trust.
-
-### LLM provider abstraction
-
-Three vendor categories: OpenAI-compatible (works with OpenAI, DeepSeek, Groq, Ollama, vLLM, Mistral), Anthropic-compatible (native Claude Messages API), and Custom (configurable enterprise endpoints). Factory function `create_provider()` dispatches on vendor type.
-
-Each LLM request has its own per-request timeout (default 120s), independent of the task's overall wall-clock `timeout_secs`. Failed requests are retried with exponential backoff (up to 3 retries by default) on HTTP 429, 5xx, and network errors — the `Retry-After` response header is honored when present. Other 4xx responses (e.g. 401, 400) fail immediately without retrying.
-
-### Tool sandboxing
-
-Five built-in tools:
-
-| Tool          | Description                                      | Restrictions                           |
-|---------------|--------------------------------------------------|----------------------------------------|
-| `read_file`   | Read a file relative to workspace root, with optional `offset`/`limit` for line-range reading | Blocks absolute paths, `..` traversal, symlink escapes |
-| `list_files`  | List directory contents, with recursive depth, glob filtering, and optional file sizes | Sandboxed to workspace; skips `.clausura/` |
-| `grep`        | Search text patterns across files with literal or regex mode, extension filtering, and binary-skip | Auto-excludes `.git`, `target`, `.clausura`, `node_modules` |
-| `git_diff`    | Run `git diff` with optional base ref or staged  | Operates inside workspace only         |
-| `shell_exec`  | Execute an allowed command (argv form, no shell) | Restricted to `tool_allowlist` argv prefixes; dangerous flags denied; scrubbed env |
-
-The `shell_exec` tool is locked by default (empty allowlist = no commands). Explicitly list allowed commands to enable it. It takes an `argv` array (e.g. `{"argv": ["git", "status"]}`) and executes `argv[0]` directly **without a shell** — shell metacharacters like `;`, `|`, `$()` or `>` are passed through as literal arguments and have no effect, so they cannot be used to bypass the allowlist. Commands run with `current_dir` set to the workspace root, but allowed commands can access paths outside the workspace via arguments.
-
-**Allowlist prefix rules.** Each `tool_allowlist` entry is an argv prefix split on whitespace: an invocation is allowed when its leading tokens equal a rule's tokens. `"git status"` allows `["git", "status"]` and `["git", "status", "--short"]`, but not `["git", "log"]`. A bare program name (e.g. `"git"`) is a length-1 prefix and allows all subcommands of that program (backward compatible). The rule's first token also matches by basename, so `["/usr/bin/git", "status"]` satisfies a `"git status"` rule.
-
-**Dangerous-flag denylist.** On top of the allowlist, known-risky flags are rejected regardless of position (scanning stops at the first `--`, whose following tokens are operands): `git -c`, `git --exec-path`, `git --git-dir`, `git --work-tree`, `tar --checkpoint-action`, `tar --to-command`. Both exact and attached forms are caught (`-c foo`, `-cfoo`, `--git-dir=/x`).
-
-**Environment scrubbing.** Commands run with a minimal, deny-by-default environment: a fixed `PATH` (`/usr/local/bin:/usr/bin:/bin`, plus `$HOME/.cargo/bin` if it exists), `HOME`/`TERM`/`LANG`/`TMPDIR`/`CI` forwarded when present, and safety overrides (`GIT_PAGER=cat`, `PAGER=cat`, `GIT_CONFIG_NOSYSTEM=1`, `GIT_TERMINAL_PROMPT=0`, `GIT_EDITOR=:`, `EDITOR=:`). Everything else — including `CLAUSURA_API_KEY`, `LD_PRELOAD`, `GIT_SSH_COMMAND`, `SSH_AUTH_SOCK`, `BASH_ENV` — is dropped. `shell_env_passthrough` can forward additional variables by exact name; `CLAUSURA_API_KEY` and names ending in `_KEY`, `_TOKEN`, `_SECRET` or `_PASSWORD` are refused with a warning.
-
-**Per-command timeout.** Each command is killed after `shell_timeout_secs` (default 120; override with `--shell-timeout` or `CLAUSURA_SHELL_TIMEOUT`) and the tool returns a `Command timed out after Ns and was killed` result.
-
-Tool outputs are truncated at 32 KB or 1000 lines (whichever comes first) to stay within token budgets; a `[output truncated ...]` marker is appended when this happens — narrow the query or use `read_file`'s `offset`/`limit` to page through large outputs.
-
-### Memory snapshots (SQLite checkpoints)
-
-On every run, the agent's message history is serialized (MessagePack) and saved to `~/.clausura/checkpoints.db`. You can resume a truncated or interrupted run with `--resume`. Snapshots include a thread ID, version number, and truncation flag.
-
-Note that checkpoints live under the user's home directory (`~/.clausura/`), not the workspace. In ephemeral CI containers without a persistent home/volume, checkpoints do not survive between runs, so `--resume` has nothing to restore from.
-
-Use `clausura snapshot list` and `clausura snapshot show` to inspect saved state.
-
-### SARIF output
-
-Findings are written to `clausura-output.sarif` (or the path from `--output`) in SARIF v2.1.0 format. This integrates with GitHub Advanced Security, CodeQL, and other SARIF-compatible tools.
+→ [All CI platforms](docs/guide/ci-integration.md)
 
 ## Development
 
-### Build
-
 ```bash
-# Debug build
-cargo build
-
-# Release build (recommended for production)
+# Build
 cargo build --release --package clausura-cli
-```
 
-### Run tests
-
-```bash
+# Run tests
 cargo test --workspace
+
+# Format (pre-commit hook enforces this)
+cargo fmt --all
+
+# Lint
+cargo clippy --workspace -- -D warnings
 ```
 
-### Pre-commit hook
-
-A `cargo fmt` pre-commit hook is included. Enable it after cloning:
-
-```bash
-git config core.hooksPath .githooks
-```
-
-Commits with misformatted Rust code will be rejected. Run `cargo fmt --all` to auto-fix.
-
-### Project structure
-
-```
-clausura/
-  Cargo.toml                    # Workspace root
-  crates/
-    clausura-core/              # Core library
-      src/
-        lib.rs                  # Crate root (module re-exports)
-        agent.rs                # Agent loop (reason -> act -> observe)
-        build_info.rs           # Version and commit metadata
-        checkpoint.rs           # SQLite checkpoint store
-        ci.rs                   # CI environment detection
-        config.rs               # Layered config loader (YAML + CLI + env)
-        context.rs              # Token budget tracking, context truncation, and archiving
-        executor.rs             # Task lifecycle orchestrator
-        logging.rs              # Structured logging (JSON or pretty)
-        provider.rs             # LLM provider (OpenAI/Anthropic/Custom + factory)
-        rules.rs                # Deterministic rule engine for gating
-        sarif.rs                # SARIF v2.1.0 output formatter
-        snapshot.rs             # Snapshot manager (save/restore)
-        tools.rs                # Tool sandbox (read_file, git_diff, shell_exec, list_files, grep)
-        types.rs                # Core type definitions
-    clausura-cli/               # CLI binary
-      src/
-        main.rs                 # CLI entry point (clap)
-        commands/
-          mod.rs                # Commands module
-          run.rs                # clausura run command
-          snapshot.rs           # clausura snapshot command
-  action.yml                    # GitHub Action definition
-  Dockerfile                    # Multi-stage Docker build (alpine, musl)
-  install.sh                    # Release install script
-```
-
-### Dependencies
-
-- **CLI**: clap (arg parsing), colored + atty (terminal output)
-- **Core**: tokio (async), serde/serde_json/serde_yaml (serialization), reqwest (HTTP), tiktoken-rs (token counting), rusqlite (checkpoints), rmp-serde (binary serialization), regex-lite (grep pattern matching)
-- **LLM**: OpenAI-compatible chat completions API (works with OpenAI, DeepSeek, Groq, Ollama, etc.)
+See [RELEASE.md](RELEASE.md) for release procedures.
 
 ## License
 
 MIT. See [LICENSE](LICENSE).
-
-## Links
-
-- [GitHub](https://github.com/liuyanghejerry/Clausura)
-- [Issues](https://github.com/liuyanghejerry/Clausura/issues)
-- [Releases](https://github.com/liuyanghejerry/Clausura/releases)
-- [Docker images](https://github.com/liuyanghejerry/Clausura/pkgs/container/clausura)

--- a/docs/guide/ci-integration.md
+++ b/docs/guide/ci-integration.md
@@ -1,0 +1,290 @@
+# CI Integration
+
+Clausura auto-detects your CI environment and integrates with GitHub Actions, GitLab CI, Jenkins, and generic CI systems.
+
+## How Detection Works
+
+Clausura checks well-known environment variables in this order:
+
+1. `GITHUB_ACTIONS` → GitHub Actions
+2. `GITLAB_CI` → GitLab CI
+3. `JENKINS_URL` → Jenkins
+4. `CI=true` or `CI=1` → Generic CI
+5. None of the above → Local (no CI context)
+
+When detected, Clausura gathers repository, PR number, commit SHA, and branch context. These are available as template variables in `prompt_template` and embedded in SARIF output.
+
+## GitHub Actions
+
+### Option A: Composite Action (Simplest)
+
+```yaml
+name: Code Review
+on: [pull_request]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2          # Required for git diff
+
+      - uses: liuyanghejerry/Clausura@v1
+        with:
+          config: .clausura.yaml
+          api_key: ${{ secrets.LLM_API_KEY }}
+          model: gpt-4o           # Optional overrides
+          vendor: openai
+          token_budget: 32000
+          timeout: 300
+          version: latest         # Or pin: "1.2.1"
+```
+
+The composite action:
+1. Downloads the matching release binary for the runner's OS/arch
+2. Verifies the binary against the release's SHA256 checksums
+3. Runs `clausura run` with your config
+
+### Option B: Direct Binary
+
+```yaml
+name: Code Review
+on: [pull_request]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install Clausura
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+
+      - name: Run Clausura
+        run: clausura run
+        env:
+          CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: clausura-output.sarif
+```
+
+Uploading SARIF to GitHub integrates findings directly into the PR diff view and the Security tab.
+
+### Option C: Docker
+
+```yaml
+- name: Run Clausura
+  run: |
+    docker run --rm \
+      -v ${{ github.workspace }}:/workspace \
+      -e CLAUSURA_API_KEY=${{ secrets.LLM_API_KEY }} \
+      ghcr.io/liuyanghejerry/clausura:latest run
+```
+
+### Branch Protection
+
+After setting up the workflow, configure branch protection rules to require the `review` job before merging:
+
+1. Go to **Settings → Branches → Branch protection rules**
+2. Add a rule for your protected branch (e.g., `main`)
+3. Check **Require status checks to pass before merging**
+4. Search for and select the `review` job
+5. Save
+
+Now PRs can't be merged unless Clausura passes.
+
+## GitLab CI
+
+```yaml
+clausura-review:
+  image: ghcr.io/liuyanghejerry/clausura:latest
+  stage: review
+  script:
+    - clausura run
+  variables:
+    CLAUSURA_API_KEY: $LLM_API_KEY
+    CLAUSURA_MODEL: "gpt-4o"
+  artifacts:
+    when: always
+    paths:
+      - clausura-output.sarif
+    expire_in: 30 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+Or using the install script:
+
+```yaml
+clausura-review:
+  stage: review
+  script:
+    - curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+    - clausura run
+  variables:
+    CLAUSURA_API_KEY: $LLM_API_KEY
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+## Jenkins
+
+### Pipeline (Declarative)
+
+```groovy
+pipeline {
+    agent any
+
+    environment {
+        CLAUSURA_API_KEY = credentials('llm-api-key')
+    }
+
+    stages {
+        stage('Code Review') {
+            steps {
+                sh '''
+                    curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+                    clausura run --model gpt-4o
+                '''
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts artifacts: 'clausura-output.sarif', fingerprint: true
+        }
+    }
+}
+```
+
+### GitHub Branch Source / Multibranch Pipeline
+
+Clausura auto-detects the PR context from Jenkins environment variables when using the GitHub Branch Source plugin.
+
+## Generic CI
+
+Any CI system that sets `CI=true` is detected. Set these environment variables for context information:
+
+```bash
+export CI=true
+export CI_REPO="owner/repo"
+export CI_PR_NUMBER="42"
+export CI_COMMIT_SHA="abc123def456"
+export CI_BRANCH="feature/new-login"
+
+export CLAUSURA_API_KEY=sk-...
+clausura run
+```
+
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `CI` | Must be `true` or `1` for Clausura to detect CI mode | Yes |
+| `CI_REPO` | Repository name (appears in SARIF) | No |
+| `CI_PR_NUMBER` | Pull request number (appears in SARIF) | No |
+| `CI_COMMIT_SHA` | Current commit SHA (appears in SARIF) | No |
+| `CI_BRANCH` | Current branch name (appears in SARIF) | No |
+
+## Template Variables in CI
+
+When CI context is detected, these template variables are available in `prompt_template`:
+
+```yaml
+prompt_template: |
+  Repository: {{repo}}
+  Branch: {{branch}}
+  Commit: {{commit_sha}}
+  PR: {{pr_number}}
+  Platform: {{ci_platform}}
+
+  Review the diff for security issues...
+```
+
+| Variable | Source |
+|----------|--------|
+| `{{repo}}` | Repo name from CI context |
+| `{{branch}}` | Current branch |
+| `{{commit_sha}}` | Current commit |
+| `{{pr_number}}` | PR number |
+| `{{ci_platform}}` | `github_actions`, `gitlab_ci`, `jenkins`, `generic_ci`, or `local` |
+
+## SARIF Upload
+
+Clausura always writes `clausura-output.sarif`. In CI, upload it to your platform's security dashboard:
+
+### GitHub Advanced Security
+
+```yaml
+- uses: github/codeql-action/upload-sarif@v3
+  if: always()
+  with:
+    sarif_file: clausura-output.sarif
+```
+
+### GitLab
+
+SARIF files can be uploaded as pipeline artifacts and viewed with GitLab's SARIF support (GitLab Ultimate).
+
+### Generic
+
+SARIF is an open standard. View it with any SARIF viewer (VS Code extension, standalone tools) or parse it as JSON for custom dashboards.
+
+## Parallel Jobs
+
+For multi-dimensional review, run separate Clausura tasks in parallel CI jobs:
+
+```yaml
+# GitHub Actions
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 2 }
+      - uses: liuyanghejerry/Clausura@v1
+        with:
+          config: .clausura/security.yaml
+          api_key: ${{ secrets.LLM_API_KEY }}
+
+  i18n:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 2 }
+      - uses: liuyanghejerry/Clausura@v1
+        with:
+          config: .clausura/i18n.yaml
+          api_key: ${{ secrets.LLM_API_KEY }}
+```
+
+Each job independently passes or fails. Use branch protection rules to require all review jobs.
+
+## Checkpoint Persistence
+
+Checkpoints are stored in `~/.clausura/checkpoints.db` (user home directory). In ephemeral CI containers without a persistent home volume, checkpoints do not survive between runs — `--resume` will have nothing to restore from.
+
+For persistent checkpointing in CI, mount a volume at `$HOME/.clausura/`.
+
+## Best Practices
+
+1. **`fetch-depth: 2`** — Clausura's `git_diff` tool needs the previous commit for comparison. Always set `fetch-depth: 2` (or higher) in your checkout step.
+
+2. **Use secrets for API keys** — Never commit API keys. Use your CI's secrets manager (`${{ secrets.LLM_API_KEY }}`, GitLab CI/CD variables, Jenkins credentials).
+
+3. **Upload SARIF on failure** — Use `if: always()` so SARIF is available for debugging even when the pipeline fails.
+
+4. **Set realistic timeouts** — The CI job timeout should exceed `task.timeout_secs` by a comfortable margin (add 60s for installation and SARIF writing).
+
+5. **Run on PRs, not pushes to main** — Clausura compares against the base branch; running on pushes to `main` without a PR context may not produce meaningful diffs.
+
+## Next
+
+→ [Troubleshooting common issues](troubleshooting.md)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,322 @@
+# Configuration Reference
+
+Clausura is configured via `.clausura.yaml` (or `.clausura.yml`) in your project root, with CLI flags and environment variables providing overrides.
+
+## Loading Priority
+
+Configuration is loaded in three layers, with later layers overriding earlier ones:
+
+```
+YAML file  <  CLI flags  <  Environment variables
+```
+
+For example, `task.model` from the YAML file is overridden by `--model` on the CLI, which is in turn overridden by `CLAUSURA_MODEL` in the environment.
+
+## Complete Schema
+
+```yaml
+version: "1"                         # Required. Schema version (currently "1").
+
+task:
+  # ── Identity ──────────────────────────────────────
+  name: my-task                      # Required. Task name, used in logs and SARIF.
+
+  # ── LLM Provider ──────────────────────────────────
+  model: gpt-4o                      # Required (or set CLAUSURA_MODEL).
+  vendor: openai                     # Shorthand: openai, anthropic, deepseek, groq, ollama.
+  # Or full config:
+  vendor:
+    type: openai_compatible          # openai_compatible | anthropic_compatible | custom
+    base_url: "https://api.deepseek.com/v1"  # Optional. Override API endpoint.
+    auth_header: "X-API-Key"         # Optional. Custom auth header (default: Authorization).
+    api_key_env: "MY_SECRET_KEY"     # Optional. Env var for API key (default: CLAUSURA_API_KEY).
+
+  # ── Prompt ────────────────────────────────────────
+  prompt_template: |                 # The agent's system prompt. Can use {{template_vars}}.
+    Review the diff for security issues.
+  skill_prompts: []                  # Optional. Reuse community skill files (local paths
+                                     # or named references).
+
+  # ── Limits ────────────────────────────────────────
+  token_budget: 32000                # Context-window budget. Drives message truncation.
+  max_total_tokens: 200000           # Optional. Cumulative token cap across all LLM calls.
+                                     # Unset = no cap. When reached, run stops (incomplete).
+  timeout_secs: 300                  # Max wall-clock time for the entire run.
+  max_iterations: 10                 # Max agent loop iterations (tool calls + LLM turns).
+  shell_timeout_secs: 120            # Per-command timeout for shell_exec.
+
+  # ── Shell Sandbox ─────────────────────────────────
+  tool_allowlist:                    # Optional. Allowed shell_exec commands as argv prefixes.
+    - git status                     # "git status" allows that subcommand tree only.
+    - cargo test                     # Bare name (e.g. "git") allows all subcommands.
+  shell_env_passthrough: []          # Optional. Extra env vars forwarded to shell_exec.
+
+  # ── Safety ────────────────────────────────────────
+  ambiguity_policy: fail_closed      # "fail_closed" or "proceed_with_caution".
+  on_incomplete: fail                # "fail" (exit 2) or "pass" (continue with partial results).
+
+  # ── Gating Rules ──────────────────────────────────
+  gating:                            # Optional. Evaluated in declaration order.
+    - rule: sql-injection            # Rule ID. Matches findings by rule_id field.
+      description: "No SQL injection"
+      min_severity: error            # hint | info | warning | error
+      max_findings: 0                # Maximum allowed findings at this severity or above.
+      action: fail                   # fail | warn | ignore
+    - rule: hardcoded-secret
+      description: "No hardcoded credentials"
+      min_severity: error
+      max_findings: 0
+      action: fail
+    - rule: missing-validation
+      description: "Warning on excessive missing validation"
+      min_severity: warning
+      max_findings: 5
+      action: warn
+```
+
+## Field Reference
+
+### `task.name`
+
+**Required.** A human-readable name for this task. Appears in log output and the SARIF report.
+
+```yaml
+task:
+  name: security-review
+```
+
+### `task.model`
+
+**Required** (or set `CLAUSURA_MODEL`). The LLM model identifier.
+
+```yaml
+task:
+  model: gpt-4o
+```
+
+### `task.vendor`
+
+**Required** (or set `CLAUSURA_VENDOR`). Specifies which LLM provider to use.
+
+Short form:
+
+```yaml
+vendor: openai      # Maps to built-in preset
+vendor: anthropic
+vendor: deepseek
+vendor: groq
+vendor: ollama
+```
+
+Full form:
+
+```yaml
+vendor:
+  type: custom
+  base_url: "https://llm.internal/v1"
+  auth_header: "X-API-Key"
+  api_key_env: "INTERNAL_LLM_KEY"
+```
+
+→ [Complete LLM provider guide](llm-providers.md)
+
+### `task.prompt_template`
+
+The system prompt sent to the LLM. This is where you define **what** the agent should look for.
+
+```yaml
+task:
+  prompt_template: |
+    Review the git diff for the following security issues:
+
+    1. SQL injection — any string concatenation in SQL queries
+       rule_id: "sql-injection", severity: "error"
+    2. Hardcoded credentials — API keys, passwords, tokens in source
+       rule_id: "hardcoded-secret", severity: "error"
+    3. Missing input validation — API endpoints without type/range checks
+       rule_id: "missing-validation", severity: "warning"
+
+    Output your findings as a JSON array of objects with rule_id, severity, message, and evidence fields.
+```
+
+**Template variables.** Clausura injects CI context as template variables:
+
+| Variable | Value |
+|----------|-------|
+| `{{task_name}}` | The task name |
+| `{{repo}}` | Repository name (from CI detection) |
+| `{{branch}}` | Current branch |
+| `{{commit_sha}}` | Current commit SHA |
+| `{{pr_number}}` | Pull request number |
+| `{{ci_platform}}` | Detected CI platform (github_actions, gitlab_ci, etc.) |
+
+### `task.skill_prompts`
+
+References to reusable skill files. Skills are appended to the system prompt before `prompt_template`.
+
+```yaml
+task:
+  skill_prompts:
+    - ./skills/security-review.md      # Local file (relative or absolute)
+    - team/vue-best-practices          # Named reference (looked up in .clausura/skills/ and ~/.clausura/skills/)
+    - community/i18n-check
+  prompt_template: |                   # Your additions go after skills
+    Also check: no console.log in production code.
+```
+
+→ [Skills guide](skills.md)
+
+### `task.token_budget`
+
+**Default: 32000.** The context-window budget. When the conversation (system prompt + message history) approaches this size, Clausura truncates older messages to make room. Truncated messages are archived to `.clausura/archives/` inside the workspace. A hint is injected into the conversation telling the agent where to find the archive.
+
+This is separate from `max_total_tokens`:
+
+- `token_budget` — how large the **active conversation** can be
+- `max_total_tokens` — total **billed tokens** across all LLM calls in the run
+
+### `task.max_total_tokens`
+
+**Default: None (no cap).** Hard limit on cumulative billed tokens. When total usage across all LLM calls reaches this value, the agent loop stops and the run is marked incomplete. Use this for cost control — it has no effect on context truncation.
+
+```yaml
+task:
+  token_budget: 32000        # context window budget
+  max_total_tokens: 200000   # stop after $X worth of API calls
+```
+
+### `task.timeout_secs`
+
+**Default: 300.** Maximum wall-clock time for the entire run. If exceeded, the run terminates with exit code 2 (error).
+
+```yaml
+task:
+  timeout_secs: 120   # Fail after 2 minutes
+```
+
+### `task.max_iterations`
+
+**Default: 10.** Maximum number of agent loop iterations. Each iteration is one LLM call + tool execution round. After this many turns, the loop stops. If the agent hasn't produced a clean `Stop` response, the run is marked incomplete.
+
+Typical runs complete in 1–3 iterations. Setting this too high risks long-running loops; too low risks incomplete reviews.
+
+### `task.shell_timeout_secs`
+
+**Default: 120.** Per-command timeout for `shell_exec`. Each individual command is killed after this duration.
+
+### `task.tool_allowlist`
+
+**Default: `[]` (empty = shell_exec disabled).** Commands the agent is allowed to execute via `shell_exec`. Each entry is an argv prefix:
+
+```yaml
+task:
+  tool_allowlist:
+    - git status      # Allows: ["git", "status"], ["git", "status", "--short"]
+                      # Denies: ["git", "log"], ["git", "push"]
+    - cargo test      # Allows: ["cargo", "test"], ["cargo", "test", "--lib"]
+                      # Denies: ["cargo", "build"]
+    - git             # Allows: ALL git subcommands (bare name = length-1 prefix)
+```
+
+Matching rules:
+- Tokens are compared literally. `"git status"` matches `["git", "status"]`.
+- The first token also matches by basename: `["/usr/bin/git", "status"]` matches a `"git status"` rule.
+- Known-dangerous flags (`git -c`, `tar --checkpoint-action`, etc.) are rejected regardless of the allowlist.
+
+→ See the [allowlist hardening research](../allowlist-hardening.md) for the full threat model.
+
+### `task.shell_env_passthrough`
+
+**Default: `[]`.** Extra environment variables forwarded to `shell_exec` commands. By default, commands run with a minimal environment (only `PATH`, `HOME`, `TERM`, `LANG`, `TMPDIR`, `CI`). Secret-shaped names (`*_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`) are refused even if listed.
+
+```yaml
+task:
+  shell_env_passthrough:
+    - HTTP_PROXY       # OK: forwarded
+    - NODE_ENV         # OK: forwarded
+    # - AWS_SECRET_KEY # REJECTED: secret-shaped name
+```
+
+### `task.ambiguity_policy`
+
+**Default: `fail_closed`.** Controls behavior when the agent's output is ambiguous or malformed.
+
+| Value | Behavior |
+|-------|----------|
+| `fail_closed` | Fail on ambiguity. Invalid JSON findings → error. Schema mismatch → error. |
+| `proceed_with_caution` | Try best-effort extraction. Log a warning but continue. |
+
+`fail_closed` is the safe default for CI — an unparseable answer should block the pipeline, not pass silently.
+
+### `task.on_incomplete`
+
+**Default: `fail`.** Controls what happens when the agent loop ends without a clean `Stop` (context exhausted, iteration limit reached, or `max_total_tokens` hit):
+
+| Value | Behavior |
+|-------|----------|
+| `fail` | Exit code 2 (error). An incomplete review with zero findings must not pass gates. |
+| `pass` | Evaluate what we have. Warning is logged. SARIF output is annotated with `incomplete: true`. |
+
+### `task.gating`
+
+An array of gating rules, evaluated in order. Each rule:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rule` | string | Rule ID. Matches `finding.rule_id`. |
+| `description` | string | Human-readable description. |
+| `min_severity` | string | Severity threshold: `hint`, `info`, `warning`, `error`. |
+| `max_findings` | number | Maximum allowed findings at or above this severity. |
+| `action` | string | What to do when exceeded: `fail` (exit 1), `warn` (log only), `ignore` (skip). |
+
+→ [Gating rules deep dive](gating.md)
+
+## CLI Flags
+
+```
+clausura run [OPTIONS]
+
+  -c, --config <PATH>       Config file path              [default: .clausura.yaml]
+      --model <MODEL>       Override LLM model
+      --vendor <VENDOR>     Override LLM vendor
+      --api-key <KEY>       API key
+      --token-budget <N>    Token budget override
+      --timeout <SECS>      Timeout override
+      --max-iterations <N>  Max agent loop iterations      [default: 10]
+      --shell-timeout <SECS> Per-command shell_exec timeout [default: 120]
+      --workspace <PATH>    Workspace root                 [default: cwd]
+      --output <PATH>       SARIF output path              [default: clausura-output.sarif]
+      --resume              Resume from last checkpoint
+      --log-format <FMT>    Log format (json|pretty)        [default: json]
+      --dry-run             Validate config and print execution plan
+      --validate-config     Validate config and exit
+```
+
+### Snapshot management
+
+```
+clausura snapshot list [--thread <ID>] [--limit <N>]     List checkpoints
+clausura snapshot show [--thread <ID>]                   Show latest checkpoint
+clausura snapshot show --id <UUID> [--thread <ID>]      Show specific checkpoint
+clausura snapshot delete --thread <ID>                   Delete all checkpoints for a thread
+```
+
+## Environment Variables
+
+| Variable | Overrides | Example |
+|----------|-----------|---------|
+| `CLAUSURA_API_KEY` | API key (required) | `sk-...` |
+| `CLAUSURA_MODEL` | `task.model` | `gpt-4o` |
+| `CLAUSURA_VENDOR` | `task.vendor` | `openai` |
+| `CLAUSURA_AMBIGUITY_POLICY` | `task.ambiguity_policy` | `fail_closed` |
+| `CLAUSURA_ON_INCOMPLETE` | `task.on_incomplete` | `fail` |
+| `CLAUSURA_TOKEN_BUDGET` | `task.token_budget` | `32000` |
+| `CLAUSURA_MAX_TOTAL_TOKENS` | `task.max_total_tokens` | `200000` |
+| `CLAUSURA_TIMEOUT` | `task.timeout_secs` | `300` |
+| `CLAUSURA_SHELL_TIMEOUT` | `task.shell_timeout_secs` | `120` |
+| `CLAUSURA_MAX_ITERATIONS` | `task.max_iterations` | `10` |
+
+## Next
+
+→ [Design your gating rules](gating.md)
+→ [See common scenarios](scenarios.md)

--- a/docs/guide/gating.md
+++ b/docs/guide/gating.md
@@ -1,0 +1,206 @@
+# Gating Rules
+
+Gating rules are the deterministic pass/fail criteria that make Clausura trustworthy in CI. After the LLM produces findings, the rule engine evaluates them with pure counting logic — no AI, no heuristics, no ambiguity.
+
+## How Rules Work
+
+Each rule defines a threshold: "for findings matching this ID at this severity or above, allow at most N occurrences." When the count exceeds the threshold, the rule's action is triggered.
+
+```
+For each gating rule:
+  1. Collect findings where finding.rule_id == rule.rule
+  2. Filter to those where finding.severity >= rule.min_severity
+  3. Count remaining → N
+  4. If N > rule.max_findings → apply rule.action
+```
+
+## Rule Schema
+
+```yaml
+gating:
+  - rule: sql-injection            # Rule ID (matches finding.rule_id)
+    description: "No SQL injection" # Human-readable description
+    min_severity: error            # Severity threshold: hint | info | warning | error
+    max_findings: 0                # Maximum allowed count
+    action: fail                   # fail | warn | ignore
+```
+
+### `rule`
+
+The rule ID. This must match the `rule_id` in the LLM's findings output. If no findings have a matching `rule_id`, the count is 0 (rule passes).
+
+### `min_severity`
+
+The minimum severity level to count. Severity levels, from lowest to highest:
+
+| Level | Typical use |
+|-------|-------------|
+| `hint` | Style suggestions, minor improvements |
+| `info` | Informational notes, things to be aware of |
+| `warning` | Best practice violations, potential issues |
+| `error` | Definite problems that should block merge |
+
+A rule with `min_severity: warning` counts findings at `warning` and `error` levels, but not `info` or `hint`.
+
+### `max_findings`
+
+The maximum number of matching findings allowed. `0` means "zero tolerance" — any finding with this rule_id at this severity or above triggers the action.
+
+### `action`
+
+| Action | Exit code | Effect |
+|--------|-----------|--------|
+| `fail` | 1 | Pipeline fails. Block merge. |
+| `warn` | 0 | Warning printed to log. Pipeline passes. |
+| `ignore` | 0 | No effect. Useful for temporarily disabling a rule. |
+
+## Designing Effective Rules
+
+### Pattern 1: Zero-Tolerance Critical Issues
+
+For security vulnerabilities and other issues you never want to ship:
+
+```yaml
+gating:
+  - rule: sql-injection
+    min_severity: error
+    max_findings: 0
+    action: fail
+  - rule: hardcoded-secret
+    min_severity: error
+    max_findings: 0
+    action: fail
+  - rule: xss
+    min_severity: error
+    max_findings: 0
+    action: fail
+```
+
+### Pattern 2: Threshold-Based Warnings
+
+For issues that are concerning in aggregate but acceptable in small numbers:
+
+```yaml
+gating:
+  - rule: missing-validation
+    min_severity: warning
+    max_findings: 3
+    action: warn
+  - rule: complex-function
+    min_severity: warning
+    max_findings: 5
+    action: warn
+```
+
+### Pattern 3: Fail on Excessive Warnings
+
+Warn on a few, fail when it gets out of hand:
+
+```yaml
+gating:
+  - rule: no-as-any
+    min_severity: warning
+    max_findings: 2
+    action: warn
+  - rule: no-as-any
+    min_severity: warning
+    max_findings: 10
+    action: fail
+```
+
+### Pattern 4: Gradual Adoption
+
+When introducing Clausura to an existing codebase, start permissive and tighten over time:
+
+```yaml
+# Week 1: Log everything, fail nothing
+gating:
+  - rule: sql-injection
+    min_severity: error
+    max_findings: 0
+    action: warn
+
+# Week 3: After fixing existing issues
+gating:
+  - rule: sql-injection
+    min_severity: error
+    max_findings: 0
+    action: fail
+
+# Week 5: Add more rules
+gating:
+  - rule: sql-injection
+    min_severity: error
+    max_findings: 0
+    action: fail
+  - rule: hardcoded-secret
+    min_severity: error
+    max_findings: 0
+    action: fail
+```
+
+## Rule Evaluation Order
+
+Rules are evaluated in the order they appear in the YAML file. **All rules are evaluated** — Clausura does not stop at the first violation. The final exit code is the maximum across all rules:
+
+- If any rule produces `fail` → exit code 1
+- If no `fail` but at least one `warn` → exit code 0 (with warnings logged)
+- If all rules pass → exit code 0
+
+This means you can have multiple `fail` rules and multiple `warn` rules in the same config, and all will be reported.
+
+## Matching `rule_id` to Findings
+
+The `rule` field in your gating config must match the `rule_id` in the LLM's findings. This is the contract between your prompt and your gates.
+
+**Prompt tells the LLM what `rule_id` to use:**
+
+```yaml
+prompt_template: |
+  For SQL injection issues, use rule_id: "sql-injection"
+  For hardcoded secrets, use rule_id: "hardcoded-secret"
+```
+
+**Gating tells Clausura what to do with those findings:**
+
+```yaml
+gating:
+  - rule: sql-injection
+    max_findings: 0
+    action: fail
+  - rule: hardcoded-secret
+    max_findings: 0
+    action: fail
+```
+
+If the LLM produces a finding with a `rule_id` that has no matching gating rule, that finding is **not counted against any gate** — it appears in the SARIF output but doesn't affect the pass/fail decision.
+
+## Severity Mapping
+
+The LLM assigns a severity to each finding. Your gating rules filter by severity threshold. Make sure your prompt teaches the LLM a consistent severity scheme:
+
+```yaml
+prompt_template: |
+  Severity guidelines:
+  - error:   Exploitable vulnerabilities, will cause data loss or security breach
+  - warning: Best practice violations that could lead to problems
+  - info:    Style inconsistencies, minor improvements
+  - hint:    Suggestions, nice-to-haves
+```
+
+## Tips
+
+1. **Start with `max_findings: 0` and `action: warn`.** Run Clausura for a week in warn-only mode. Review the SARIF output to calibrate your thresholds. Then switch to `action: fail`.
+
+2. **Use `ignore` instead of deleting rules.** When you need to temporarily disable a rule (e.g., during a refactor), change `action` to `ignore` rather than removing the rule. This keeps the rule visible in config and makes it easy to re-enable.
+
+3. **Keep rule_ids stable.** If you rename a `rule_id` in your prompt, update the corresponding gating rule at the same time. Mismatched `rule_id`s silently produce zero-count matches.
+
+4. **One rule per concern.** Avoid compound rules like "check-for-sql-injection-and-xss". The rule engine matches by exact `rule_id`, so each concern needs its own rule.
+
+5. **Review SARIF for un-gated findings.** Findings with `rule_id`s that have no matching gating rule appear in the SARIF output but don't affect the verdict. Regularly review SARIF to see if you're missing gates for important issue types.
+
+## Next
+
+→ [Reuse community skills](skills.md)
+→ [See complete scenario configs](scenarios.md)

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,124 @@
+# Installation
+
+## Supported Platforms
+
+Clausura supports **Linux** and **macOS** (x86_64 and aarch64).
+
+Windows is not directly supported — use WSL2 or Docker instead.
+
+## Method 1: Install Script (Recommended)
+
+The install script downloads the latest release binary for your OS/arch, verifies its SHA256 checksum, and installs to `/usr/local/bin` (or `~/.local/bin` if `/usr/local/bin` is not writable).
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+```
+
+To install a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash -s -- v1.2.1
+```
+
+### What the script does
+
+1. Detects your OS (Linux/macOS) and architecture (x86_64/aarch64)
+2. Downloads the matching `.tar.gz` from GitHub Releases
+3. Downloads `checksums.txt` from the same release
+4. Verifies the archive's SHA256 hash
+5. Extracts the binary and installs it
+
+## Method 2: Cargo
+
+Requires Rust toolchain (install via [rustup](https://rustup.rs)).
+
+```bash
+cargo install clausura-cli
+```
+
+This compiles from source and installs to `~/.cargo/bin/clausura`.
+
+To install a specific version:
+
+```bash
+cargo install clausura-cli --version 1.2.1
+```
+
+## Method 3: Docker
+
+Pre-built images are published to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/liuyanghejerry/clausura:latest
+
+# Run with current directory mounted as workspace
+docker run --rm -v $(pwd):/workspace ghcr.io/liuyanghejerry/clausura run
+
+# With API key
+docker run --rm \
+  -v $(pwd):/workspace \
+  -e CLAUSURA_API_KEY=sk-... \
+  ghcr.io/liuyanghejerry/clausura run
+```
+
+Tag format: `latest` for the most recent release, `v1.2.1` for a specific version.
+
+## Method 4: Build from Source
+
+```bash
+git clone https://github.com/liuyanghejerry/Clausura.git
+cd Clausura
+cargo build --release --package clausura-cli
+# Binary at ./target/release/clausura
+```
+
+## Verify Installation
+
+```bash
+clausura --version
+# Example output:
+# clausura 1.2.1 (commit: a1b2c3d, built: 2026-07-15)
+```
+
+## GitHub Actions
+
+If you're using GitHub Actions, the simplest approach is the composite action — it handles installation automatically:
+
+```yaml
+- uses: liuyanghejerry/Clausura@v1
+  with:
+    config: .clausura.yaml
+    api_key: ${{ secrets.LLM_API_KEY }}
+```
+
+The action downloads the correct binary for the runner, verifies it, and runs Clausura with your config. See [CI Integration](ci-integration.md) for details.
+
+## Upgrading
+
+For script-based installs, re-run the install script.
+
+For Cargo:
+
+```bash
+cargo install clausura-cli --force
+```
+
+For Docker, pull the new tag:
+
+```bash
+docker pull ghcr.io/liuyanghejerry/clausura:latest
+```
+
+## Uninstalling
+
+```bash
+# Script / Cargo install
+rm $(which clausura)
+
+# Also remove config and checkpoints
+rm -rf ~/.clausura
+```
+
+## Next
+
+→ [Set up your LLM provider](llm-providers.md)

--- a/docs/guide/llm-providers.md
+++ b/docs/guide/llm-providers.md
@@ -1,0 +1,237 @@
+# LLM Providers
+
+Clausura works with any LLM that exposes a chat completions API. Three vendor categories are supported out of the box, plus a custom option for enterprise endpoints.
+
+## Configuration: The `vendor` Field
+
+The `vendor` field in `.clausura.yaml` accepts two forms:
+
+**Shorthand (string):**
+
+```yaml
+vendor: openai
+```
+
+**Full config (object):**
+
+```yaml
+vendor:
+  type: openai_compatible
+  base_url: "https://api.mistral.ai/v1"
+  auth_header: "Authorization"
+  api_key_env: "MY_CUSTOM_KEY"
+```
+
+The shorthand maps to built-in presets. The object form gives you full control.
+
+## Provider Presets
+
+### 1. OpenAI
+
+```yaml
+task:
+  model: gpt-4o
+  vendor: openai
+```
+
+Uses `https://api.openai.com/v1` with `Authorization: Bearer` header.
+
+| Model | Recommended for |
+|-------|-----------------|
+| `gpt-4o` | General-purpose code review |
+| `gpt-4o-mini` | Faster, cheaper, good for lint-like checks |
+| `o3-mini` | Reasoning-heavy analysis |
+
+Set the API key:
+
+```bash
+export CLAUSURA_API_KEY=sk-proj-...
+```
+
+### 2. Anthropic (Claude)
+
+```yaml
+task:
+  model: claude-sonnet-4-20250514
+  vendor: anthropic
+```
+
+Uses Anthropic's native [Messages API](https://docs.anthropic.com/en/api/messages) at `https://api.anthropic.com` with `x-api-key` header and `anthropic-version: 2023-06-01`.
+
+| Model | Recommended for |
+|-------|-----------------|
+| `claude-sonnet-4-20250514` | Balanced speed and quality |
+| `claude-opus-4-20250514` | Complex analysis, large diffs |
+| `claude-haiku-3-5-20241022` | Fast, cheap, simple checks |
+
+The shorthand `claude` is an alias for `anthropic`:
+
+```yaml
+vendor: claude  # same as vendor: anthropic
+```
+
+Set the API key:
+
+```bash
+export CLAUSURA_API_KEY=sk-ant-...
+```
+
+### 3. DeepSeek
+
+```yaml
+task:
+  model: deepseek-chat
+  vendor: deepseek
+```
+
+Uses DeepSeek's OpenAI-compatible endpoint at `https://api.deepseek.com/v1`.
+
+| Model | Notes |
+|-------|-------|
+| `deepseek-chat` | General purpose (V3) |
+| `deepseek-reasoner` | Reasoning model (R1) |
+
+Set the API key:
+
+```bash
+export CLAUSURA_API_KEY=sk-...
+```
+
+### 4. Groq
+
+```yaml
+task:
+  model: llama-3.3-70b-versatile
+  vendor: groq
+```
+
+Uses Groq's OpenAI-compatible endpoint at `https://api.groq.com/openai/v1`. Groq is known for very fast inference.
+
+Set the API key:
+
+```bash
+export CLAUSURA_API_KEY=gsk_...
+```
+
+### 5. Ollama (Local)
+
+```yaml
+task:
+  model: llama3.2
+  vendor: ollama
+```
+
+Uses your local Ollama instance at `http://localhost:11434/v1`. No API key required — set a dummy value:
+
+```bash
+export CLAUSURA_API_KEY=ollama
+```
+
+Ollama must be running locally:
+
+```bash
+ollama serve
+ollama pull llama3.2
+```
+
+## Custom Providers
+
+Any endpoint that speaks the OpenAI chat completions API format can be used:
+
+```yaml
+task:
+  model: my-model
+  vendor:
+    type: custom
+    base_url: "https://llm.internal.company.com/v1"
+    auth_header: "X-API-Key"
+    api_key_env: "INTERNAL_LLM_KEY"
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `type` | — | Must be `custom` |
+| `base_url` | — | Your endpoint's base URL (required) |
+| `auth_header` | `Authorization` | Custom auth header name |
+| `api_key_env` | `CLAUSURA_API_KEY` | Env var to read the key from |
+
+For `type: openai_compatible`, you can also override the base URL while keeping `Authorization: Bearer` auth:
+
+```yaml
+vendor:
+  type: openai_compatible
+  base_url: "https://api.mistral.ai/v1"
+```
+
+This is useful for Mistral, Together AI, Fireworks, vLLM, and any other OpenAI-compatible provider.
+
+## API Key
+
+The API key is **never** read from the YAML config file. It must come from one of:
+
+1. `CLAUSURA_API_KEY` environment variable (default)
+2. `--api-key` CLI flag
+3. A custom env var specified via `api_key_env` in the vendor config
+
+```bash
+# Environment variable (recommended for CI)
+export CLAUSURA_API_KEY=sk-...
+
+# CLI flag
+clausura run --api-key sk-...
+
+# Custom env var (with vendor.api_key_env: "LLM_KEY")
+export LLM_KEY=sk-...
+clausura run
+```
+
+## Model Selection Tips
+
+### For Code Review Tasks
+
+Code review is the primary use case. Key considerations:
+
+| Priority | Concern | Recommendation |
+|----------|---------|----------------|
+| Quality | False negatives (missed issues) | Use a strong model: `gpt-4o`, `claude-sonnet-4` |
+| Speed | CI pipeline latency | `gpt-4o-mini` or `claude-haiku` for lint-like checks |
+| Cost | API spend per PR | Smaller models + low `token_budget`; skip large diffs |
+
+### For Classification Tasks
+
+If your task is classification rather than reasoning (e.g., "does this file use Options API or Composition API?"), cheaper models like `gpt-4o-mini` or `claude-haiku-3-5` work well.
+
+### Conditional Model Selection
+
+Clausura uses a single model per run. For different review dimensions that benefit from different models, run multiple `clausura run` commands with different configs in parallel CI jobs.
+
+## Retry Behavior
+
+Clausura retries failed LLM requests with exponential backoff:
+
+- Retries on: HTTP 429 (rate limit), 5xx (server error), network errors
+- No retry on: HTTP 4xx (bad request, auth failure) — these fail immediately
+- Backoff: 1s, 2s, 4s with jitter
+- Honors `Retry-After` response header when present
+- Maximum 3 retry attempts per request
+
+## Token Budget vs. Cumulative Token Cap
+
+Two separate limits control token usage:
+
+| Field | Purpose | Default |
+|-------|---------|---------|
+| `token_budget` | Context window limit — drives message truncation | 32,000 |
+| `max_total_tokens` | Cumulative spend cap across all LLM calls in a run | None (no cap) |
+
+`token_budget` keeps the conversation from exceeding the model's context window. Older messages are truncated and archived. `max_total_tokens` stops the run entirely when cumulative billed tokens reach the cap — useful for cost control.
+
+```yaml
+task:
+  token_budget: 32000       # trim conversation at 32K tokens
+  max_total_tokens: 200000  # stop entire run at 200K tokens billed
+```
+
+## Next
+
+→ [Understand the full configuration](configuration.md)

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -1,0 +1,171 @@
+# Overview & Philosophy
+
+## What Clausura Is
+
+Clausura is a **CI-native agent CLI** that runs bounded LLM tasks against your codebase and produces a deterministic pass/fail verdict. It was built for a single purpose: **automated code review gating in CI/CD pipelines.**
+
+Think of it as a code reviewer that:
+
+- Never gets tired or distracted
+- Always follows the same rules
+- Produces machine-readable output (SARIF) that integrates with your existing tools
+- Fails the pipeline when it should — and only when it should
+
+## What Clausura Is Not
+
+- **Not an interactive coding assistant.** There is no chat, no follow-up questions, no human in the loop. Every run is fully autonomous.
+- **Not a general-purpose agent framework.** The tool set is deliberately limited. The iteration count is capped. The output format is fixed.
+- **Not a replacement for linting or static analysis.** Clausura complements ESLint, Semgrep, and CodeQL — it catches semantic and architectural issues those tools can't express.
+
+## Core Design Principles
+
+### 1. Closed-Loop Execution
+
+Every Clausura run is **bounded** by three hard limits:
+
+| Limit | Default | What happens when exceeded |
+|-------|---------|---------------------------|
+| `token_budget` | 32,000 | Older messages are truncated and archived; agent is notified to inspect archives if needed |
+| `timeout_secs` | 300 | Run terminates with exit code 2 |
+| `max_iterations` | 10 | Run ends; if incomplete → exit code 2 (`on_incomplete: fail`) |
+
+The agent loop follows a simple **reason → act → observe** cycle:
+
+```
+1. Send conversation to LLM (system prompt + message history)
+2. LLM responds with either:
+   a. Tool calls → execute them, feed results back, repeat
+   b. Stop signal → extract findings, exit loop
+3. If loop ends without clean Stop → mark as incomplete, fail closed
+```
+
+There is no branching, no sub-tasking, no delegation. One agent. One loop. One result.
+
+### 2. Deterministic Gating
+
+After the LLM produces findings, the **rule engine** takes over. This is pure counting logic — no AI, no heuristics:
+
+```
+For each gating rule:
+  1. Filter findings matching rule.rule_id
+  2. Filter by severity >= rule.min_severity
+  3. Count remaining
+  4. If count > rule.max_findings → apply rule.action
+```
+
+The rule engine is why Clausura can be trusted in CI. The LLM might hallucinate, miss things, or produce inconsistent output — but the gating decision is always deterministic and auditable.
+
+### 3. CI-Native
+
+Clausura is designed to run unattended in CI environments:
+
+- **Auto-detection**: recognizes GitHub Actions, GitLab CI, Jenkins, generic CI via environment variables
+- **Exit codes map to pipeline status**: 0 = pass, 1 = fail (rule violation), 2 = error (runtime), 3 = error (config)
+- **SARIF output**: `clausura-output.sarif` in SARIF v2.1.0 format, compatible with GitHub Advanced Security, CodeQL dashboard, and any SARIF viewer
+- **No interactive prompts**: the run either completes or fails — there is no "ask the user what to do next"
+
+## Key Concepts
+
+### Task
+
+A **task** is a single Clausura run defined by a `.clausura.yaml` config file. It specifies:
+
+- Which LLM to use (model + vendor)
+- What to check (prompt template or skills)
+- How long to run (budget, timeout, iterations)
+- What counts as failure (gating rules)
+
+### Findings
+
+**Findings** are structured issues discovered by the LLM. Each finding has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rule_id` | string | Identifier matching a gating rule (e.g. `"sql-injection"`) |
+| `severity` | enum | `hint` < `info` < `warning` < `error` |
+| `message` | string | Human-readable description of the issue |
+| `evidence` | string | The code or text that triggered the finding |
+| `location` | object? | Optional file/line/column range |
+
+The LLM is instructed to output findings as a JSON array. Clausura validates every finding against its schema — schema mismatches fail loudly, not silently.
+
+### Gating Rules
+
+**Gating rules** are the deterministic pass/fail criteria. Each rule says: "for findings with `rule_id` X at severity Y or higher, allow at most Z occurrences, and if exceeded, do W."
+
+→ [Full gating guide](gating.md)
+
+### Skills
+
+**Skills** are reusable Markdown files that encode review knowledge. They tell the LLM **what** to look for, while gating rules tell Clausura **how many** is too many. Skills come from the community or your team's internal repository.
+
+→ [Skills guide](skills.md)
+
+## Architecture at a Glance
+
+```
+┌─────────────────────────────────────────────────┐
+│                    .clausura.yaml                 │
+│  task definition + gating rules                  │
+└──────────────────┬──────────────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────────────┐
+│                 Config Loader                     │
+│  YAML → CLI flags → env vars (layered)           │
+└──────────────────┬──────────────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────────────┐
+│                 Executor                          │
+│  provider → agent loop → rule engine → SARIF     │
+└──┬───────────┬───────────┬───────────┬──────────┘
+   │           │           │           │
+   ▼           ▼           ▼           ▼
+┌──────┐ ┌──────────┐ ┌────────┐ ┌──────────┐
+│LLM   │ │Agent Loop│ │Rule    │ │SARIF     │
+│Provider│ │(≤N iter)│ │Engine  │ │Formatter │
+└──────┘ └────┬─────┘ └────────┘ └──────────┘
+              │
+              ▼
+┌────────────────────────────┐
+│  Tools (sandboxed)         │
+│  read_file | list_files    │
+│  grep | git_diff           │
+│  shell_exec (allowlisted)  │
+└────────────────────────────┘
+```
+
+### Components
+
+- **Provider**: Abstracts over LLM APIs (OpenAI-compatible, Anthropic Messages, Custom). Handles auth, retries, and response parsing.
+- **Agent Loop**: The bounded reason→act→observe cycle. Manages context window truncation, archive hints, and checkpoint saves.
+- **Context Manager**: Tracks token usage, truncates older messages to stay within `token_budget`, archives dropped context.
+- **Tool Registry**: Five built-in tools with sandboxing — path confinement, command allowlisting, environment scrubbing.
+- **Rule Engine**: Deterministic counting engine. No LLM. Pure logic.
+- **SARIF Formatter**: Writes findings to `clausura-output.sarif` in SARIF v2.1.0 format.
+- **Snapshot Manager**: SQLite-based checkpoint store for crash recovery (`--resume`).
+
+## Design Decisions
+
+Here are a few explicit choices that shape Clausura's design:
+
+**Why no sub-agents?**
+Clausura's value is bounded, deterministic execution. Sub-agents make the system less predictable — harder to budget, harder to gate, harder to debug. Parallel review is better done at the CI orchestration level (multiple `clausura run` calls in parallel jobs).
+
+**Why JSON findings instead of free-text?**
+Structured output is the contract between the LLM and the rule engine. Free-text findings would require another LLM call to classify — adding cost, latency, and non-determinism between the reviewer and the gate.
+
+**Why `on_incomplete: fail` by default?**
+An incomplete review (context exhausted, iteration limit hit) that finds zero issues must not silently pass. Fail closed is the safe default for CI gating.
+
+**Why no interactive mode?**
+Clausura is not an assistant. It's a pipeline gate. Every interactive prompt is a CI timeout waiting to happen.
+
+## Next Steps
+
+- [Quick start with a minimal config →](../README.md#quick-start)
+- [Set up your LLM provider →](llm-providers.md)
+- [Understand the configuration →](configuration.md)
+- [Design your gating rules →](gating.md)
+- [See real-world scenarios →](scenarios.md)

--- a/docs/guide/scenarios.md
+++ b/docs/guide/scenarios.md
@@ -1,0 +1,313 @@
+# Common Scenarios
+
+Real-world configurations for typical use cases. Each scenario is a complete `.clausura.yaml` you can adapt.
+
+## Scenario 1: Security Code Review
+
+The most common use case — catch SQL injection, XSS, hardcoded secrets, and input validation gaps.
+
+```yaml
+version: "1"
+task:
+  name: security-review
+  model: gpt-4o
+  vendor: openai
+  prompt_template: |
+    Review the git diff for security issues. For each finding use the specified rule_id.
+
+    ### SQL Injection
+    - String concatenation in SQL queries
+    - Non-parameterized database calls
+    - rule_id: "sql-injection", severity: "error"
+
+    ### Hardcoded Credentials
+    - API keys, passwords, tokens in source code
+    - Config files with plaintext secrets (exclude example/docs files)
+    - rule_id: "hardcoded-secret", severity: "error"
+
+    ### XSS
+    - Direct user input insertion into HTML (innerHTML, document.write)
+    - Unescaped template variable output
+    - rule_id: "xss", severity: "error"
+
+    ### Missing Input Validation
+    - API endpoints without type/range validation
+    - File upload without type/size checks
+    - rule_id: "missing-validation", severity: "warning"
+
+    ### Insecure Dependencies
+    - Known-vulnerable dependency versions
+    - Scripts loaded from untrusted sources
+    - rule_id: "insecure-dependency", severity: "warning"
+
+    Output a JSON object with a "findings" array. Each finding: rule_id, severity, message, evidence, location (optional).
+
+  token_budget: 16000
+  timeout_secs: 120
+
+  gating:
+    - rule: sql-injection
+      description: "SQL injection is a critical vulnerability"
+      min_severity: error
+      max_findings: 0
+      action: fail
+    - rule: hardcoded-secret
+      description: "No hardcoded credentials in source"
+      min_severity: error
+      max_findings: 0
+      action: fail
+    - rule: xss
+      description: "XSS is a critical vulnerability"
+      min_severity: error
+      max_findings: 0
+      action: fail
+    - rule: missing-validation
+      description: "All user inputs should be validated"
+      min_severity: warning
+      max_findings: 3
+      action: warn
+    - rule: insecure-dependency
+      description: "Dependencies should be vetted"
+      min_severity: warning
+      max_findings: 3
+      action: warn
+```
+
+## Scenario 2: i18n Completeness Check
+
+Ensure translation coverage stays consistent across locales.
+
+```yaml
+version: "1"
+task:
+  name: i18n-check
+  model: gpt-4o-mini
+  vendor: openai
+  prompt_template: |
+    Review the git diff for internationalization issues. Locale files are in locales/ or i18n/ directories.
+
+    Use these rule_ids:
+    - "hardcoded-text": UI strings not using i18n keys (exclude comments and logs), severity: "warning"
+    - "missing-translation-key": Key referenced in code but missing from locale files, severity: "error"
+    - "locale-mismatch": Inconsistent key counts across locale files, severity: "warning"
+    - "unused-translation-key": Key defined in locale files but never referenced, severity: "info"
+
+  token_budget: 8000
+  timeout_secs: 60
+
+  gating:
+    - rule: missing-translation-key
+      description: "All referenced keys must exist in locale files"
+      min_severity: error
+      max_findings: 0
+      action: fail
+    - rule: hardcoded-text
+      description: "Warn on hardcoded UI strings"
+      min_severity: warning
+      max_findings: 3
+      action: warn
+    - rule: locale-mismatch
+      description: "Locale files should be consistent"
+      min_severity: warning
+      max_findings: 1
+      action: warn
+```
+
+Note the use of `gpt-4o-mini` — classification tasks like "is this string hardcoded?" don't need a frontier model.
+
+## Scenario 3: Architecture Compliance
+
+Enforce layer boundaries and import rules in a layered architecture.
+
+```yaml
+version: "1"
+task:
+  name: architecture-check
+  model: gpt-4o
+  vendor: openai
+  prompt_template: |
+    Review the git diff for architecture violations in our layered architecture:
+
+    Layers (outer to inner):
+    - controllers/   → depends on services/
+    - services/      → depends on repositories/
+    - repositories/  → depends on models/ and db/
+    - models/        → no internal dependencies
+
+    Rules:
+    - rule_id: "layer-violation" severity: "error"
+      A module importing from a more-inner layer than it should.
+      Example: controllers/ importing from repositories/ (skip services/).
+
+    - rule_id: "circular-dependency" severity: "error"
+      Two modules importing from each other.
+
+    - rule_id: "forbidden-import" severity: "error"
+      Importing from deprecated or forbidden paths.
+
+  token_budget: 16000
+  timeout_secs: 120
+
+  gating:
+    - rule: layer-violation
+      description: "Must follow layer dependency direction"
+      min_severity: error
+      max_findings: 0
+      action: fail
+    - rule: circular-dependency
+      description: "No circular imports"
+      min_severity: error
+      max_findings: 0
+      action: fail
+    - rule: forbidden-import
+      description: "No forbidden imports"
+      min_severity: error
+      max_findings: 0
+      action: fail
+```
+
+## Scenario 4: Vue Best Practices
+
+Enforce Vue-specific conventions in a frontend project.
+
+```yaml
+version: "1"
+task:
+  name: vue-review
+  model: gpt-4o-mini
+  vendor: openai
+  skill_prompts:
+    - vue-best-practices
+  prompt_template: |
+    Additionally check:
+    - No `any` type in TypeScript files (rule_id: "no-as-any", severity: "warning")
+
+  token_budget: 8000
+
+  gating:
+    - rule: vue-component-name
+      description: "Components must use multi-word PascalCase names"
+      min_severity: warning
+      max_findings: 2
+      action: warn
+    - rule: vue-missing-prop-validation
+      description: "Props must have type declarations"
+      min_severity: warning
+      max_findings: 5
+      action: warn
+    - rule: no-as-any
+      description: "Avoid TypeScript `as any`"
+      min_severity: warning
+      max_findings: 0
+      action: fail
+```
+
+This scenario shows combining a skill (`vue-best-practices`) with a custom `prompt_template` addition. See the [Skills guide](skills.md) for more.
+
+## Scenario 5: Multi-Dimensional Review via Parallel CI Jobs
+
+For projects that need different review dimensions (security, i18n, architecture), run multiple Clausura tasks in parallel CI jobs:
+
+```yaml
+# .github/workflows/review.yml
+name: Code Review
+
+on: [pull_request]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Security Review
+        run: clausura run -c .clausura/security.yaml
+        env:
+          CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+
+  i18n:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: i18n Check
+        run: clausura run -c .clausura/i18n.yaml
+        env:
+          CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+
+  architecture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Architecture Check
+        run: clausura run -c .clausura/architecture.yaml
+        env:
+          CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+```
+
+Each job uses its own config file. This gives you:
+- Independent gating rules per dimension
+- Different models per job (fast model for i18n, strong model for security)
+- Parallel execution for speed
+- Separate SARIF outputs per dimension
+
+## Scenario 6: Smart Gating with Custom Tool Execution
+
+For reviews that need to run project-specific tools (linters, test suites) before analysis:
+
+```yaml
+version: "1"
+task:
+  name: smart-gate
+  model: gpt-4o
+  vendor: openai
+  prompt_template: |
+    Run `cargo clippy --message-format=json` first using shell_exec to gather lint results.
+    Then review the git diff and clippy output together.
+    Focus on issues that clippy can't catch: logic errors, unsafe patterns, missing error handling.
+
+    rule_ids:
+    - "unsafe-block", severity: "error"
+    - "missing-error-handling", severity: "warning"
+    - "panic-in-library", severity: "error"
+
+  tool_allowlist:
+    - cargo clippy
+    - cargo check
+  token_budget: 16000
+  shell_timeout_secs: 180
+
+  gating:
+    - rule: unsafe-block
+      max_findings: 0
+      action: fail
+    - rule: panic-in-library
+      max_findings: 0
+      action: fail
+    - rule: missing-error-handling
+      max_findings: 5
+      action: warn
+```
+
+This lets the agent gather data from project tooling before making its analysis, combining traditional static analysis with LLM reasoning.
+
+## Selecting the Right Model
+
+| Task Type | Recommended Model | Why |
+|-----------|------------------|-----|
+| Security review | `gpt-4o` / `claude-sonnet-4` | Needs deep reasoning to spot subtle vulnerabilities |
+| Style/lint checks | `gpt-4o-mini` / `claude-haiku` | Pattern matching, not reasoning |
+| Architecture analysis | `gpt-4o` / `claude-sonnet-4` | Requires understanding project structure |
+| i18n coverage | `gpt-4o-mini` / `claude-haiku` | Classification task, fast and cheap |
+| Local dev / offline | Ollama + `llama3.2` or `qwen2.5-coder` | No API cost, suitable for pre-commit hooks |
+
+→ [LLM provider setup](llm-providers.md)
+
+## Next
+
+→ [Set up CI integration](ci-integration.md)
+→ [Learn about skills](skills.md)

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -1,0 +1,208 @@
+# Skills
+
+Skills are reusable Markdown files that encode **what** to review. They answer "what should I look for and how should I report it?" — while gating rules answer "how many findings is too many?" The two are cleanly separated.
+
+## Why Skills?
+
+Without skills, every project writes its own prompt from scratch. This means:
+
+- Review quality depends on the developer's domain knowledge
+- The same review logic can't be reused across projects
+- Team conventions are hard to distribute and enforce
+
+Skills solve this: write the review logic once (as a Markdown file), reuse everywhere, and let each team set their own thresholds.
+
+## Using a Skill
+
+Reference skills in `skill_prompts`:
+
+```yaml
+task:
+  skill_prompts:
+    # Local file (relative to workspace root, or absolute)
+    - ./skills/security-review.md
+
+    # Named reference (looks in .clausura/skills/<name>/SKILL.md,
+    # then ~/.clausura/skills/<name>/SKILL.md)
+    - security-review
+    - team/vue-best-practices
+
+  # Your own additions go after the skills
+  prompt_template: |
+    Also check: no console.log in production code.
+
+  gating:
+    - rule: sql-injection
+      max_findings: 0
+      action: fail
+```
+
+When the agent runs, skill content is injected into the system prompt before your `prompt_template`:
+
+```
+[Skill: security-review]
+...skill content...
+
+[Skill: team/vue-best-practices]
+...skill content...
+
+---
+
+Your prompt_template content
+```
+
+## Skill File Format
+
+A skill is a Markdown file, optionally with YAML frontmatter:
+
+```markdown
+---
+name: security-review
+description: Check for SQL injection, XSS, hardcoded secrets, and insecure dependencies.
+---
+
+# Security Code Review
+
+Review the code diff for the following security issues.
+
+## SQL Injection
+- Any string concatenation used to build SQL queries
+- Non-parameterized database calls
+- rule_id: `sql-injection`
+- severity: `error`
+
+## Hardcoded Credentials
+- API keys, passwords, tokens in source code
+- Config files with plaintext secrets (exclude example/docs)
+- rule_id: `hardcoded-secret`
+- severity: `error`
+
+## Output Format
+
+For each finding, output:
+
+```json
+{
+  "rule_id": "sql-injection",
+  "severity": "error",
+  "message": "SQL injection in login.js:15 — user input concatenated into SQL query",
+  "evidence": "const sql = \"SELECT * FROM users WHERE name = '\" + user + \"'\"",
+  "location": {
+    "file": "src/login.js",
+    "line_start": 15,
+    "line_end": 15,
+    "column_start": 13,
+    "column_end": 62
+  }
+}
+```
+```
+
+**Frontmatter** (`---` delimited YAML at the top) is stripped automatically. Only the Markdown body is injected into the prompt.
+
+**No gating in skills.** Skills define what and how to review, never the pass/fail threshold. That belongs in `.clausura.yaml` under `gating:`.
+
+## Installing Skills
+
+### Project-level (this repo only)
+
+```bash
+mkdir -p .clausura/skills/security-review
+cp ~/Downloads/security-review-SKILL.md .clausura/skills/security-review/SKILL.md
+```
+
+Then reference by name:
+
+```yaml
+skill_prompts:
+  - security-review
+```
+
+### User-level (available to all your projects)
+
+```bash
+mkdir -p ~/.clausura/skills/team/vue-check
+cp ~/Downloads/vue-check-SKILL.md ~/.clausura/skills/team/vue-check/SKILL.md
+```
+
+Then reference by path including the namespace:
+
+```yaml
+skill_prompts:
+  - team/vue-check
+```
+
+## Skill Resolution Order
+
+When you reference a skill by name (not a file path), Clausura searches:
+
+1. `.clausura/skills/<name>/SKILL.md` (project-level, in your workspace)
+2. `~/.clausura/skills/<name>/SKILL.md` (user-level, in your home directory)
+
+The first match wins. Project-level skills take precedence.
+
+## Composing Multiple Skills
+
+Skills are appended in declaration order. The agent sees them as a single system prompt:
+
+```yaml
+task:
+  skill_prompts:
+    - community/security-review
+    - team/vue-best-practices
+    - ./project-specific-checks.md
+```
+
+This composes three review perspectives into one agent run. All findings from all skills are evaluated against the same gating rules.
+
+If two skills define the same `rule_id` (e.g., both define `sql-injection`), findings from both are counted together. This is intentional — you get one threshold per concern, regardless of which skill found it.
+
+## Creating Your Own Skill
+
+A good skill file:
+
+1. **Has clear rule_ids** — each check has a unique `rule_id` that gating rules can match
+2. **Specifies severities** — teaches the LLM a consistent severity scheme
+3. **Shows output format** — includes an example finding so the LLM knows the expected JSON shape
+4. **Includes `location` guidance** — tells the LLM to report file/line when possible
+5. **Keeps scope narrow** — one skill per domain (security, i18n, Vue conventions, etc.)
+
+### Example: Team Coding Standard Skill
+
+```markdown
+---
+name: team-standards
+description: Enforce our team's coding standards.
+---
+
+# Team Coding Standards
+
+## Error Handling
+- All async operations must have try-catch
+- rule_id: `missing-error-handling`
+- severity: `warning`
+
+## Logging
+- Use the shared `logger` module, not console.log
+- rule_id: `console-log`
+- severity: `warning`
+
+## Imports
+- No relative imports beyond 2 levels (use path aliases)
+- rule_id: `deep-relative-import`
+- severity: `info`
+```
+
+## Non-Goals
+
+Skills intentionally do **not** support:
+
+- **Gating thresholds** — those live in `.clausura.yaml` where CI config belongs
+- **Tool definitions** — skills can't grant new tool permissions; tool allowlist is in config
+- **Version management** — use git tags on your skill repository for versioning
+- **Hot reloading** — skills are loaded at run time from the filesystem
+
+## Next
+
+→ [See skills in action (scenarios)](scenarios.md)
+→ [Browse example skills](https://github.com/liuyanghejerry/Clausura/tree/main/examples/skills)

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,0 +1,215 @@
+# Troubleshooting
+
+Common issues, error codes, and debugging strategies for Clausura.
+
+## Exit Codes
+
+| Code | Meaning | Typical causes |
+|------|---------|---------------|
+| 0 | Pass | All gating rules satisfied. |
+| 1 | Fail | One or more rules with `action: fail` were violated. Check the log output for violation details. |
+| 2 | Error | Runtime failure: LLM provider error, timeout, incomplete run (`on_incomplete: fail`), max total tokens reached. |
+| 3 | Config | Invalid `.clausura.yaml`. Run `clausura run --validate-config` to get details. |
+
+## Common Issues
+
+### "Authentication failed" (exit code 2)
+
+**Symptom:** Run fails immediately with an auth error.
+
+**Causes and fixes:**
+
+1. **Missing API key.**
+   ```bash
+   # Ensure the key is set
+   export CLAUSURA_API_KEY=sk-...
+   clausura run
+   ```
+
+2. **Wrong vendor.** If you're using Anthropic with an OpenAI key (or vice versa):
+   ```yaml
+   vendor: anthropic    # Make sure this matches your key type
+   ```
+
+3. **Custom auth header.** If your enterprise LLM uses a non-standard header:
+   ```yaml
+   vendor:
+     type: custom
+     base_url: "https://llm.internal/v1"
+     auth_header: "X-API-Key"    # Match what your endpoint expects
+   ```
+
+4. **Custom API key env var.** If you set `api_key_env`:
+   ```yaml
+   vendor:
+     api_key_env: "INTERNAL_LLM_KEY"
+   ```
+   Then export that variable, not `CLAUSURA_API_KEY`:
+   ```bash
+   export INTERNAL_LLM_KEY=sk-...
+   ```
+
+### "Agent run incomplete" (exit code 2 with `on_incomplete: fail`)
+
+**Symptom:** Run ends with exit code 2 and the error message includes "Agent run incomplete."
+
+**Causes and fixes:**
+
+1. **Context exhausted.** The conversation grew beyond `token_budget` and couldn't be truncated further.
+   - Increase `token_budget` (e.g., 32000 → 64000)
+   - Reduce the size of the input (narrower diff, shorter prompt)
+   - Increase `max_iterations` if truncation keeps happening
+
+2. **Iteration limit reached.** The agent used all `max_iterations` without producing a final answer.
+   - Increase `max_iterations` (e.g., 10 → 15)
+   - Simplify the task — fewer, more focused checks per run
+   - Check if the LLM is stuck in a tool-call loop (see below)
+
+3. **`max_total_tokens` reached.** Cumulative billing exceeded the cap.
+   - Increase `max_total_tokens` or remove it
+   - Use a cheaper model
+   - Reduce `token_budget` to limit per-request cost
+
+### "Task timeout exceeded" (exit code 2)
+
+**Symptom:** Run fails with a timeout error.
+
+- Increase `timeout_secs` (e.g., 300 → 600)
+- Use a faster model
+- Reduce the scope of the review
+- Check if `shell_exec` commands are hanging — adjust `shell_timeout_secs`
+
+### Agent stuck in a tool-call loop
+
+**Symptom:** The run uses all `max_iterations` repeatedly calling tools without producing findings.
+
+This happens when the LLM calls a tool, isn't satisfied with the result, calls it again with slightly different arguments, and repeats.
+
+**Fixes:**
+- Make your prompt more directive: "After running tools, output your findings. Do not re-run tools."
+- Reduce `max_iterations` to force earlier termination
+- Check if the tool output is confusing the LLM (e.g., truncated output, unexpected format)
+
+### "No findings" but I expected some
+
+**Symptom:** Clausura passes (exit 0) but you know there should be findings.
+
+**Debug steps:**
+
+1. **Check the SARIF output.** Even empty runs produce valid SARIF. The file may contain partial output even in "clean" runs.
+
+2. **Verify the prompt is clear.** If the LLM doesn't understand what to look for, it produces nothing. Test your prompt interactively (e.g., in ChatGPT/Claude) before putting it in Clausura.
+
+3. **Check `rule_id` matching.** If the LLM uses a different `rule_id` than your gating rules expect, findings are produced but not counted. Review `clausura-output.sarif` for unmatched findings.
+
+4. **Run with more iterations.** The agent might need more tool calls to gather context. Increase `max_iterations`.
+
+5. **Check if context is being truncated.** If `token_budget` is too low for your diff size, the agent might lose important context.
+
+### Schema mismatch errors
+
+**Symptom:** Error message says "X of Y finding(s) failed to match the Finding schema."
+
+The LLM produced JSON that doesn't match Clausura's expected finding format. Required fields: `rule_id`, `severity`, `message`, `evidence`. Optional: `location`.
+
+**Fixes:**
+- Include an example finding in your `prompt_template` showing the exact format
+- Use a more capable model that follows JSON schemas reliably
+- Check if the LLM is wrapping findings in extra nesting or using wrong field names
+
+### "Command not in allowlist" (shell_exec error)
+
+**Symptom:** The agent tries to run a command but gets "Command not in allowlist."
+
+- Check your `tool_allowlist` — the command must be explicitly listed
+- Remember that allowlist entries are argv prefixes: `"git status"` allows `git status --short` but NOT `git log`
+- The first token matches by basename: `"/usr/bin/git"` satisfies a `"git"` rule
+
+### "Config error" (exit code 3)
+
+**Symptom:** Clausura exits immediately with exit code 3.
+
+Run the config validator for detailed error messages:
+
+```bash
+clausura run --validate-config
+```
+
+Or use dry-run to see how Clausura interprets your config:
+
+```bash
+clausura run --dry-run
+```
+
+## Debugging Strategies
+
+### 1. Use `--log-format pretty`
+
+By default, logs are JSON (designed for CI log processors). For local debugging:
+
+```bash
+clausura run --log-format pretty
+```
+
+### 2. Validate config without running
+
+```bash
+clausura run --validate-config  # Check config syntax
+clausura run --dry-run          # Show the execution plan
+```
+
+### 3. Inspect the SARIF output
+
+Even failed runs produce (partial) SARIF:
+
+```bash
+cat clausura-output.sarif | jq '.runs[0].results[] | {ruleId, level, message: .message.text}'
+```
+
+### 4. Check the checkpoint
+
+If a run was interrupted, inspect what the agent had done:
+
+```bash
+clausura snapshot list
+clausura snapshot show
+```
+
+### 5. Test with a small config first
+
+Before running a full review pipeline, test with minimal settings:
+
+```yaml
+task:
+  name: test
+  model: gpt-4o-mini
+  vendor: openai
+  prompt_template: "Look at the diff and tell me if you see any issues. Output {'findings': []}."
+  token_budget: 4000
+  timeout_secs: 30
+  max_iterations: 2
+```
+
+This verifies your LLM connection, API key, and basic agent loop work.
+
+### 6. Check context archives
+
+When runs are truncated, archived messages land in `.clausura/archives/`. These can help debug what the agent saw:
+
+```bash
+ls -la .clausura/archives/
+cat .clausura/archives/context-dump-<task-id>-1.log
+```
+
+### 7. Test prompts interactively
+
+Before deploying a prompt to CI, test it against your favorite LLM chat interface. Copy the prompt, paste it into ChatGPT or Claude, and see if it produces the findings format you expect.
+
+## Getting Help
+
+If you're stuck:
+
+- Check the [GitHub Issues](https://github.com/liuyanghejerry/Clausura/issues) for similar problems
+- Enable verbose logging: `clausura run --log-format pretty`
+- Run with `--dry-run` to confirm config interpretation
+- Ensure your LLM provider is accessible from the CI environment (some corp networks block API endpoints)

--- a/docs/skill-as-task.md
+++ b/docs/skill-as-task.md
@@ -1,11 +1,11 @@
 # Skill-as-Task: 社区 Skill 复用
 
-> 状态：设计中
-> 版本：target v1.x
+> 状态：已实现 (v1.2.0+)
+> 实现模块：`crates/clausura-core/src/skills.rs` + `crates/clausura-core/src/config.rs`
 
 ## 动机
 
-Clausura 的核心价值是 "LLM 审查 + 确定性门禁"。目前引擎（agent loop、rule engine、SARIF 输出）已经成熟，但**内容层（审查知识）完全由用户从零手写**。每个项目都要自己写 prompt，导致：
+Clausura 的核心价值是 "LLM 审查 + 确定性门禁"。引擎（agent loop、rule engine、SARIF 输出）已经成熟，但**内容层（审查知识）完全由用户从零手写**。每个项目都要自己写 prompt，导致：
 
 - 审查质量取决于开发者的领域知识（初级工程师可能遗漏关键检查项）
 - 相同的审查逻辑无法跨项目复用
@@ -89,11 +89,11 @@ task:
 
 ## Skill 引用解析
 
-| 引用形式 | 解析规则 | 示例 |
-|----------|---------|------|
-| 本地文件路径 | 相对 workspace 或绝对路径 | `./skills/check.md`, `/path/to/skill.md` |
-| 命名引用 | 按顺序查找：`.clausura/skills/<name>/SKILL.md` → `~/.clausura/skills/<name>/SKILL.md` | `team/vue-check` |
-| 远程 URL | HTTPS 下载，缓存到 `.clausura/cache/skills/` | `https://.../security.md` |
+| 引用形式 | 解析规则 | 示例 | 状态 |
+|----------|---------|------|------|
+| 本地文件路径 | 先匹配原样路径，再匹配 workspace 相对路径 | `./skills/check.md`, `/path/to/skill.md` | ✅ 已实现 |
+| 命名引用 | 按顺序查找：`.clausura/skills/<name>/SKILL.md` → `~/.clausura/skills/<name>/SKILL.md` | `team/vue-check` | ✅ 已实现 |
+| 远程 URL | HTTPS 下载，缓存到 `.clausura/cache/skills/` | `https://.../security.md` | ❌ 未实现 |
 
 ## Skill 文件格式
 
@@ -132,6 +132,35 @@ Clausura 读取时：
 <用户 prompt_template>
 ```
 
+当 `prompt_template` 为空或为默认值 `{{task_description}}` 时，用户模板段省略。
+
+## 实现总结
+
+| 模块 | 改动 |
+|------|------|
+| `skills.rs` | 新增模块：`resolve_skill()` 三级解析（本地→workspace→命名引用）、`strip_frontmatter()` YAML frontmatter 剥离、`merge_prompts()` 多 skill 拼接 |
+| `config.rs` | `YamlTaskConfig` 加 `skill_prompts: Vec<String>` 字段；`resolve_config()` 在加载时解析所有 skill 引用并合并到 `prompt_template` |
+| `types.rs` | 无需改动 — skill 内容直接合并到现有的 `prompt_template` 字段 |
+| `agent.rs` | 无需改动 — system prompt 构建逻辑不变 |
+
+### 关键实现细节
+
+**`resolve_skill(name_or_path, workspace)`** — 解析顺序：
+1. 如果 `name_or_path` 作为路径直接存在 → 加载（支持绝对路径和 cwd 相对路径）
+2. 否则拼接到 `workspace` 下 → 如果存在则加载
+3. 否则如果不含 `://` 且非绝对路径 → 作为命名引用查找 `.clausura/skills/` 和 `~/.clausura/skills/`
+4. 以上均失败 → `ConfigError::FileNotFound`
+
+**`strip_frontmatter(content)`** — 剥离逻辑：
+- 检测开头 `---\n`，找到下一个 `\n---\n` 作为结束标记
+- 提取 body 部分并 `trim_start`
+- 无 frontmatter 或格式不正确时返回原内容（不报错，容错处理）
+
+**`merge_prompts(skill_contents, template)`** — 合并格式：
+- 每个 skill 前加 `[Skill: <name>]` 头
+- skill 之间以 `\n\n---\n\n` 分隔
+- 用户 `prompt_template` 追加在末尾（仅当非空且非 `{{task_description}}` 默认值时）
+
 ## 非目标
 
 - ❌ Clausura 不定义自有的 skill 格式
@@ -140,17 +169,9 @@ Clausura 读取时：
 - ❌ 不支持 skill 的热更新或版本管理（先用文件路径，版本用 git tag）
 - ❌ 不支持工具型 skill（依赖外部 CLI/API 的 skill 无法在 Clausura 沙盒中运行）
 
-## 改动范围
-
-| 模块 | 改动 |
-|------|------|
-| `config.rs` | `YamlTaskConfig` 加 `skill_prompts` 字段；加载时解析并合并到 `prompt_template` |
-| `skills.rs` | 新增：skill 文件解析、frontmatter 剥离、多种引用方式的解析 |
-| `types.rs` | 无需改动（skill 内容合并到现有 `prompt_template` 字段） |
-| `agent.rs` | 无需改动（system prompt 构建逻辑不变） |
-
 ## 后续演进
 
+- 远程 skill 的下载与缓存（`https://...` URL 支持）
 - 远程 skill 的版本锁定（`community/security-review@v1.2`）
 - Skill 级别的 tool_allowlist 覆盖
 - `--skill` CLI 快捷参数

--- a/guide.md
+++ b/guide.md
@@ -1,5 +1,7 @@
 # Clausura + Playwright 端到端 CI 实践
 
+> **📖 本教程是独立的长篇实战案例。** 如需查阅结构化文档，请从 [README](README.md) 开始，或直接访问 [docs/guide/](docs/guide/) 目录下的专题文档（哲学、配置、LLM、门禁、场景、CI 集成、Skills、排错）。
+>
 > 适用版本: clausura 1.0.0
 > 仓库: https://github.com/clausura/clausura
 


### PR DESCRIPTION
## Summary

Restructure user documentation from a monolithic README into a focused landing page + 9 dedicated topic guides.

### Changes

**README.md** (589 → 145 lines)
- Rewritten as a focused landing page: overview, philosophy, quick start, doc index

**New: `docs/guide/`** (9 files)
- `overview.md` — design philosophy, core concepts, architecture diagram
- `installation.md` — 4 install methods, upgrade, uninstall
- `llm-providers.md` — 6 vendor types with model recommendations
- `configuration.md` — complete YAML schema, every field explained
- `gating.md` — rule engine logic, 5 design patterns, gradual adoption strategy
- `scenarios.md` — 6 complete runnable configs (security, i18n, architecture, Vue, parallel CI, smart gating)
- `skills.md` — using, installing, creating, composing skills
- `ci-integration.md` — GitHub Actions (3 methods), GitLab CI, Jenkins, generic CI, SARIF upload
- `troubleshooting.md` — 4 exit codes, 8 common issues, 7 debugging strategies

**Updated**
- `docs/skill-as-task.md`: status changed from "设计中" to "已实现 (v1.2.0+)"; added implementation summary; corrected remote URL support status
- `guide.md`: added navigation header pointing to new docs

### Before / After

| | Before | After |
|---|---|---|
| Entry point | 589-line monolithic README | 145-line README + indexed topic guides |
| Design philosophy | Scattered | Dedicated overview.md |
| Config reference | Inline in README | 322-line configuration.md with per-field detail |
| LLM setup | One table | Full provider guide with model selection advice |
| Scenarios | None | 6 complete runnable `.clausura.yaml` examples |
| Troubleshooting | None | 215-line guide covering exit codes through debugging |