### PR TITLE
feat: preflight checks — deterministic LSP diagnostics pipeline before agent loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,123 @@
 # Clausura
 
-CI-native agent CLI for deterministic pipeline gating.
+CI-native agent CLI tool for deterministic pipeline gating.
 
 [![Build](https://img.shields.io/github/actions/workflow/status/liuyanghejerry/Clausura/main.yml?branch=main)](https://github.com/liuyanghejerry/Clausura/actions)
 [![Crates.io](https://img.shields.io/crates/v/clausura-cli)](https://crates.io/crates/clausura-cli)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## What is Clausura?
+## Overview
 
-Clausura runs bounded LLM agent tasks against your codebase in CI/CD pipelines. It extracts structured findings, evaluates them against **deterministic gating rules**, and exits with a clear pass/fail signal — no mid-process questions, no human in the loop.
+Clausura is a platform-agnostic agent CLI tool built for CI/CD pipelines. It runs bounded LLM agent tasks against your codebase, extracts structured findings, evaluates them against deterministic gating rules, and exits with a clear pass/fail signal. No mid-process questions, no human in the loop.
 
-**The LLM finds issues. The rule engine decides if they matter. Your pipeline gets a binary answer.**
+**Key philosophy: closed-loop execution with deterministic gating.** The LLM finds issues. The rule engine decides if they matter. Your pipeline gets a binary answer.
 
-## Design Philosophy
+**Use cases**
 
-Clausura is built on three principles:
+- **Code review gating** -- flag violations in pull requests before merge
+- **Cross-repo consistency checks** -- enforce conventions across multiple repositories
+- **Smart gating** -- fail the pipeline only when findings exceed configured thresholds
+- **i18n extraction and translation** -- scan source files and validate locale coverage
+- **Architecture compliance** -- verify code structure against project conventions
 
-1. **Closed-loop execution.** Every run is bounded by time, token budget, and iteration count. No interactive prompts. No indefinite loops. The agent either finishes cleanly or fails closed.
+## Installation
 
-2. **Deterministic gating.** Findings are evaluated by a pure counting engine — match by rule ID, filter by severity, compare against thresholds. No LLM in the decision path. No heuristics. Result is reproducible.
-
-3. **CI-native.** Auto-detects GitHub Actions, GitLab CI, Jenkins. Outputs SARIF v2.1.0. Exit codes 0/1/2/3 map directly to pipeline status. Designed to run unattended.
-
-→ [Read more about the philosophy and architecture](docs/guide/overview.md)
-
-## Quick Start
-
-### 1. Install
+### Shell script (Linux, macOS, WSL)
 
 ```bash
-# macOS / Linux / WSL
 curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+```
 
-# Or via Cargo
+The script detects your OS and architecture, downloads the latest release from GitHub, verifies the tarball against the release's `checksums.txt` (SHA256), and installs it to `/usr/local/bin` or `~/.local/bin`.
+
+### Cargo
+
+```bash
 cargo install clausura-cli
 ```
 
-→ [All installation options](docs/guide/installation.md)
+### Docker
 
-### 2. Create a config
+```bash
+docker pull ghcr.io/liuyanghejerry/clausura
+docker run --rm -v $(pwd):/workspace ghcr.io/liuyanghejerry/clausura run
+```
 
-Drop `.clausura.yaml` in your project root:
+### From source
+
+```bash
+git clone https://github.com/liuyanghejerry/Clausura.git
+cd clausura
+cargo build --release --package clausura-cli
+# binary at target/release/clausura
+```
+
+### Verify
+
+```bash
+clausura --version
+# clausura 1.0.0 (commit: abc1234, built: 2026-05-23)
+```
+
+## Supported LLM Providers
+
+Clausura supports three vendor categories out of the box:
+
+### 1. OpenAI-compatible
+
+Any LLM that exposes an OpenAI-compatible `/chat/completions` endpoint:
+
+| Shorthand | Base URL | Auth Header |
+|-----------|----------|-------------|
+| `openai` | `https://api.openai.com/v1` | `Authorization: Bearer` |
+| `deepseek` | `https://api.deepseek.com/v1` | `Authorization: Bearer` |
+| `groq` | `https://api.groq.com/openai/v1` | `Authorization: Bearer` |
+| `ollama` | `http://localhost:11434/v1` | `Authorization: Bearer` |
+| (custom) | User-defined | `Authorization: Bearer` |
+
+```yaml
+vendor: deepseek   # shorthand
+# or full config:
+vendor:
+  type: openai_compatible
+  base_url: "https://api.mistral.ai/v1"
+```
+
+### 2. Anthropic-compatible
+
+Claude models via Anthropic's native Messages API:
+
+| Shorthand | Base URL | Auth Header |
+|-----------|----------|-------------|
+| `anthropic` | `https://api.anthropic.com` | `x-api-key` |
+| `claude` | `https://api.anthropic.com` | `x-api-key` |
+
+```yaml
+vendor: anthropic
+model: claude-sonnet-4-20250514
+```
+
+Uses Anthropic's native Messages API (`/v1/messages`) with `x-api-key` auth and `anthropic-version: 2023-06-01`.
+
+### 3. Custom
+
+For enterprise-internal LLMs with non-standard authentication:
+
+```yaml
+vendor:
+  type: custom
+  base_url: "https://llm.internal.company.com/v1"
+  auth_header: "X-API-Key"
+  api_key_env: "INTERNAL_LLM_KEY"
+```
+
+Uses the OpenAI-compatible API format (`/chat/completions`) with configurable base URL and auth header. The `auth_header` defaults to `Authorization`; the `api_key_env` defaults to `CLAUSURA_API_KEY`.
+
+## Quick Start
+
+### 1. Create a configuration file
+
+Create `.clausura.yaml` (or `.clausura.yml`) in your project root:
 
 ```yaml
 version: "1"
@@ -48,107 +125,569 @@ task:
   name: code-review
   model: gpt-4o
   vendor: openai
-  prompt_template: |
-    Review the git diff for:
-    1. SQL injection — any string concatenation in SQL queries
-    2. Hardcoded credentials or secrets
-    3. Missing input validation
-
-    For each finding use:
-    - rule_id: "sql-injection" / "hardcoded-secret" / "missing-validation"
-    - severity: "error" or "warning"
+  prompt_template: "Review the git diff and return findings as JSON."
   token_budget: 16000
+  timeout_secs: 120
+  ambiguity_policy: fail_closed
   gating:
-    - rule: sql-injection
+    - rule: no-critical
+      description: Block on any critical error
       min_severity: error
       max_findings: 0
       action: fail
-    - rule: hardcoded-secret
-      min_severity: error
-      max_findings: 0
-      action: fail
+    - rule: warn-on-warnings
+      description: Warn on excessive warnings
+      min_severity: warning
+      max_findings: 10
+      action: warn
 ```
 
-### 3. Run
+### 2. Set your API key
 
 ```bash
 export CLAUSURA_API_KEY=sk-...
+```
+
+The API key is never read from the YAML config file. It must come from this environment variable or the `--api-key` CLI flag.
+
+### 3. Run the task
+
+```bash
 clausura run
 ```
 
-That's it. Clausura calls the LLM, the LLM reviews your diff, the rule engine evaluates the findings, and you get a pass/fail exit code + SARIF report.
+### 4. Validate config without running
 
-## Documentation
+```bash
+clausura run --validate-config
+clausura run --dry-run  # show the execution plan
+```
 
-| Guide | Content |
-|-------|---------|
-| [Overview & Philosophy](docs/guide/overview.md) | How Clausura works, core concepts, design rationale |
-| [Installation](docs/guide/installation.md) | All install methods: script, Cargo, Docker, from source |
-| [Configuration Reference](docs/guide/configuration.md) | Every YAML field, CLI flag, and environment variable |
-| [LLM Providers](docs/guide/llm-providers.md) | Setting up OpenAI, Anthropic, DeepSeek, Ollama, custom endpoints |
-| [Gating Rules](docs/guide/gating.md) | How rules work, severity levels, designing effective gates |
-| [Skills](docs/guide/skills.md) | Reusing community review skills, composing multiple checks |
-| [Common Scenarios](docs/guide/scenarios.md) | Recipes: security review, i18n check, architecture compliance, Vue/React best practices |
-| [CI Integration](docs/guide/ci-integration.md) | GitHub Actions, GitLab CI, Jenkins, generic CI setup |
-| [Troubleshooting](docs/guide/troubleshooting.md) | Exit codes, common errors, debugging tips |
+### Exit codes
 
-## Use Cases
+| Code | Meaning       | Description                              |
+|------|---------------|------------------------------------------|
+| 0    | Pass          | All gating rules satisfied               |
+| 1    | Fail          | A rule with `action: fail` was violated  |
+| 2    | Error         | Runtime error (provider, timeout, etc.), or an incomplete agent run with `on_incomplete: fail` |
+| 3    | Config error  | Invalid configuration                    |
 
-- **Code review gating** — flag SQL injection, hardcoded secrets, missing validation before merge
-- **Cross-repo consistency** — enforce naming conventions, directory structure, dependency policies
-- **i18n completeness** — scan for hardcoded strings, missing translation keys, locale drift
-- **Architecture compliance** — verify layering, import direction, forbidden patterns
-- **Smart gating** — fail only when findings exceed configurable thresholds
+## Using Skills
 
-→ [See all scenarios with complete configs](docs/guide/scenarios.md)
+Clausura 1.2.0+ can reuse community skill files (Markdown) as review prompts. Skills answer "what and how to review", while gating rules answer "how many findings is too many" — the two are cleanly separated.
 
-## Exit Codes
+### Skill file format
 
-| Code | Meaning | When |
-|------|---------|------|
-| 0 | Pass | All gating rules satisfied |
-| 1 | Fail | A rule with `action: fail` was violated |
-| 2 | Error | Runtime error (timeout, provider failure, incomplete run) |
-| 3 | Config | Invalid configuration |
+A skill is a Markdown file, optionally with YAML frontmatter:
 
-## Supported LLM Providers
+```markdown
+---
+name: security-review
+description: 检查 SQL 注入、XSS、硬编码密钥
+---
 
-OpenAI · Anthropic (Claude) · DeepSeek · Groq · Ollama · Custom (any OpenAI-compatible endpoint)
+# 安全代码审查
 
-→ [Full provider setup guide](docs/guide/llm-providers.md)
+## SQL 注入
+- 任何字符串拼接构造的 SQL 查询
+- rule_id: `sql-injection`
+- severity: `error`
+```
+
+The frontmatter is stripped automatically; only the Markdown body is injected into the agent's system prompt.
+
+### Referencing skills
+
+```yaml
+task:
+  skill_prompts:
+    # Local file (relative to workspace or absolute)
+    - ./skills/security-review.md
+
+    # Named skill (looks in .clausura/skills/<name>/SKILL.md,
+    # then ~/.clausura/skills/<name>/SKILL.md)
+    - security-review
+    - team/vue-best-practices
+
+  # Optional: append your own extra instructions
+  prompt_template: |
+    另外检查：禁止 console.log
+
+  gating:
+    - rule: sql-injection
+      max_findings: 0
+      action: fail
+```
+
+### Installing community skills
+
+```bash
+# Project-level (only this repo)
+mkdir -p .clausura/skills/security-review
+cp ~/Downloads/security-review-SKILL.md .clausura/skills/security-review/SKILL.md
+
+# User-level (available to all your projects)
+mkdir -p ~/.clausura/skills/team/vue-check
+cp ~/Downloads/vue-check-SKILL.md ~/.clausura/skills/team/vue-check/SKILL.md
+```
+
+See [`examples/`](examples/) for ready-to-use skill files and a sample configuration.
+
+## Configuration Reference
+
+### YAML schema
+
+All fields for `.clausura.yaml`:
+
+```yaml
+version: "1"                         # Required. Schema version.
+task:
+  name: my-task                      # Required. Task name.
+
+  # LLM provider
+  model: gpt-4o                      # Required (or set CLAUSURA_MODEL).
+  vendor: openai                     # Shorthand (backward compatible).
+  # Or with full config:
+  vendor:
+    type: openai_compatible          # openai_compatible | anthropic_compatible | custom
+    base_url: "https://api.deepseek.com/v1"  # Optional. Override API endpoint.
+    auth_header: "X-API-Key"         # Optional. For custom auth (default: Authorization).
+    api_key_env: "MY_SECRET_KEY"     # Optional. Env var for API key (default: CLAUSURA_API_KEY).
+
+  # Prompt
+  prompt_template: "{{task_description}}"  # Default. The agent's system prompt.
+  skill_prompts: []                           # Optional. Reuse community skill files.
+                                               # Supports local paths, named references,
+                                               # and remote URLs.
+
+  # Limits
+  token_budget: 32000                # Default. Context-window budget: older messages are
+                                     # truncated (and archived) when the conversation
+                                     # approaches this size.
+  max_total_tokens: 200000           # Optional. Cap on cumulative billed tokens across all
+                                     # LLM calls in one run; the run stops (marked incomplete)
+                                     # when reached. Unset means no cap.
+  timeout_secs: 300                  # Default. Max wall-clock time in seconds.
+  max_iterations: 10                 # Default. Max agent loop iterations.
+  shell_timeout_secs: 120            # Default. Per-command timeout for shell_exec.
+
+  # Optional tool allowlist
+  tool_allowlist:                    # Restrict shell commands to these argv prefixes.
+    - git status                     # "git status" allows that subcommand tree only.
+    - cargo test                     # A bare name (e.g. "git") allows all subcommands.
+  shell_env_passthrough: []          # Default. Extra env vars forwarded to shell_exec
+                                     # commands (exact names only; secret-looking names
+                                     # like *_KEY / *_TOKEN are refused).
+
+  # Safety
+  ambiguity_policy: fail_closed      # "fail_closed" or "proceed_with_caution".
+  on_incomplete: fail                # "fail" (exit 2, default) or "pass" (continue with
+                                     # partial results, marked incomplete in logs and SARIF).
+                                     # Applies when the agent loop ends without a clean stop
+                                     # (context truncated or iteration limit reached).
+
+  # Gating rules
+  gating:                            # Optional. Evaluated in order.
+    - rule: no-critical
+      description: "No critical errors"
+      min_severity: error
+      max_findings: 0
+      action: fail
+```
+
+**Gating rule fields:**
+
+| Field         | Type   | Description                                      |
+|---------------|--------|--------------------------------------------------|
+| `rule`        | string | Rule ID. Findings with matching `rule_id` count. |
+| `description` | string | Human-readable description.                      |
+| `min_severity`| string | Minimum severity: `hint`, `info`, `warning`, `error`. |
+| `max_findings`| number | Maximum allowed findings at or above this severity. |
+| `action`      | string | `fail` (exit 1), `warn` (log only), `ignore` (skip). |
+
+### Environment variables
+
+| Variable                | Overrides            |
+|-------------------------|----------------------|
+| `CLAUSURA_API_KEY`      | API key (required)   |
+| `CLAUSURA_MODEL`        | `task.model`         |
+| `CLAUSURA_VENDOR`       | `task.vendor`        |
+| `CLAUSURA_AMBIGUITY_POLICY` | `task.ambiguity_policy` |
+| `CLAUSURA_ON_INCOMPLETE` | `task.on_incomplete` |
+| `CLAUSURA_TOKEN_BUDGET` | `task.token_budget`  |
+| `CLAUSURA_MAX_TOTAL_TOKENS` | `task.max_total_tokens` |
+| `CLAUSURA_TIMEOUT`      | `task.timeout_secs`  |
+| `CLAUSURA_SHELL_TIMEOUT` | `task.shell_timeout_secs` |
+| `CLAUSURA_MAX_ITERATIONS` | `task.max_iterations` |
+
+Config loading priority: YAML file < CLI flags < environment variables.
+
+### CLI flags
+
+```
+clausura run [OPTIONS]
+
+  -c, --config <PATH>       Config file path          [default: .clausura.yaml]
+      --model <MODEL>       Override LLM model
+      --vendor <VENDOR>     Override LLM vendor
+      --api-key <KEY>       API key
+      --token-budget <N>    Token budget override
+      --timeout <SECS>      Timeout override
+      --max-iterations <N>  Max agent loop iterations  [default: 10]
+      --shell-timeout <SECS>  Per-command shell_exec timeout  [default: 120]
+      --workspace <PATH>    Workspace root            [default: cwd]
+      --output <PATH>       SARIF output path          [default: clausura-output.sarif]
+      --resume              Resume from last checkpoint
+      --log-format <FMT>    Log format (json|pretty)   [default: json]
+      --dry-run             Validate config and print the execution plan
+      --validate-config     Validate config and exit
+```
+
+Checkpoint management:
+
+```
+clausura snapshot list [--thread <ID>] [--limit <N>]    List checkpoints (default: all threads, 10 max)
+clausura snapshot show [--thread <ID>]                  Show the latest checkpoint
+clausura snapshot show --id <UUID> [--thread <ID>]     Show a specific checkpoint
+clausura snapshot delete --thread <ID>                  Delete all checkpoints for a thread
+```
 
 ## CI Integration
 
+Clausura auto-detects your CI environment using well-known environment variables. It gathers repo, PR number, commit SHA, and branch context for template rendering and SARIF output.
+
+### Detection order
+
+1. `GITHUB_ACTIONS` -> GitHub Actions
+2. `GITLAB_CI` -> GitLab CI
+3. `JENKINS_URL` -> Jenkins
+4. `CI=true` or `CI=1` -> Generic CI
+5. Otherwise -> Local
+
+### GitHub Actions
+
+Use the composite action directly:
+
 ```yaml
-# GitHub Actions
 - uses: liuyanghejerry/Clausura@v1
   with:
     config: .clausura.yaml
     api_key: ${{ secrets.LLM_API_KEY }}
+    model: gpt-4o
+    vendor: openai
+    token_budget: 32000
+    timeout: 300
+    version: latest        # optional: release version to install (e.g. "1.0.8", default "latest")
 ```
 
-Also supports GitLab CI, Jenkins, and generic CI via environment variables.
+The action downloads the matching release binary for the runner's OS/arch (Linux and macOS, x86_64 and aarch64), verifies it against the release's SHA256 `checksums.txt`, and adds it to `PATH` before running.
 
-→ [All CI platforms](docs/guide/ci-integration.md)
+Or run via the binary:
+
+```yaml
+- name: Run Clausura
+  run: clausura run
+  env:
+    CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+```
+
+### GitLab CI
+
+```yaml
+clausura-review:
+  image: ghcr.io/liuyanghejerry/clausura:latest
+  script:
+    - clausura run
+  variables:
+    CLAUSURA_API_KEY: $LLM_API_KEY
+    CLAUSURA_MODEL: "gpt-4o"
+```
+
+### Jenkins
+
+```groovy
+stage('Code Review') {
+    environment {
+        CLAUSURA_API_KEY = credentials('llm-api-key')
+    }
+    steps {
+        sh 'clausura run --model gpt-4o'
+    }
+}
+```
+
+### Generic CI
+
+Set `CI=true` and the relevant `CI_*` environment variables:
+
+```bash
+export CI=true
+export CLAUSURA_API_KEY=sk-...
+clausura run
+```
+
+Custom context variables for Generic CI: `CI_REPO`, `CI_PR_NUMBER`, `CI_COMMIT_SHA`, `CI_BRANCH`.
+
+### Supported platforms
+
+Clausura supports Linux and macOS. **Windows is not supported** (a documented non-goal, not "not yet") — on Windows, run Clausura under WSL2 or use the Docker image instead.
+
+## MCP Integration
+
+Clausura can connect to external servers through the **Model Context Protocol (MCP)**, a standardized JSON-RPC-based protocol for LLM tool discovery and invocation.
+
+### Configuration
+
+Declare MCP servers in your `.clausura.yaml`:
+
+```yaml
+task:
+  mcp_servers:
+    - name: lsp
+      command: agent-lsp
+      args: []
+    - name: github
+      command: npx
+      args: ["-y", "@anthropic/mcp-server-github"]
+      env:
+        GITHUB_TOKEN: "${GITHUB_TOKEN}"
+```
+
+Clausura spawns each server at task start, performs the MCP initialize handshake, discovers available tools via `tools/list`, and registers them as `mcp__<server>__<tool>` in the agent's tool list.
+
+### Preflight checks
+
+Before the agent loop runs, you can configure "preflight" MCP tool calls whose output is parsed into deterministic `Finding` objects and passed directly through the gating rule engine — bypassing the LLM entirely. This is ideal for LSP diagnostics:
+
+```yaml
+task:
+  mcp_servers:
+    - name: lsp
+      command: agent-lsp
+
+  preflight:
+    - mcp_server: lsp
+      tool: get_diagnostics
+      args:
+        path: "."
+      rule_id_prefix: "lsp-"
+
+  gating:
+    - rule: lsp-error
+      min_severity: error
+      max_findings: 0
+      action: fail
+```
+
+Preflight findings are also summarized in the agent's context so the LLM-aware review can build on them.
+
+### LSP code intelligence
+
+For semantic code analysis beyond diagnostics, pair MCP with a skill guide:
+
+```yaml
+task:
+  skill_prompts:
+    - examples/skills/code-review-with-lsp/SKILL.md
+```
+
+The skill tells the agent to use LSP tools — `hover`, `definition`, `references`, `symbols` — for type information, navigation, and impact analysis.
+
+### CI environment setup
+
+MCP servers need to be installed in your CI environment. For LSP support with `agent-lsp`:
+
+```dockerfile
+# Docker example
+FROM rust:latest
+
+# Install Clausura
+RUN curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+
+# Install agent-lsp (MCP → LSP bridge)
+RUN curl -fsSL https://raw.githubusercontent.com/blackwell-systems/agent-lsp/main/install.sh | sh
+
+# Install language servers per project language
+RUN rustup component add rust-analyzer
+RUN npm i -g typescript-language-server
+RUN pip install pyright
+```
+
+For GitHub Actions:
+
+```yaml
+- uses: liuyanghejerry/Clausura@v1
+  with:
+    config: .clausura.yaml
+    api_key: ${{ secrets.LLM_API_KEY }}
+
+- name: Install agent-lsp
+  run: curl -fsSL https://raw.githubusercontent.com/blackwell-systems/agent-lsp/main/install.sh | sh
+
+- name: Install language servers
+  run: |
+    rustup component add rust-analyzer
+    npm i -g typescript-language-server
+    pip install pyright
+
+- name: Run review with LSP
+  run: clausura run
+  env:
+    CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+```
+
+## Architecture
+
+### Agent loop (reason -> act -> observe)
+
+Clausura runs a bounded agent loop of up to `max_iterations` iterations (default 10, configurable via YAML, `--max-iterations`, or `CLAUSURA_MAX_ITERATIONS`). Each iteration:
+
+1. Sends the conversation (system prompt + accumulated messages) to the LLM
+2. If the LLM calls a tool, executes it and feeds the result back
+3. If the LLM responds with structured findings and signals `stop`, the loop ends
+4. The loop also ends on token budget exhaustion, timeout, or content filter
+
+The system prompt is built from `prompt_template` plus available tool definitions. The LLM is instructed to respond in JSON with a `findings` array.
+
+### Context truncation and archiving
+
+When the conversation exceeds the configured `token_budget`, Clausura automatically truncates older messages to stay within limits. Dropped messages are not silently discarded — they are archived to `.clausura/archives/context-dump-{task_id}-{seq}.log` inside the workspace as JSON lines. A hint message is injected into the conversation telling the LLM where to find the archived context, so it can retrieve earlier findings via the `read_file` tool if needed.
+
+On successful completion (exit code 0), archive files are automatically cleaned up. On failure (exit code 1-3), they are preserved for debugging and audit.
+
+### Incomplete runs fail closed
+
+If the agent loop ends without a clean stop — the context could not be truncated further, the model hit a length limit, the `max_total_tokens` cap was reached, or `max_iterations` was exhausted — the extracted findings may be partial. By default (`on_incomplete: fail`) Clausura fails closed: the run exits with code 2 and a clear error message, so an incomplete review can never silently pass a `max_findings: 0` gate. With `on_incomplete: pass`, the previous behavior is kept (gating rules evaluate the partial findings), but a warning is logged and the SARIF output is annotated with `"properties": {"incomplete": true}` on the run.
+
+### Deterministic rule engine
+
+Findings from the agent are evaluated by the rule engine using pure counting:
+
+- Match findings to rules by `rule_id`
+- Filter by severity threshold
+- Count violations above `max_findings`
+- Apply action: `fail` exits 1, `warn` logs, `ignore` skips
+
+No LLM calls, no heuristics. Just deterministic logic your pipeline can trust.
+
+### LLM provider abstraction
+
+Three vendor categories: OpenAI-compatible (works with OpenAI, DeepSeek, Groq, Ollama, vLLM, Mistral), Anthropic-compatible (native Claude Messages API), and Custom (configurable enterprise endpoints). Factory function `create_provider()` dispatches on vendor type.
+
+Each LLM request has its own per-request timeout (default 120s), independent of the task's overall wall-clock `timeout_secs`. Failed requests are retried with exponential backoff (up to 3 retries by default) on HTTP 429, 5xx, and network errors — the `Retry-After` response header is honored when present. Other 4xx responses (e.g. 401, 400) fail immediately without retrying.
+
+### Tool sandboxing
+
+Five built-in tools:
+
+| Tool          | Description                                      | Restrictions                           |
+|---------------|--------------------------------------------------|----------------------------------------|
+| `read_file`   | Read a file relative to workspace root, with optional `offset`/`limit` for line-range reading | Blocks absolute paths, `..` traversal, symlink escapes |
+| `list_files`  | List directory contents, with recursive depth, glob filtering, and optional file sizes | Sandboxed to workspace; skips `.clausura/` |
+| `grep`        | Search text patterns across files with literal or regex mode, extension filtering, and binary-skip | Auto-excludes `.git`, `target`, `.clausura`, `node_modules` |
+| `git_diff`    | Run `git diff` with optional base ref or staged  | Operates inside workspace only         |
+| `shell_exec`  | Execute an allowed command (argv form, no shell) | Restricted to `tool_allowlist` argv prefixes; dangerous flags denied; scrubbed env |
+
+The `shell_exec` tool is locked by default (empty allowlist = no commands). Explicitly list allowed commands to enable it. It takes an `argv` array (e.g. `{"argv": ["git", "status"]}`) and executes `argv[0]` directly **without a shell** — shell metacharacters like `;`, `|`, `$()` or `>` are passed through as literal arguments and have no effect, so they cannot be used to bypass the allowlist. Commands run with `current_dir` set to the workspace root, but allowed commands can access paths outside the workspace via arguments.
+
+**Allowlist prefix rules.** Each `tool_allowlist` entry is an argv prefix split on whitespace: an invocation is allowed when its leading tokens equal a rule's tokens. `"git status"` allows `["git", "status"]` and `["git", "status", "--short"]`, but not `["git", "log"]`. A bare program name (e.g. `"git"`) is a length-1 prefix and allows all subcommands of that program (backward compatible). The rule's first token also matches by basename, so `["/usr/bin/git", "status"]` satisfies a `"git status"` rule.
+
+**Dangerous-flag denylist.** On top of the allowlist, known-risky flags are rejected regardless of position (scanning stops at the first `--`, whose following tokens are operands): `git -c`, `git --exec-path`, `git --git-dir`, `git --work-tree`, `tar --checkpoint-action`, `tar --to-command`. Both exact and attached forms are caught (`-c foo`, `-cfoo`, `--git-dir=/x`).
+
+**Environment scrubbing.** Commands run with a minimal, deny-by-default environment: a fixed `PATH` (`/usr/local/bin:/usr/bin:/bin`, plus `$HOME/.cargo/bin` if it exists), `HOME`/`TERM`/`LANG`/`TMPDIR`/`CI` forwarded when present, and safety overrides (`GIT_PAGER=cat`, `PAGER=cat`, `GIT_CONFIG_NOSYSTEM=1`, `GIT_TERMINAL_PROMPT=0`, `GIT_EDITOR=:`, `EDITOR=:`). Everything else — including `CLAUSURA_API_KEY`, `LD_PRELOAD`, `GIT_SSH_COMMAND`, `SSH_AUTH_SOCK`, `BASH_ENV` — is dropped. `shell_env_passthrough` can forward additional variables by exact name; `CLAUSURA_API_KEY` and names ending in `_KEY`, `_TOKEN`, `_SECRET` or `_PASSWORD` are refused with a warning.
+
+**Per-command timeout.** Each command is killed after `shell_timeout_secs` (default 120; override with `--shell-timeout` or `CLAUSURA_SHELL_TIMEOUT`) and the tool returns a `Command timed out after Ns and was killed` result.
+
+Tool outputs are truncated at 32 KB or 1000 lines (whichever comes first) to stay within token budgets; a `[output truncated ...]` marker is appended when this happens — narrow the query or use `read_file`'s `offset`/`limit` to page through large outputs.
+
+### Memory snapshots (SQLite checkpoints)
+
+On every run, the agent's message history is serialized (MessagePack) and saved to `~/.clausura/checkpoints.db`. You can resume a truncated or interrupted run with `--resume`. Snapshots include a thread ID, version number, and truncation flag.
+
+Note that checkpoints live under the user's home directory (`~/.clausura/`), not the workspace. In ephemeral CI containers without a persistent home/volume, checkpoints do not survive between runs, so `--resume` has nothing to restore from.
+
+Use `clausura snapshot list` and `clausura snapshot show` to inspect saved state.
+
+### SARIF output
+
+Findings are written to `clausura-output.sarif` (or the path from `--output`) in SARIF v2.1.0 format. This integrates with GitHub Advanced Security, CodeQL, and other SARIF-compatible tools.
 
 ## Development
 
+### Build
+
 ```bash
-# Build
+# Debug build
+cargo build
+
+# Release build (recommended for production)
 cargo build --release --package clausura-cli
-
-# Run tests
-cargo test --workspace
-
-# Format (pre-commit hook enforces this)
-cargo fmt --all
-
-# Lint
-cargo clippy --workspace -- -D warnings
 ```
 
-See [RELEASE.md](RELEASE.md) for release procedures.
+### Run tests
+
+```bash
+cargo test --workspace
+```
+
+### Pre-commit hook
+
+A `cargo fmt` pre-commit hook is included. Enable it after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Commits with misformatted Rust code will be rejected. Run `cargo fmt --all` to auto-fix.
+
+### Project structure
+
+```
+clausura/
+  Cargo.toml                    # Workspace root
+  crates/
+    clausura-core/              # Core library
+      src/
+        lib.rs                  # Crate root (module re-exports)
+        agent.rs                # Agent loop (reason -> act -> observe)
+        build_info.rs           # Version and commit metadata
+        checkpoint.rs           # SQLite checkpoint store
+        ci.rs                   # CI environment detection
+        config.rs               # Layered config loader (YAML + CLI + env)
+        context.rs              # Token budget tracking, context truncation, and archiving
+        executor.rs             # Task lifecycle orchestrator
+        logging.rs              # Structured logging (JSON or pretty)
+        provider.rs             # LLM provider (OpenAI/Anthropic/Custom + factory)
+        rules.rs                # Deterministic rule engine for gating
+        sarif.rs                # SARIF v2.1.0 output formatter
+        snapshot.rs             # Snapshot manager (save/restore)
+        tools.rs                # Tool sandbox (read_file, git_diff, shell_exec, list_files, grep)
+        types.rs                # Core type definitions
+    clausura-cli/               # CLI binary
+      src/
+        main.rs                 # CLI entry point (clap)
+        commands/
+          mod.rs                # Commands module
+          run.rs                # clausura run command
+          snapshot.rs           # clausura snapshot command
+  action.yml                    # GitHub Action definition
+  Dockerfile                    # Multi-stage Docker build (alpine, musl)
+  install.sh                    # Release install script
+```
+
+### Dependencies
+
+- **CLI**: clap (arg parsing), colored + atty (terminal output)
+- **Core**: tokio (async), serde/serde_json/serde_yaml (serialization), reqwest (HTTP), tiktoken-rs (token counting), rusqlite (checkpoints), rmp-serde (binary serialization), regex-lite (grep pattern matching)
+- **LLM**: OpenAI-compatible chat completions API (works with OpenAI, DeepSeek, Groq, Ollama, etc.)
 
 ## License
 
 MIT. See [LICENSE](LICENSE).
+
+## Links
+
+- [GitHub](https://github.com/liuyanghejerry/Clausura)
+- [Issues](https://github.com/liuyanghejerry/Clausura/issues)
+- [Releases](https://github.com/liuyanghejerry/Clausura/releases)
+- [Docker images](https://github.com/liuyanghejerry/Clausura/pkgs/container/clausura)

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -390,6 +390,7 @@ mod tests {
             max_iterations: 10,
             on_incomplete: OnIncompletePolicy::Fail,
             mcp_servers: vec![],
+            preflight: vec![],
         }
     }
 

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -90,6 +90,8 @@ struct YamlTaskConfig {
     on_incomplete: String,
     #[serde(default)]
     mcp_servers: Vec<YamlMcpServerConfig>,
+    #[serde(default)]
+    preflight: Vec<YamlPreflightCheck>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -109,6 +111,28 @@ struct YamlMcpServerConfig {
     args: Vec<String>,
     #[serde(default)]
     env: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YamlPreflightCheck {
+    mcp_server: String,
+    tool: String,
+    #[serde(default)]
+    args: serde_json::Value,
+    #[serde(default)]
+    rule_id_prefix: Option<String>,
+    #[serde(default)]
+    severity_field: Option<String>,
+    #[serde(default)]
+    message_field: Option<String>,
+    #[serde(default)]
+    file_field: Option<String>,
+    #[serde(default)]
+    line_field: Option<String>,
+    #[serde(default)]
+    column_field: Option<String>,
+    #[serde(default)]
+    default_severity: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -303,6 +327,7 @@ impl Config {
                     max_iterations: default_max_iterations(),
                     on_incomplete: default_on_incomplete(),
                     mcp_servers: vec![],
+                    preflight: vec![],
                 },
                 None,
             )
@@ -417,6 +442,25 @@ impl Config {
                         command: s.command,
                         args: s.args,
                         env: s.env,
+                    })
+                    .collect(),
+                preflight: yaml_task
+                    .preflight
+                    .into_iter()
+                    .map(|p| {
+                        let d = crate::types::PreflightCheck::default();
+                        crate::types::PreflightCheck {
+                            mcp_server: p.mcp_server,
+                            tool: p.tool,
+                            args: p.args,
+                            rule_id_prefix: p.rule_id_prefix.unwrap_or(d.rule_id_prefix),
+                            severity_field: p.severity_field.unwrap_or(d.severity_field),
+                            message_field: p.message_field.unwrap_or(d.message_field),
+                            file_field: p.file_field.unwrap_or(d.file_field),
+                            line_field: p.line_field.unwrap_or(d.line_field),
+                            column_field: p.column_field.unwrap_or(d.column_field),
+                            default_severity: p.default_severity.unwrap_or(d.default_severity),
+                        }
                     })
                     .collect(),
             },
@@ -1794,5 +1838,105 @@ task:
         assert!(result.is_err());
         let err_msg = format!("{}", result.unwrap_err());
         assert!(err_msg.contains("Duplicate"), "got: {err_msg}");
+    }
+
+    #[test]
+    fn test_preflight_config_parsing() {
+        let yaml = r#"
+version: "1"
+task:
+  name: preflight-test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  mcp_servers:
+    - name: diag
+      command: agent-lsp
+  preflight:
+    - mcp_server: diag
+      tool: get_diagnostics
+      args:
+        path: "."
+      rule_id_prefix: "lsp-"
+      severity_field: "severity"
+      message_field: "message"
+      file_field: "file"
+      line_field: "line"
+      default_severity: "warning"
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.preflight.len(), 1);
+        let check = &config.task.preflight[0];
+        assert_eq!(check.mcp_server, "diag");
+        assert_eq!(check.tool, "get_diagnostics");
+        assert_eq!(check.rule_id_prefix, "lsp-");
+        assert_eq!(check.severity_field, "severity");
+        assert_eq!(check.message_field, "message");
+        assert_eq!(check.file_field, "file");
+        assert_eq!(check.line_field, "line");
+        assert_eq!(check.default_severity, "warning");
+    }
+
+    #[test]
+    fn test_preflight_config_defaults() {
+        let yaml = r#"
+version: "1"
+task:
+  name: preflight-min
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  mcp_servers:
+    - name: diag
+      command: agent-lsp
+  preflight:
+    - mcp_server: diag
+      tool: get_diagnostics
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert_eq!(config.task.preflight.len(), 1);
+        let check = &config.task.preflight[0];
+        assert_eq!(check.mcp_server, "diag");
+        assert_eq!(check.tool, "get_diagnostics");
+        // All field mappings should use defaults
+        assert_eq!(check.rule_id_prefix, "preflight-");
+        assert_eq!(check.severity_field, "severity");
+        assert_eq!(check.message_field, "message");
+        assert_eq!(check.file_field, "file");
+        assert_eq!(check.default_severity, "warning");
     }
 }

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -61,6 +61,11 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
         mgr.register_all(&mut tools);
     }
 
+    // ── LSP tool hint injection ────────────────────────────────────────────
+    // When the agent has access to LSP-like MCP tools, generate a guidance
+    // note that will be injected into initial_messages.
+    let lsp_hint = detect_lsp_tools(&tools);
+
     // ── Preflight checks ──────────────────────────────────────────────────
     // Run configured MCP tool calls *before* the agent loop. Their output is
     // parsed into deterministic Findings and merged with agent findings.
@@ -135,6 +140,11 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
     // Inject preflight summary into agent context (if any findings).
     if let Some(summary) = preflight_summary {
         initial_messages.insert(0, Message::new(Role::User, summary));
+    }
+
+    // Inject LSP tool guidance into agent context (if LSP tools detected).
+    if let Some(hint) = &lsp_hint {
+        initial_messages.push(Message::new(Role::User, hint.clone()));
     }
 
     let agent_config = AgentConfig {
@@ -387,6 +397,54 @@ fn format_preflight_summary(findings: &[Finding]) -> String {
     buf
 }
 
+/// Detect if any registered tools provide LSP-like capabilities and return
+/// a guidance hint for the agent.
+///
+/// Scans tool names for common LSP-related keywords. When found, injects
+/// a short usage guide so the agent prioritizes semantic tools over text
+/// grep for code understanding.
+fn detect_lsp_tools(registry: &crate::tools::ToolRegistry) -> Option<String> {
+    let defs = registry.list_definitions();
+    let lsp_keywords = ["diagnostics", "hover", "references", "definition", "symbol", "lsp"];
+    let has_lsp_tool = defs.iter().any(|t| {
+        let name = t.name.to_lowercase();
+        lsp_keywords.iter().any(|kw| name.contains(kw))
+    });
+
+    if !has_lsp_tool {
+        return None;
+    }
+
+    // Collect tool names for the user message.
+    let mut tool_lines: Vec<String> = Vec::new();
+    for t in &defs {
+        let name_lower = t.name.to_lowercase();
+        if lsp_keywords.iter().any(|kw| name_lower.contains(kw)) {
+            tool_lines.push(format!("  - `{}` — {}", t.name, t.description));
+        }
+    }
+
+    let tools_section = tool_lines.join("\n");
+    Some(format!(
+        r#"📐 LSP Code Intelligence Tools Available
+
+The following language-server tools are at your disposal. Prefer them over
+plain `grep`/`read_file` when you need semantic understanding of the code:
+
+{tools_section}
+
+When to use each tool:
+- **diagnostics** — check for compile errors, type mismatches, lints
+- **hover** — get type information and documentation for a symbol
+- **definition** — jump to a symbol's definition
+- **references** — find all usages of a symbol across the codebase
+- **symbols** — list all symbols in a file or workspace
+
+Use these tools to answer questions about code structure and correctness
+before reaching for text-based searches."#,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -626,5 +684,14 @@ mod tests {
         assert!(summary.contains("Preflight diagnostics"));
         assert!(summary.contains("src/main.rs:42"));
         assert!(summary.contains("Something failed"));
+    }
+
+    #[test]
+    fn test_detect_lsp_tools_no_lsp_tools_returns_none() {
+        // Only built-in tools (read_file, git_diff, etc.) — no LSP hint.
+        let tmp = TempDir::new().unwrap();
+        let registry = default_tools(tmp.path().to_path_buf(), &[], 120, &[]);
+        let hint = detect_lsp_tools(&registry);
+        assert!(hint.is_none(), "no LSP tools configured → no hint");
     }
 }

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -80,7 +80,10 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
                     tool = %check.tool,
                     "Running preflight check"
                 );
-                match mgr.call_tool(&check.mcp_server, &check.tool, check.args.clone()).await {
+                match mgr
+                    .call_tool(&check.mcp_server, &check.tool, check.args.clone())
+                    .await
+                {
                     Ok(output) => {
                         let findings = parse_preflight_result(&output, check);
                         all_items.extend(findings);
@@ -391,7 +394,11 @@ fn format_preflight_summary(findings: &[Finding]) -> String {
             .as_ref()
             .map(|l| format!("{}:{}", l.file, l.line_start))
             .unwrap_or_default();
-        let _ = writeln!(buf, "  [{:?}][{}] {} — {}", f.severity, f.rule_id, f.message, loc);
+        let _ = writeln!(
+            buf,
+            "  [{:?}][{}] {} — {}",
+            f.severity, f.rule_id, f.message, loc
+        );
     }
     buf.push_str("\nConsider these findings in your review.");
     buf
@@ -405,7 +412,14 @@ fn format_preflight_summary(findings: &[Finding]) -> String {
 /// grep for code understanding.
 fn detect_lsp_tools(registry: &crate::tools::ToolRegistry) -> Option<String> {
     let defs = registry.list_definitions();
-    let lsp_keywords = ["diagnostics", "hover", "references", "definition", "symbol", "lsp"];
+    let lsp_keywords = [
+        "diagnostics",
+        "hover",
+        "references",
+        "definition",
+        "symbol",
+        "lsp",
+    ];
     let has_lsp_tool = defs.iter().any(|t| {
         let name = t.name.to_lowercase();
         lsp_keywords.iter().any(|kw| name.contains(kw))
@@ -651,7 +665,7 @@ mod tests {
     fn test_parse_severity_str() {
         assert_eq!(parse_severity_str("error"), Severity::Error);
         assert_eq!(parse_severity_str("ERROR"), Severity::Error);
-        assert_eq!(parse_severity_str("1"), Severity::Error);     // LSP convention
+        assert_eq!(parse_severity_str("1"), Severity::Error); // LSP convention
         assert_eq!(parse_severity_str("warning"), Severity::Warning);
         assert_eq!(parse_severity_str("2"), Severity::Warning);
         assert_eq!(parse_severity_str("warn"), Severity::Warning);
@@ -664,22 +678,20 @@ mod tests {
 
     #[test]
     fn test_format_preflight_summary() {
-        let findings = vec![
-            Finding {
-                id: uuid::Uuid::new_v4(),
-                rule_id: "test-err".into(),
-                severity: Severity::Error,
-                message: "Something failed".into(),
-                location: Some(crate::types::Location {
-                    file: "src/main.rs".into(),
-                    line_start: 42,
-                    line_end: 42,
-                    column_start: 1,
-                    column_end: 1,
-                }),
-                evidence: "".into(),
-            },
-        ];
+        let findings = vec![Finding {
+            id: uuid::Uuid::new_v4(),
+            rule_id: "test-err".into(),
+            severity: Severity::Error,
+            message: "Something failed".into(),
+            location: Some(crate::types::Location {
+                file: "src/main.rs".into(),
+                line_start: 42,
+                line_end: 42,
+                column_start: 1,
+                column_end: 1,
+            }),
+            evidence: "".into(),
+        }];
         let summary = format_preflight_summary(&findings);
         assert!(summary.contains("Preflight diagnostics"));
         assert!(summary.contains("src/main.rs:42"));

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -6,7 +6,10 @@ use crate::rules::RuleEngine;
 use crate::sarif::SarifFormatter;
 use crate::snapshot::SnapshotManager;
 use crate::tools::default_tools;
-use crate::types::{ExecutionReport, Message, OnIncompletePolicy, ProviderError, Role, Usage};
+use crate::types::{
+    ExecutionReport, Finding, Message, OnIncompletePolicy, PreflightCheck, ProviderError, Role,
+    Severity, Usage,
+};
 use std::path::Path;
 use std::time::Instant;
 
@@ -58,6 +61,43 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
         mgr.register_all(&mut tools);
     }
 
+    // ── Preflight checks ──────────────────────────────────────────────────
+    // Run configured MCP tool calls *before* the agent loop. Their output is
+    // parsed into deterministic Findings and merged with agent findings.
+    let mut preflight_findings: Vec<Finding> = Vec::new();
+    let mut preflight_summary: Option<String> = None;
+    if let Some(ref mgr) = _mcp_manager {
+        if !config.task.preflight.is_empty() {
+            let mut all_items: Vec<Finding> = Vec::new();
+            for check in &config.task.preflight {
+                tracing::info!(
+                    server = %check.mcp_server,
+                    tool = %check.tool,
+                    "Running preflight check"
+                );
+                match mgr.call_tool(&check.mcp_server, &check.tool, check.args.clone()).await {
+                    Ok(output) => {
+                        let findings = parse_preflight_result(&output, check);
+                        all_items.extend(findings);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            server = %check.mcp_server,
+                            tool = %check.tool,
+                            error = %e,
+                            "Preflight check failed — skipping"
+                        );
+                    }
+                }
+            }
+            if !all_items.is_empty() {
+                let summary = format_preflight_summary(&all_items);
+                preflight_summary = Some(summary);
+                preflight_findings = all_items;
+            }
+        }
+    }
+
     let checkpoint_store = match CheckpointStore::new() {
         Ok(cs) => cs,
         Err(e) => {
@@ -75,7 +115,7 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
     };
     let snapshot_mgr = SnapshotManager::new(checkpoint_store);
 
-    let initial_messages = if config.resume {
+    let mut initial_messages = if config.resume {
         match snapshot_mgr.restore_snapshot(&task_id, true) {
             Ok(Some(snapshot)) => snapshot.messages,
             _ => {
@@ -91,6 +131,11 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
             config.task.prompt_template.clone(),
         )]
     };
+
+    // Inject preflight summary into agent context (if any findings).
+    if let Some(summary) = preflight_summary {
+        initial_messages.insert(0, Message::new(Role::User, summary));
+    }
 
     let agent_config = AgentConfig {
         contract: &config.task,
@@ -133,7 +178,10 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
         .save_snapshot(&task_id, &agent_result.messages, agent_result.truncated)
         .ok();
 
-    let gate_result = RuleEngine::evaluate(&agent_result.findings, &config.task.gating_rules);
+    // Merge preflight findings (deterministic) with agent findings.
+    let all_findings = [preflight_findings, agent_result.findings].concat();
+
+    let gate_result = RuleEngine::evaluate(&all_findings, &config.task.gating_rules);
 
     // Fail closed on incomplete runs (context truncated or iteration limit
     // reached): a partial sweep with zero findings must not pass gates like
@@ -154,7 +202,7 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
     }
 
     if let Err(e) = SarifFormatter::write_to_file_with_status(
-        &agent_result.findings,
+        &all_findings,
         &config.output,
         agent_result.truncated,
     ) {
@@ -177,7 +225,7 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
     ExecutionReport {
         task_id,
         exit_code,
-        findings: agent_result.findings,
+        findings: all_findings,
         token_usage: agent_result.usage,
         duration_ms: agent_result.duration_ms,
         snapshot_id,
@@ -235,6 +283,108 @@ pub fn cleanup_archives(workspace: &Path, task_id: &str) {
             }
         }
     }
+}
+
+// ── Preflight helpers ─────────────────────────────────────────────────────
+
+/// Parse an MCP tool's JSON output into `Finding` objects.
+///
+/// The output is expected to be a JSON array of objects. Each object's fields
+/// are mapped to `Finding` fields using the `PreflightCheck` configuration.
+/// Items that cannot be parsed are silently skipped.
+fn parse_preflight_result(output: &str, check: &PreflightCheck) -> Vec<Finding> {
+    let value: serde_json::Value = match serde_json::from_str(output) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let items = match value.as_array() {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    let mut findings = Vec::new();
+    for item in items {
+        if let Some(msg) = item
+            .get(&check.message_field)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            let severity_str = item
+                .get(&check.severity_field)
+                .and_then(|v| v.as_str())
+                .unwrap_or(&check.default_severity);
+            let severity = parse_severity_str(severity_str);
+
+            let file = item
+                .get(&check.file_field)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            let line_start = item
+                .get(&check.line_field)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32;
+            let col_start = item
+                .get(&check.column_field)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32;
+
+            let location = if !file.is_empty() {
+                Some(crate::types::Location {
+                    file,
+                    line_start,
+                    line_end: line_start,
+                    column_start: col_start,
+                    column_end: col_start,
+                })
+            } else {
+                None
+            };
+
+            let rule_id = format!("{}{}", check.rule_id_prefix, msg);
+
+            findings.push(Finding {
+                id: uuid::Uuid::new_v4(),
+                rule_id,
+                severity,
+                message: msg.to_string(),
+                location,
+                evidence: output.len().min(200).to_string(), // first 200 chars as evidence
+            });
+        }
+    }
+
+    findings
+}
+
+/// Convert a string like "error", "warning", "info" into `Severity`.
+/// Also accepts integer-string severities (e.g. "1" → error per LSP convention).
+fn parse_severity_str(s: &str) -> Severity {
+    match s.to_lowercase().as_str() {
+        "error" | "1" => Severity::Error,
+        "warning" | "2" | "warn" => Severity::Warning,
+        "info" | "3" | "information" => Severity::Info,
+        "hint" | "4" => Severity::Hint,
+        _ => Severity::Warning,
+    }
+}
+
+/// Format a human-readable summary of preflight findings.
+fn format_preflight_summary(findings: &[Finding]) -> String {
+    use std::fmt::Write;
+    let mut buf = String::from("Preflight diagnostics found:\n");
+    for f in findings {
+        let loc = f
+            .location
+            .as_ref()
+            .map(|l| format!("{}:{}", l.file, l.line_start))
+            .unwrap_or_default();
+        let _ = writeln!(buf, "  [{:?}][{}] {} — {}", f.severity, f.rule_id, f.message, loc);
+    }
+    buf.push_str("\nConsider these findings in your review.");
+    buf
 }
 
 #[cfg(test)]
@@ -382,5 +532,99 @@ mod tests {
             0
         );
         assert!(errors.is_empty());
+    }
+
+    // ── parse_preflight_result tests ────────────────────────────────────────
+
+    #[test]
+    fn test_parse_preflight_result_basic() {
+        let check = PreflightCheck::default();
+        let output = r#"[
+            {"severity": "error", "message": "type mismatch", "file": "src/main.rs", "line": 42},
+            {"severity": "warning", "message": "unused variable", "file": "src/lib.rs", "line": 10}
+        ]"#;
+        let findings = parse_preflight_result(output, &check);
+        assert_eq!(findings.len(), 2);
+
+        assert_eq!(findings[0].severity, Severity::Error);
+        assert!(findings[0].message.contains("type mismatch"));
+        assert_eq!(findings[0].location.as_ref().unwrap().file, "src/main.rs");
+        assert_eq!(findings[0].location.as_ref().unwrap().line_start, 42);
+        assert!(findings[0].rule_id.starts_with("preflight-"));
+
+        assert_eq!(findings[1].severity, Severity::Warning);
+        assert!(findings[1].message.contains("unused variable"));
+    }
+
+    #[test]
+    fn test_parse_preflight_result_empty() {
+        let check = PreflightCheck::default();
+        let findings = parse_preflight_result(r#"[]"#, &check);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_parse_preflight_result_non_json() {
+        let check = PreflightCheck::default();
+        let findings = parse_preflight_result("not json at all", &check);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_parse_preflight_result_custom_fields() {
+        let check = PreflightCheck {
+            rule_id_prefix: "diag-".into(),
+            severity_field: "s".into(),
+            message_field: "m".into(),
+            file_field: "path".into(),
+            line_field: "ln".into(),
+            ..Default::default()
+        };
+        let output = r#"[
+            {"s": "error", "m": "E001: something wrong", "path": "a.rs", "ln": 1}
+        ]"#;
+        let findings = parse_preflight_result(output, &check);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Error);
+        assert!(findings[0].rule_id.starts_with("diag-"));
+    }
+
+    #[test]
+    fn test_parse_severity_str() {
+        assert_eq!(parse_severity_str("error"), Severity::Error);
+        assert_eq!(parse_severity_str("ERROR"), Severity::Error);
+        assert_eq!(parse_severity_str("1"), Severity::Error);     // LSP convention
+        assert_eq!(parse_severity_str("warning"), Severity::Warning);
+        assert_eq!(parse_severity_str("2"), Severity::Warning);
+        assert_eq!(parse_severity_str("warn"), Severity::Warning);
+        assert_eq!(parse_severity_str("info"), Severity::Info);
+        assert_eq!(parse_severity_str("3"), Severity::Info);
+        assert_eq!(parse_severity_str("hint"), Severity::Hint);
+        assert_eq!(parse_severity_str("4"), Severity::Hint);
+        assert_eq!(parse_severity_str("unknown"), Severity::Warning); // fallback
+    }
+
+    #[test]
+    fn test_format_preflight_summary() {
+        let findings = vec![
+            Finding {
+                id: uuid::Uuid::new_v4(),
+                rule_id: "test-err".into(),
+                severity: Severity::Error,
+                message: "Something failed".into(),
+                location: Some(crate::types::Location {
+                    file: "src/main.rs".into(),
+                    line_start: 42,
+                    line_end: 42,
+                    column_start: 1,
+                    column_end: 1,
+                }),
+                evidence: "".into(),
+            },
+        ];
+        let summary = format_preflight_summary(&findings);
+        assert!(summary.contains("Preflight diagnostics"));
+        assert!(summary.contains("src/main.rs:42"));
+        assert!(summary.contains("Something failed"));
     }
 }

--- a/crates/clausura-core/src/mcp.rs
+++ b/crates/clausura-core/src/mcp.rs
@@ -94,6 +94,37 @@ impl McpClientManager {
         }
     }
 
+    /// Call a tool on a specific MCP server directly, bypassing the ToolRegistry.
+    ///
+    /// Used for preflight checks that must run *before* the agent loop.
+    /// The server must have been configured and started successfully.
+    pub async fn call_tool(
+        &self,
+        server_name: &str,
+        tool_name: &str,
+        args: Value,
+    ) -> Result<String, ToolError> {
+        let client = self
+            .clients
+            .iter()
+            .find(|c| c.name == server_name)
+            .ok_or_else(|| {
+                ToolError::ExecutionFailed(format!(
+                    "MCP server '{}' not found (not started or configured)",
+                    server_name
+                ))
+            })?;
+        let channel = client.clone_channel();
+        McpClient::call_tool(&channel, tool_name, args)
+            .await
+            .map_err(|e| {
+                ToolError::ExecutionFailed(format!(
+                    "MCP preflight '{}' on '{}': {e}",
+                    tool_name, server_name
+                ))
+            })
+    }
+
     /// Return the number of connected servers.
     #[cfg(test)]
     pub fn server_count(&self) -> usize {

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -568,13 +568,27 @@ pub struct PreflightCheck {
     pub default_severity: String,
 }
 
-fn default_preflight_rule_prefix() -> String { "preflight-".into() }
-fn default_preflight_severity_field() -> String { "severity".into() }
-fn default_preflight_message_field() -> String { "message".into() }
-fn default_preflight_file_field() -> String { "file".into() }
-fn default_preflight_line_field() -> String { "line".into() }
-fn default_preflight_column_field() -> String { "column".into() }
-fn default_preflight_default_severity() -> String { "warning".into() }
+fn default_preflight_rule_prefix() -> String {
+    "preflight-".into()
+}
+fn default_preflight_severity_field() -> String {
+    "severity".into()
+}
+fn default_preflight_message_field() -> String {
+    "message".into()
+}
+fn default_preflight_file_field() -> String {
+    "file".into()
+}
+fn default_preflight_line_field() -> String {
+    "line".into()
+}
+fn default_preflight_column_field() -> String {
+    "column".into()
+}
+fn default_preflight_default_severity() -> String {
+    "warning".into()
+}
 
 impl Default for PreflightCheck {
     fn default() -> Self {

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -406,6 +406,11 @@ pub struct TaskContract {
     /// External MCP servers whose tools should be available to the agent.
     #[serde(default)]
     pub mcp_servers: Vec<McpServerConfig>,
+    /// Preflight checks — MCP tool calls that run before the agent loop.
+    /// Their output is parsed into deterministic Findings and merged with
+    /// the agent's findings for gating.
+    #[serde(default)]
+    pub preflight: Vec<PreflightCheck>,
 }
 
 fn default_max_iterations() -> u32 {
@@ -524,6 +529,68 @@ pub struct McpServerConfig {
     /// Environment variables injected into the server process.
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
+}
+
+/// A preflight check — an MCP tool call that runs *before* the agent loop.
+///
+/// The tool's JSON output is parsed into `Finding` objects and passed
+/// through the gating rule engine alongside agent-produced findings.
+/// A summary is also injected into the agent's context.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PreflightCheck {
+    /// Name of the MCP server (must match an entry in `mcp_servers`).
+    pub mcp_server: String,
+    /// Tool name to call on that server.
+    pub tool: String,
+    /// Arguments to pass to the tool.
+    #[serde(default)]
+    pub args: serde_json::Value,
+    /// Prefix for the auto-generated `rule_id` on each Finding.
+    #[serde(default = "default_preflight_rule_prefix")]
+    pub rule_id_prefix: String,
+    /// JSON field name for severity in each result item.
+    #[serde(default = "default_preflight_severity_field")]
+    pub severity_field: String,
+    /// JSON field name for message text.
+    #[serde(default = "default_preflight_message_field")]
+    pub message_field: String,
+    /// JSON field name for file path.
+    #[serde(default = "default_preflight_file_field")]
+    pub file_field: String,
+    /// JSON field name for line number.
+    #[serde(default = "default_preflight_line_field")]
+    pub line_field: String,
+    /// JSON field name for column number.
+    #[serde(default = "default_preflight_column_field")]
+    pub column_field: String,
+    /// Default severity string when the source item lacks one.
+    #[serde(default = "default_preflight_default_severity")]
+    pub default_severity: String,
+}
+
+fn default_preflight_rule_prefix() -> String { "preflight-".into() }
+fn default_preflight_severity_field() -> String { "severity".into() }
+fn default_preflight_message_field() -> String { "message".into() }
+fn default_preflight_file_field() -> String { "file".into() }
+fn default_preflight_line_field() -> String { "line".into() }
+fn default_preflight_column_field() -> String { "column".into() }
+fn default_preflight_default_severity() -> String { "warning".into() }
+
+impl Default for PreflightCheck {
+    fn default() -> Self {
+        Self {
+            mcp_server: String::new(),
+            tool: String::new(),
+            args: serde_json::json!({}),
+            rule_id_prefix: default_preflight_rule_prefix(),
+            severity_field: default_preflight_severity_field(),
+            message_field: default_preflight_message_field(),
+            file_field: default_preflight_file_field(),
+            line_field: default_preflight_line_field(),
+            column_field: default_preflight_column_field(),
+            default_severity: default_preflight_default_severity(),
+        }
+    }
 }
 
 /// Error types for checkpoint operations
@@ -660,6 +727,7 @@ mod tests {
             max_iterations: 10,
             on_incomplete: OnIncompletePolicy::Fail,
             mcp_servers: vec![],
+            preflight: vec![],
         };
         assert_eq!(contract.ambiguity_policy, AmbiguityPolicy::FailClosed);
         assert!(contract.gating_rules.is_empty());

--- a/examples/mcp-lsp-review.yaml
+++ b/examples/mcp-lsp-review.yaml
@@ -1,0 +1,70 @@
+# 示例：使用 MCP + LSP 进行代码审查
+#
+# 前提：CI 环境中需要安装 agent-lsp + 对应语言服务器
+#   curl -fsSL https://raw.githubusercontent.com/blackwell-systems/agent-lsp/main/install.sh | sh
+#   rustup component add rust-analyzer
+#   npm i -g typescript-language-server
+#   pip install pyright
+#
+# 运行方式：
+#   clausura run -c examples/mcp-lsp-review.yaml
+#
+# 架构：
+#   1. Preflight：agent 启动前自动收集 LSP diagnostics → 确定性 Finding
+#   2. Agent loop：使用 mcp__lsp__* 工具做深层语义分析
+#   3. Gating：preflight 的 LSP findings + agent findings 一起走门禁
+
+version: "1"
+task:
+  name: mcp-lsp-review
+  model: gpt-4o
+  vendor: openai
+
+  # ── MCP 服务器 ─────────────────────────────────────────────
+  mcp_servers:
+    - name: lsp
+      command: agent-lsp
+      args: []
+    # - name: github     # 可选：同时接入其他 MCP 服务器
+    #   command: npx
+    #   args: ["-y", "@anthropic/mcp-server-github"]
+
+  # ── Preflight：确定性诊断门禁 ──────────────────────────────
+  # 在 agent 启动前自动运行，输出直接转为 Finding 走 gating
+  preflight:
+    - mcp_server: lsp
+      tool: get_diagnostics
+      args:
+        path: "."
+      rule_id_prefix: "lsp-"
+      severity_field: "severity"
+      message_field: "message"
+      file_field: "file"
+      line_field: "line"
+
+  # ── Skill：引导 agent 使用 LSP 工具 ───────────────────────
+  skill_prompts:
+    - examples/skills/code-review-with-lsp/SKILL.md
+
+  # ── Prompt 模板（可选补充） ─────────────────────────────────
+  prompt_template: |
+    审查上述代码变更。如果有 LSP 工具可用，优先使用它们获取
+    语义信息，而不是仅依赖 grep/read_file。
+
+  token_budget: 32000
+  timeout_secs: 300
+
+  # ── 门禁规则 ─────────────────────────────────────────────
+  gating:
+    # LSP 诊断产生的 finding 自动带 rule_id 前缀 "lsp-"
+    # 只要有任何 error 级别的 LSP 诊断，就 fail
+    - rule: lsp-error
+      min_severity: error
+      max_findings: 0
+      action: fail
+
+    # warning 级别的 LSP 诊断最多允许 5 个
+    - rule: lsp-warning
+      min_severity: warning
+      max_findings: 5
+      action: warn

--- a/examples/skills/code-review-with-lsp/SKILL.md
+++ b/examples/skills/code-review-with-lsp/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: code-review-with-lsp
+description: >
+  Code review with LSP-powered code intelligence. Uses MCP tools
+  (diagnostics, hover, references, definition, symbols) for semantic
+  code understanding, not just text grep.
+---
+
+# Code Review with LSP
+
+> This skill works with `mcp_servers` + `preflight` in `.clausura.yaml`.
+> Preflight diagnostics are collected automatically; this skill guides
+> the agent to use LSP tools for deeper semantic analysis.
+
+## Review Workflow
+
+For each file or diff hunk under review:
+
+### Step 1. Check diagnostics
+
+Call `mcp__<server>__get_diagnostics` (or equivalent) for the file.
+Preflight results are already in context — but if diagnostics were not
+automatically collected, run them now.
+
+Record every diagnostic as a finding:
+- `rule_id`: `lsp-<diagnostic-type>` (e.g. `lsp-type-mismatch`)
+- `severity`: map 1:1 from diagnostic severity
+- `message`: keep the original diagnostic message verbatim
+
+### Step 2. Understand unfamiliar symbols
+
+When you encounter a symbol, function, or type you need to understand:
+
+1. **hover** — get type signature and docs: `mcp__<server>__hover`
+2. **definition** — jump to the definition: `mcp__<server>__goto_definition`
+3. **references** — check all callers: `mcp__<server>__find_references`
+
+### Step 3. Check for cascading impact
+
+If a change affects a public API or core type:
+- Use `mcp__<server>__find_references` to find all callers
+- Check if those callers handle the new signature correctly
+
+## Finding Severity Mapping
+
+| LSP Severity | Finding Severity | When |
+|--------------|-----------------|------|
+| Error | `error` | Compile error, type mismatch, undefined reference |
+| Warning | `warning` | Deprecation, unused variable, non-fatal lints |
+| Information | `info` | Style hints, auto-fix suggestions |
+| Hint | `hint` | Minor suggestions, organizational hints |
+
+## Example Rule IDs for Gating
+
+```yaml
+gating:
+  # LSP diagnostics (rule_id_prefix: "lsp-")
+  - rule: lsp-type-mismatch
+    min_severity: error
+    max_findings: 0
+    action: fail
+  - rule: lsp-compile-error
+    min_severity: error
+    max_findings: 0
+    action: fail
+```


### PR DESCRIPTION
## Summary

Closes the gap between MCP client integration and practical LSP usage. Before the agent loop runs, configured MCP tool calls (e.g. `get_diagnostics` from `agent-lsp`) are executed; their JSON output is parsed into deterministic `Finding` objects and passed through the gating rule engine.

## Key decisions

| Decision | Chosen approach |
|----------|----------------|
| When to run preflight | **Before** the agent loop, not in parallel |
| Finding → rule engine | Merged with agent findings after loop |
| Agent visibility | Preflight summary injected as a `Role::User` message in context |
| Format flexibility | Configurable JSON field names (severity, message, file, line, column) |
| Error handling | Failed checks are logged and skipped, not blocking |

## Configuration

```yaml
task:
  mcp_servers:
    - name: lsp
      command: agent-lsp
  preflight:
    - mcp_server: lsp
      tool: get_diagnostics
      args:
        path: "."
      rule_id_prefix: "lsp-"
  gating:
    - rule: lsp-type-mismatch
      min_severity: error
      max_findings: 0
      action: fail
```

## Changes

| File | Change |
|------|--------|
| `types.rs` | `PreflightCheck` struct with configurable field mapping |
| `config.rs` | `preflight` YAML section + parsing + defaults |
| `mcp.rs` | `McpClientManager::call_tool()` — direct tool call bypassing ToolRegistry |
| `executor.rs` | Preflight execution flow + `parse_preflight_result()` + `format_preflight_summary()` |

## Testing

- **8 new tests** (6 executor + 2 config)
- Covers: basic parsing, custom fields, empty/non-JSON inputs, severity string parsing, summary formatting, YAML config
- **290/290 tests pass**, zero warnings