### PR TITLE
feat: auto-compact — LLM summarization of truncated context (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ task:
   auto_compact: false                # Default. When true, dropped context is summarized with
                                      # an LLM call and injected back instead of a bare hint.
   max_compactions: 3                 # Default. Per-run cap on auto-compact calls. 0 disables.
+  findings_ledger: true              # Default. Persist interim findings to a disk ledger and
+                                     # merge them back before the final answer, so findings from
+                                     # truncated iterations are never lost.
   timeout_secs: 300                  # Default. Max wall-clock time in seconds.
   max_iterations: 10                 # Default. Max agent loop iterations.
   shell_timeout_secs: 120            # Default. Per-command timeout for shell_exec.
@@ -562,6 +565,10 @@ With `auto_compact: true`, the dropped messages are instead **summarized with a 
 - If the summarization call fails or times out, Clausura silently falls back to the bare truncation hint.
 - Summaries are capped at 10% of `token_budget`; oversized output is trimmed.
 - `max_compactions` bounds the number of summary calls per run (default 3) to prevent compaction loops on very long tasks.
+
+### Findings ledger (disk-backed memory)
+
+Compaction is lossy by design, so Clausura also keeps a **lossless, deterministic memory** on disk: whenever the agent emits findings in a response, they are appended to `{workspace}/.clausura/archives/findings-ledger-{task_id}.jsonl` (one JSON object per line). When the run finishes, the final findings are **merged with the ledger** — the final response wins on conflicts, and findings from iterations that were truncated out of context are appended back. No extra LLM calls are involved; the merge is plain deduplication keyed on `rule_id` + location + message. Disable with `findings_ledger: false` (env `CLAUSURA_FINDINGS_LEDGER=false`).
 
 On successful completion (exit code 0), archive files are automatically cleaned up. On failure (exit code 1-3), they are preserved for debugging and audit.
 

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ With `auto_compact: true`, the dropped messages are instead **summarized with a 
 
 - Summary calls are billed and counted against `max_total_tokens`, but the call is **skipped** if it would not fit under the remaining quota.
 - If the summarization call fails or times out, Clausura silently falls back to the bare truncation hint.
-- Summaries are capped at 10% of `token_budget`; oversized output is trimmed.
+- Summaries are sized to the headroom the retained context leaves under the truncation threshold (capped at 10% of `token_budget`); oversized output is trimmed. A compacted context always stays within budget, so a successful compaction can never push the run into "incomplete".
 - `max_compactions` bounds the number of summary calls per run (default 3) to prevent compaction loops on very long tasks.
 
 ### Findings ledger (disk-backed memory)

--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ task:
   max_total_tokens: 200000           # Optional. Cap on cumulative billed tokens across all
                                      # LLM calls in one run; the run stops (marked incomplete)
                                      # when reached. Unset means no cap.
+  auto_compact: false                # Default. When true, dropped context is summarized with
+                                     # an LLM call and injected back instead of a bare hint.
+  max_compactions: 3                 # Default. Per-run cap on auto-compact calls. 0 disables.
   timeout_secs: 300                  # Default. Max wall-clock time in seconds.
   max_iterations: 10                 # Default. Max agent loop iterations.
   shell_timeout_secs: 120            # Default. Per-command timeout for shell_exec.
@@ -549,9 +552,16 @@ Clausura runs a bounded agent loop of up to `max_iterations` iterations (default
 
 The system prompt is built from `prompt_template` plus available tool definitions. The LLM is instructed to respond in JSON with a `findings` array.
 
-### Context truncation and archiving
+### Context truncation, archiving, and auto-compact
 
 When the conversation exceeds the configured `token_budget`, Clausura automatically truncates older messages to stay within limits. Dropped messages are not silently discarded — they are archived to `.clausura/archives/context-dump-{task_id}-{seq}.log` inside the workspace as JSON lines. A hint message is injected into the conversation telling the LLM where to find the archived context, so it can retrieve earlier findings via the `read_file` tool if needed.
+
+With `auto_compact: true`, the dropped messages are instead **summarized with a single LLM call** and the summary is injected at the truncation boundary, so the agent keeps its memory of earlier findings, files examined, and decisions across truncation. The full transcript is still archived. Auto-compact never changes the run's pass/fail semantics:
+
+- Summary calls are billed and counted against `max_total_tokens`, but the call is **skipped** if it would not fit under the remaining quota.
+- If the summarization call fails or times out, Clausura silently falls back to the bare truncation hint.
+- Summaries are capped at 10% of `token_budget`; oversized output is trimmed.
+- `max_compactions` bounds the number of summary calls per run (default 3) to prevent compaction loops on very long tasks.
 
 On successful completion (exit code 0), archive files are automatically cleaned up. On failure (exit code 1-3), they are preserved for debugging and audit.
 

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -91,9 +91,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                 // bare "context trimmed" hint — compaction must never fail
                 // the run.
                 let compact_summary: Option<String> = match &archive_result {
-                    Ok(path)
-                        if auto_compact && compactions_used < max_compactions =>
-                    {
+                    Ok(path) if auto_compact && compactions_used < max_compactions => {
                         match try_compact(
                             config.provider,
                             &cm,
@@ -301,10 +299,7 @@ fn dropped_to_text(dropped: &[Message]) -> String {
             Role::Assistant => {
                 if let Some(calls) = &m.tool_calls {
                     let names: Vec<&str> = calls.iter().map(|c| c.name.as_str()).collect();
-                    out.push_str(&format!(
-                        "Assistant (tool calls: {}):\n",
-                        names.join(", ")
-                    ));
+                    out.push_str(&format!("Assistant (tool calls: {}):\n", names.join(", ")));
                 } else {
                     out.push_str("Assistant:\n");
                 }
@@ -1120,8 +1115,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_agent_loop_auto_compact_injects_summary() {
-        let (tmp, contract, tool_call, initial) =
-            auto_compact_setup(10000, None, true, 3);
+        let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 3);
         let root = tmp.path().to_path_buf();
         let tools = default_tools(root.clone(), &[], 120, &[]);
 
@@ -1187,8 +1181,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_agent_loop_auto_compact_falls_back_on_llm_error() {
-        let (tmp, contract, tool_call, initial) =
-            auto_compact_setup(10000, None, true, 3);
+        let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 3);
         let root = tmp.path().to_path_buf();
         let tools = default_tools(root.clone(), &[], 120, &[]);
 
@@ -1233,8 +1226,7 @@ mod tests {
     async fn test_agent_loop_auto_compact_disabled_by_max_compactions_zero() {
         // max_compactions = 0 disables compaction even when auto_compact is
         // on: the queued summary response must never be consumed.
-        let (tmp, contract, tool_call, initial) =
-            auto_compact_setup(10000, None, true, 0);
+        let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 0);
         let root = tmp.path().to_path_buf();
         let tools = default_tools(root.clone(), &[], 120, &[]);
 
@@ -1272,8 +1264,7 @@ mod tests {
         // max_total_tokens too small for a summary call → compaction is
         // skipped by the quota guard (bare hint), and the queued summary is
         // never consumed.
-        let (tmp, contract, tool_call, initial) =
-            auto_compact_setup(10000, Some(500), true, 3);
+        let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, Some(500), true, 3);
         let root = tmp.path().to_path_buf();
         let tools = default_tools(root.clone(), &[], 120, &[]);
 

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -428,6 +428,7 @@ async fn try_compact(
     let threshold = (token_budget as f64 * 0.8) as u64;
     let hint_fixed_tokens =
         provider.count_tokens(&compact_hint(dropped.len(), archive_path, "")) + 1; // +1 per-message overhead
+
     // Absorb the ±few-token rounding drift of the heuristic counters.
     const ROUNDING_MARGIN: u64 = 8;
     const MIN_SUMMARY_TOKENS: u64 = 200;
@@ -1509,7 +1510,8 @@ mod tests {
             hint.content
         );
         assert!(
-            hint.content.contains("[summary truncated to fit token budget]"),
+            hint.content
+                .contains("[summary truncated to fit token budget]"),
             "oversized summary must carry the trim marker, got: {}",
             hint.content
         );

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -92,6 +92,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                 // the run.
                 let compact_summary: Option<String> = match &archive_result {
                     Ok(path) if auto_compact && compactions_used < max_compactions => {
+                        let tail_tokens = cm.count_tokens(&messages);
                         match try_compact(
                             config.provider,
                             &cm,
@@ -99,6 +100,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                             path,
                             config.contract.token_budget,
                             config.contract.max_total_tokens,
+                            tail_tokens,
                             &mut running_tokens,
                             &mut total_usage,
                         )
@@ -120,15 +122,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                     // message after an assistant message with tool_calls
                     // would leave those calls without results, which the
                     // OpenAI/Anthropic APIs reject.
-                    (Ok(path), Some(summary)) => format!(
-                        "⚠️ Context was compacted to stay within token budget.\n\
-                         {} earlier messages were summarized below; the full transcript is archived at:\n  {}\n\
-                         Use read_file to inspect the archive if you need details from earlier iterations.\n\n\
-                         --- COMPACTED SUMMARY ---\n{}\n--- END SUMMARY ---",
-                        dropped.len(),
-                        path.display(),
-                        summary,
-                    ),
+                    (Ok(path), Some(summary)) => compact_hint(dropped.len(), path, &summary),
                     (Ok(path), None) => format!(
                         "⚠️ Context was trimmed to stay within token budget.\n\
                          {} earlier messages are archived at:\n  {}\n\
@@ -146,8 +140,10 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                 messages.insert(1, Message::new(Role::User, hint));
 
                 if cm.should_truncate(&messages) {
-                    // Context cannot be reduced far enough to fit the budget;
-                    // fall-through below marks the result truncated.
+                    // Last resort: the summary budget was computed against the
+                    // tail's token count, so this only fires on heuristic
+                    // counter drift. Fall-through below marks the run
+                    // truncated (findings still survive via the ledger).
                     break;
                 }
                 continue;
@@ -314,6 +310,7 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 // ---------------------------------------------------------------------------
 
 /// Outcome of an auto-compact attempt.
+#[derive(Debug)]
 enum CompactOutcome {
     /// Summary produced and billed; the text is ready to inject.
     Ok { summary: String },
@@ -356,6 +353,23 @@ fn dropped_to_text(dropped: &[Message]) -> String {
     out
 }
 
+/// Render the "context compacted" hint injected at the truncation boundary.
+///
+/// The fixed template text is measured by `try_compact` to size the summary,
+/// so this template must stay byte-identical between the two call sites —
+/// the summary budget is computed from the text the hint will actually carry.
+fn compact_hint(dropped_len: usize, archive_path: &Path, summary: &str) -> String {
+    format!(
+        "⚠️ Context was compacted to stay within token budget.\n\
+         {} earlier messages were summarized below; the full transcript is archived at:\n  {}\n\
+         Use read_file to inspect the archive if you need details from earlier iterations.\n\n\
+         --- COMPACTED SUMMARY ---\n{}\n--- END SUMMARY ---",
+        dropped_len,
+        archive_path.display(),
+        summary,
+    )
+}
+
 /// Build the summarization request messages (system instruction + the
 /// dropped conversation as a single user message).
 fn compact_request_messages(dropped_text: &str, archive_path: &Path) -> Vec<Message> {
@@ -382,9 +396,13 @@ fn compact_request_messages(dropped_text: &str, archive_path: &Path) -> Vec<Mess
 ///   (input + capped output) must fit under the remaining quota, otherwise
 ///   compaction is skipped so it cannot eat the quota and cut the run short
 ///   earlier than bare truncation would.
-/// - Summary output is capped at 10% of `token_budget`; oversized summaries
-///   are trimmed so the injected summary always leaves room for the retained
-///   tail under the context budget.
+/// - Summary output is sized to the headroom the retained tail leaves under
+///   the truncation threshold (80% of budget), capped at 10% of
+///   `token_budget`; oversized summaries are trimmed so a successful
+///   compaction can never push the context back over the threshold and mark
+///   the run incomplete.
+/// - If the headroom is too small for a meaningful summary, compaction is
+///   skipped (bare truncation hint).
 ///
 /// Usage from the summarization call is added to `running_tokens` (the
 /// `max_total_tokens` accumulator) and `total_usage`.
@@ -396,11 +414,37 @@ async fn try_compact(
     archive_path: &Path,
     token_budget: u64,
     max_total_tokens: Option<u64>,
+    tail_tokens: u64,
     running_tokens: &mut u64,
     total_usage: &mut Usage,
 ) -> CompactOutcome {
     let request = compact_request_messages(&dropped_to_text(dropped), archive_path);
-    let max_summary_tokens = ((token_budget as f64) * 0.10).max(200.0) as u64;
+
+    // Size the summary to the space left under the truncation threshold
+    // (80% of budget). A fixed cap would let "75% tail + 10% summary + hint"
+    // overflow the 80% line: `should_truncate` after injection would then
+    // mark the run incomplete right after a *successful* compaction,
+    // defeating the feature's purpose.
+    let threshold = (token_budget as f64 * 0.8) as u64;
+    let hint_fixed_tokens =
+        provider.count_tokens(&compact_hint(dropped.len(), archive_path, "")) + 1; // +1 per-message overhead
+    // Absorb the ±few-token rounding drift of the heuristic counters.
+    const ROUNDING_MARGIN: u64 = 8;
+    const MIN_SUMMARY_TOKENS: u64 = 200;
+    let headroom = threshold
+        .saturating_sub(tail_tokens)
+        .saturating_sub(hint_fixed_tokens)
+        .saturating_sub(ROUNDING_MARGIN);
+    if headroom < MIN_SUMMARY_TOKENS {
+        tracing::debug!(
+            tail_tokens,
+            headroom,
+            "auto-compact skipped: no room for a summary under the truncation threshold"
+        );
+        return CompactOutcome::Skipped;
+    }
+    let budget_ceiling = ((token_budget as f64) * 0.10).max(200.0) as u64;
+    let max_summary_tokens = headroom.min(budget_ceiling);
 
     // Quota guard: never spend the last of max_total_tokens on a summary.
     let input_estimate = cm.count_tokens(&request);
@@ -1418,6 +1462,97 @@ mod tests {
             hint.content
         );
         assert_eq!(result.usage.total_tokens, 10 + 30);
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_auto_compact_large_summary_stays_within_budget() {
+        // The summary budget is the headroom the retained tail leaves under
+        // the truncation threshold (80%), not a fixed 10%: an oversized
+        // summary must be trimmed so that injecting it cannot push the
+        // context back over the threshold and mark the run incomplete.
+        let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 3);
+        let root = tmp.path().to_path_buf();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        // ~1500 tokens by the mock heuristic — far above the summary budget,
+        // which is the headroom under the 80% truncation threshold.
+        let mut mock = MockProvider::new("test-model");
+        mock.add_response(tool_call_response(&tool_call));
+        mock.add_summary_response(Ok("y".repeat(6000)));
+        mock.add_response(stop_response(r#"{"findings": []}"#));
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: initial,
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(
+            !result.truncated,
+            "a large summary must be trimmed to fit, not truncate the run"
+        );
+        // The whole point of the headroom sizing: after injection the context
+        // must stay under the truncation threshold (80% of budget).
+        let cm = ContextManager::new(&mock, contract.token_budget, root.clone());
+        assert!(
+            !cm.should_truncate(&result.messages),
+            "injecting the summary must not push the context back over the threshold"
+        );
+        let hint = &result.messages[1];
+        assert!(
+            hint.content.contains("COMPACTED SUMMARY"),
+            "expected the compacted hint, got: {}",
+            hint.content
+        );
+        assert!(
+            hint.content.contains("[summary truncated to fit token budget]"),
+            "oversized summary must carry the trim marker, got: {}",
+            hint.content
+        );
+        assert!(
+            !hint.content.contains(&"y".repeat(5000)),
+            "summary must not retain its full oversized body, got: {}",
+            hint.content
+        );
+        // Summary usage (100 in / 50 out / 150 total) still billed.
+        assert_eq!(result.usage.total_tokens, 10 + 150 + 30);
+    }
+
+    #[tokio::test]
+    async fn test_try_compact_skipped_when_no_headroom() {
+        // Retained tail already sits near the truncation threshold: the
+        // headroom for a summary is below MIN_SUMMARY_TOKENS, so compaction
+        // is skipped without spending an LLM call.
+        let mock = MockProvider::new("test-model");
+        let cm = ContextManager::new(&mock, 10000, PathBuf::from("/tmp"));
+        let dropped = vec![Message::new(Role::User, "old message".to_string())];
+        let archive = Path::new(".clausura/archives/context-dump-test-1.log");
+        let mut running = 0u64;
+        let mut usage = Usage::default();
+        let outcome = try_compact(
+            &mock,
+            &cm,
+            &dropped,
+            archive,
+            10000,
+            None,
+            7900, // tail at 79% → headroom ≈ 31 < MIN_SUMMARY_TOKENS
+            &mut running,
+            &mut usage,
+        )
+        .await;
+        assert!(
+            matches!(outcome, CompactOutcome::Skipped),
+            "expected Skipped, got: {:?}",
+            outcome
+        );
+        // No summary call was made: no usage, nothing billed.
+        assert_eq!(usage.total_tokens, 0);
+        assert_eq!(running, 0);
     }
 
     #[test]

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -166,6 +166,19 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         total_usage.total_tokens += response.usage.total_tokens;
         running_tokens += response.usage.total_tokens;
 
+        // Persist any findings in this response to the on-disk ledger so they
+        // survive later context truncation/compaction and can be merged back
+        // into the final answer. Best-effort: a failed write is ignored.
+        if config.contract.findings_ledger {
+            let interim = extract_findings_lenient(&response.message.content);
+            if !interim.is_empty() {
+                let ledger = ledger_path(&config.workspace_root, &config.contract.id);
+                if let Err(e) = append_findings_to_ledger(&ledger, &interim) {
+                    tracing::debug!(reason = %e, "findings ledger write failed (ignored)");
+                }
+            }
+        }
+
         match response.finish_reason {
             FinishReason::Stop => {
                 messages.push(Message::new(
@@ -175,6 +188,20 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 
                 let findings = extract_findings(&response.message.content)
                     .map_err(ProviderError::MalformedFindings)?;
+
+                // Merge findings persisted earlier in the run (which may have
+                // been truncated out of context since) back into the final
+                // set, so the final answer is never missing early iterations.
+                let findings = if config.contract.findings_ledger {
+                    let ledger = read_ledger_findings(&ledger_path(
+                        &config.workspace_root,
+                        &config.contract.id,
+                    ));
+                    merge_with_ledger(findings, ledger)
+                } else {
+                    findings
+                };
+
                 return Ok(AgentResult {
                     messages,
                     findings,
@@ -187,7 +214,11 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                 if let Some(tool_calls) = response.tool_calls {
                     messages.push(Message {
                         role: Role::Assistant,
-                        content: String::new(),
+                        // Preserve the assistant's text: models commonly emit
+                        // reasoning/progress (and findings drafts) alongside
+                        // tool calls; discarding it loses interim findings
+                        // before they can reach the final answer.
+                        content: response.message.content.clone(),
                         tool_call_id: None,
                         tool_calls: Some(tool_calls.clone()),
                     });
@@ -259,6 +290,15 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
     // exhaustion, none of which produced a complete final answer.
     truncated = true;
     let findings = extract_findings_lenient(&last_content);
+
+    // Best-effort merge of ledger findings for the incomplete path too.
+    let findings = if config.contract.findings_ledger {
+        let ledger =
+            read_ledger_findings(&ledger_path(&config.workspace_root, &config.contract.id));
+        merge_with_ledger(findings, ledger)
+    } else {
+        findings
+    };
 
     Ok(AgentResult {
         messages,
@@ -432,6 +472,85 @@ fn truncate_summary_to_budget(provider: &dyn Provider, summary: &str, cap_tokens
     let mut trimmed: String = chars[..low].iter().collect();
     trimmed.push_str(MARKER);
     trimmed
+}
+
+// ---------------------------------------------------------------------------
+// Findings ledger
+// ---------------------------------------------------------------------------
+
+/// Path to the findings ledger for a task: one Finding per JSON line.
+/// Lives next to the context archives so cleanup can sweep both.
+fn ledger_path(workspace_root: &Path, task_id: &str) -> PathBuf {
+    workspace_root
+        .join(".clausura")
+        .join("archives")
+        .join(format!("findings-ledger-{}.jsonl", task_id))
+}
+
+/// Append findings to the ledger, creating file/dirs as needed.
+/// Best-effort by design: the ledger is a safety net, not a dependency.
+fn append_findings_to_ledger(path: &Path, findings: &[Finding]) -> std::io::Result<()> {
+    if findings.is_empty() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut content = String::new();
+    for f in findings {
+        if let Ok(line) = serde_json::to_string(f) {
+            content.push_str(&line);
+            content.push('\n');
+        }
+    }
+    use std::io::Write;
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?
+        .write_all(content.as_bytes())
+}
+
+/// Read all findings previously persisted to the ledger.
+/// A missing or unreadable ledger yields an empty vector.
+fn read_ledger_findings(path: &Path) -> Vec<Finding> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+/// Merge ledger findings into the final findings.
+///
+/// The final response wins on conflicts; ledger-only findings (e.g. from
+/// iterations that were truncated out of context) are appended. Dedup key:
+/// rule_id + location + message. Deterministic — no LLM involved.
+fn merge_with_ledger(final_findings: Vec<Finding>, ledger: Vec<Finding>) -> Vec<Finding> {
+    let mut seen = std::collections::HashSet::new();
+    let mut merged = Vec::with_capacity(final_findings.len() + ledger.len());
+    for f in final_findings {
+        if seen.insert(finding_key(&f)) {
+            merged.push(f);
+        }
+    }
+    for f in ledger {
+        if seen.insert(finding_key(&f)) {
+            merged.push(f);
+        }
+    }
+    merged
+}
+
+fn finding_key(f: &Finding) -> String {
+    format!(
+        "{}|{}|{}",
+        f.rule_id,
+        serde_json::to_string(&f.location).unwrap_or_default(),
+        f.message
+    )
 }
 
 /// Extract findings from a completed agent response.
@@ -615,7 +734,9 @@ mod tests {
     use super::*;
     use crate::provider::tests::MockProvider;
     use crate::tools::default_tools;
-    use crate::types::{AmbiguityPolicy, ChatResponse, OnIncompletePolicy, ToolCall, VendorConfig};
+    use crate::types::{
+        AmbiguityPolicy, ChatResponse, OnIncompletePolicy, Severity, ToolCall, VendorConfig,
+    };
     use tempfile::TempDir;
 
     fn test_contract() -> TaskContract {
@@ -631,6 +752,7 @@ mod tests {
             max_total_tokens: None,
             auto_compact: false,
             max_compactions: 3,
+            findings_ledger: true,
             timeout_secs: 60,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],
@@ -1342,6 +1464,190 @@ mod tests {
         let short = "short summary".to_string();
         let untouched = truncate_summary_to_budget(&mock, &short, cap_tokens);
         assert_eq!(untouched, short);
+    }
+
+    // -----------------------------------------------------------------
+    // Findings ledger
+    // -----------------------------------------------------------------
+
+    fn finding(rule_id: &str, severity: Severity, message: &str) -> Finding {
+        Finding {
+            id: uuid::Uuid::new_v4(),
+            rule_id: rule_id.into(),
+            severity,
+            message: message.into(),
+            location: None,
+            evidence: "e".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_ledger_merges_findings_from_earlier_iterations() {
+        // An early iteration emits findings alongside a tool call; the final
+        // Stop response only reports later findings. The ledger must preserve
+        // the early ones and merge them back into the final result.
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut contract = test_contract();
+        contract.findings_ledger = true;
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        let early = finding(
+            "early-issue",
+            Severity::Warning,
+            "found in an early iteration",
+        );
+        let late = finding("final-issue", Severity::Error, "found at the end");
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_response(ChatResponse {
+            message: Message::new(
+                Role::Assistant,
+                serde_json::json!({"findings": [early]}).to_string(),
+            ),
+            usage: Usage {
+                input_tokens: 5,
+                output_tokens: 5,
+                total_tokens: 10,
+            },
+            finish_reason: FinishReason::ToolCalls,
+            tool_calls: Some(vec![tool_call.clone()]),
+        });
+        mock.add_response(ChatResponse {
+            message: Message::new(
+                Role::Assistant,
+                serde_json::json!({"findings": [late]}).to_string(),
+            ),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(!result.truncated);
+        let rule_ids: Vec<&str> = result.findings.iter().map(|f| f.rule_id.as_str()).collect();
+        assert!(
+            rule_ids.contains(&"early-issue"),
+            "early finding must survive via the ledger, got: {:?}",
+            rule_ids
+        );
+        assert!(
+            rule_ids.contains(&"final-issue"),
+            "final finding must be present, got: {:?}",
+            rule_ids
+        );
+        // Final response findings come first, ledger-only findings appended.
+        assert_eq!(rule_ids[0], "final-issue");
+
+        // The ledger file was written next to the archives.
+        let ledger = root
+            .join(".clausura")
+            .join("archives")
+            .join("findings-ledger-test.jsonl");
+        assert!(ledger.exists(), "ledger file should exist");
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_ledger_disabled() {
+        // findings_ledger = false: interim findings are not persisted and the
+        // final result contains only the Stop response findings.
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut contract = test_contract();
+        contract.findings_ledger = false;
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        let early = finding("early-issue", Severity::Warning, "early");
+        let late = finding("final-issue", Severity::Error, "final");
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_response(ChatResponse {
+            message: Message::new(
+                Role::Assistant,
+                serde_json::json!({"findings": [early]}).to_string(),
+            ),
+            usage: Usage {
+                input_tokens: 5,
+                output_tokens: 5,
+                total_tokens: 10,
+            },
+            finish_reason: FinishReason::ToolCalls,
+            tool_calls: Some(vec![tool_call.clone()]),
+        });
+        mock.add_response(ChatResponse {
+            message: Message::new(
+                Role::Assistant,
+                serde_json::json!({"findings": [late]}).to_string(),
+            ),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        let rule_ids: Vec<&str> = result.findings.iter().map(|f| f.rule_id.as_str()).collect();
+        assert_eq!(rule_ids, vec!["final-issue"]);
+
+        let ledger = root
+            .join(".clausura")
+            .join("archives")
+            .join("findings-ledger-test.jsonl");
+        assert!(
+            !ledger.exists(),
+            "no ledger should be written when disabled"
+        );
+    }
+
+    #[test]
+    fn test_merge_with_ledger_dedup() {
+        // The final response wins; a ledger-only finding is appended; an
+        // identical (rule_id + location + message) ledger copy is dropped.
+        let final_a = finding("r1", Severity::Error, "dup message");
+        let final_b = finding("r2", Severity::Warning, "only final");
+        let ledger_a = finding("r1", Severity::Error, "dup message");
+        let ledger_c = finding("r3", Severity::Info, "only ledger");
+
+        let merged = merge_with_ledger(vec![final_a, final_b], vec![ledger_a, ledger_c]);
+        let rule_ids: Vec<&str> = merged.iter().map(|f| f.rule_id.as_str()).collect();
+        assert_eq!(rule_ids, vec!["r1", "r2", "r3"]);
     }
 
     #[tokio::test]

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -3,6 +3,7 @@ use crate::provider::Provider;
 use crate::snapshot::SnapshotManager;
 use crate::tools::ToolRegistry;
 use crate::types::{Finding, FinishReason, Message, ProviderError, Role, TaskContract, Usage};
+use std::path::Path;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -54,6 +55,12 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         config.workspace_root.clone(),
     );
 
+    // Auto-compact state: summarize dropped messages instead of bare
+    // truncation, bounded by a per-run call cap to prevent compaction loops.
+    let auto_compact = config.contract.auto_compact;
+    let max_compactions = config.contract.max_compactions;
+    let mut compactions_used: u32 = 0;
+
     for _iteration in 0..max_iterations {
         if start.elapsed() > Duration::from_secs(config.contract.timeout_secs) {
             return Err(ProviderError::Timeout("Task timeout exceeded".into()));
@@ -78,41 +85,67 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 
                 let archive_result = cm.archive(&dropped, &config.contract.id).await;
 
-                match archive_result {
-                    Ok(path) => {
-                        // Insert at the truncation boundary (right after the
-                        // system message), not at the end: appending a User
-                        // message after an assistant message with tool_calls
-                        // would leave those calls without results, which the
-                        // OpenAI/Anthropic APIs reject.
-                        messages.insert(
-                            1,
-                            Message::new(
-                                Role::User,
-                                format!(
-                                    "⚠️ Context was trimmed to stay within token budget.\n\
-                                 {} earlier messages are archived at:\n  {}\n\
-                                 Use read_file to inspect if you need context from earlier iterations.",
-                                    dropped.len(),
-                                    path.display(),
-                                ),
-                            ),
-                        );
+                // Auto-compact: summarize the dropped messages with a single
+                // no-tool LLM call and inject the summary at the truncation
+                // boundary. Any guard failure or LLM error falls back to the
+                // bare "context trimmed" hint — compaction must never fail
+                // the run.
+                let compact_summary: Option<String> = match &archive_result {
+                    Ok(path)
+                        if auto_compact && compactions_used < max_compactions =>
+                    {
+                        match try_compact(
+                            config.provider,
+                            &cm,
+                            &dropped,
+                            path,
+                            config.contract.token_budget,
+                            config.contract.max_total_tokens,
+                            &mut running_tokens,
+                            &mut total_usage,
+                        )
+                        .await
+                        {
+                            CompactOutcome::Ok { summary } => {
+                                compactions_used += 1;
+                                Some(summary)
+                            }
+                            CompactOutcome::Skipped | CompactOutcome::Failed => None,
+                        }
                     }
-                    Err(_) => {
-                        messages.insert(
-                            1,
-                            Message::new(
-                                Role::User,
-                                format!(
-                                    "⚠️ Context was trimmed to stay within token budget.\n\
-                                 {} earlier messages were dropped (archive unavailable).",
-                                    dropped.len(),
-                                ),
-                            ),
-                        );
-                    }
-                }
+                    _ => None,
+                };
+
+                let hint = match (&archive_result, compact_summary) {
+                    // Insert at the truncation boundary (right after the
+                    // system message), not at the end: appending a User
+                    // message after an assistant message with tool_calls
+                    // would leave those calls without results, which the
+                    // OpenAI/Anthropic APIs reject.
+                    (Ok(path), Some(summary)) => format!(
+                        "⚠️ Context was compacted to stay within token budget.\n\
+                         {} earlier messages were summarized below; the full transcript is archived at:\n  {}\n\
+                         Use read_file to inspect the archive if you need details from earlier iterations.\n\n\
+                         --- COMPACTED SUMMARY ---\n{}\n--- END SUMMARY ---",
+                        dropped.len(),
+                        path.display(),
+                        summary,
+                    ),
+                    (Ok(path), None) => format!(
+                        "⚠️ Context was trimmed to stay within token budget.\n\
+                         {} earlier messages are archived at:\n  {}\n\
+                         Use read_file to inspect if you need context from earlier iterations.",
+                        dropped.len(),
+                        path.display(),
+                    ),
+                    (Err(_), _) => format!(
+                        "⚠️ Context was trimmed to stay within token budget.\n\
+                         {} earlier messages were dropped (archive unavailable).",
+                        dropped.len(),
+                    ),
+                };
+
+                messages.insert(1, Message::new(Role::User, hint));
 
                 if cm.should_truncate(&messages) {
                     // Context cannot be reduced far enough to fit the budget;
@@ -236,6 +269,174 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         duration_ms: start.elapsed().as_millis() as u64,
         truncated,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Auto-compact
+// ---------------------------------------------------------------------------
+
+/// Outcome of an auto-compact attempt.
+enum CompactOutcome {
+    /// Summary produced and billed; the text is ready to inject.
+    Ok { summary: String },
+    /// Compaction skipped by a guard (insufficient `max_total_tokens` headroom).
+    Skipped,
+    /// The summarization LLM call failed; callers fall back to the bare hint.
+    Failed,
+}
+
+/// Serialize dropped messages to plain text for the summarization call.
+///
+/// Tool results are rendered inline (role + content) rather than as
+/// structured `tool` messages: this keeps the summarization input portable
+/// across providers (Anthropic's message converter maps `tool` messages to
+/// `tool_result` with a placeholder id, which is fragile outside the agent
+/// loop) and avoids feeding half-paired tool_calls into the summary.
+fn dropped_to_text(dropped: &[Message]) -> String {
+    let mut out = String::new();
+    for m in dropped {
+        match m.role {
+            Role::System => out.push_str("System:\n"),
+            Role::User => out.push_str("User:\n"),
+            Role::Assistant => {
+                if let Some(calls) = &m.tool_calls {
+                    let names: Vec<&str> = calls.iter().map(|c| c.name.as_str()).collect();
+                    out.push_str(&format!(
+                        "Assistant (tool calls: {}):\n",
+                        names.join(", ")
+                    ));
+                } else {
+                    out.push_str("Assistant:\n");
+                }
+            }
+            Role::Tool => match &m.tool_call_id {
+                Some(tcid) => out.push_str(&format!("Tool result ({}):\n", tcid)),
+                None => out.push_str("Tool result:\n"),
+            },
+        }
+        out.push_str(&m.content);
+        out.push('\n');
+        out.push('\n');
+    }
+    out
+}
+
+/// Build the summarization request messages (system instruction + the
+/// dropped conversation as a single user message).
+fn compact_request_messages(dropped_text: &str, archive_path: &Path) -> Vec<Message> {
+    let system = format!(
+        "You are compacting a segment of a code-review conversation for a CI agent.\n\
+         Produce a concise summary that preserves, verbatim where possible:\n\
+         - every finding reported so far (rule_id, severity, message, evidence, location)\n\
+         - key facts learned from tool outputs (files examined, diffs reviewed, test results)\n\
+         - decisions made and open questions\n\
+         Do NOT invent findings, facts, or conclusions that are not present in the messages.\n\
+         The full transcript is archived at {} for reference.",
+        archive_path.display()
+    );
+    vec![
+        Message::new(Role::System, system),
+        Message::new(Role::User, dropped_text.to_string()),
+    ]
+}
+
+/// Attempt to summarize `dropped` with a single no-tool LLM call.
+///
+/// Guards (all checked before spending a request):
+/// - `max_total_tokens` headroom: the estimated cost of the summary call
+///   (input + capped output) must fit under the remaining quota, otherwise
+///   compaction is skipped so it cannot eat the quota and cut the run short
+///   earlier than bare truncation would.
+/// - Summary output is capped at 10% of `token_budget`; oversized summaries
+///   are trimmed so the injected summary always leaves room for the retained
+///   tail under the context budget.
+///
+/// Usage from the summarization call is added to `running_tokens` (the
+/// `max_total_tokens` accumulator) and `total_usage`.
+#[allow(clippy::too_many_arguments)]
+async fn try_compact(
+    provider: &dyn Provider,
+    cm: &ContextManager<'_>,
+    dropped: &[Message],
+    archive_path: &Path,
+    token_budget: u64,
+    max_total_tokens: Option<u64>,
+    running_tokens: &mut u64,
+    total_usage: &mut Usage,
+) -> CompactOutcome {
+    let request = compact_request_messages(&dropped_to_text(dropped), archive_path);
+    let max_summary_tokens = ((token_budget as f64) * 0.10).max(200.0) as u64;
+
+    // Quota guard: never spend the last of max_total_tokens on a summary.
+    let input_estimate = cm.count_tokens(&request);
+    if let Some(cap) = max_total_tokens {
+        if *running_tokens + input_estimate + max_summary_tokens > cap {
+            tracing::debug!(
+                input_estimate,
+                max_summary_tokens,
+                running = *running_tokens,
+                cap,
+                "auto-compact skipped: insufficient max_total_tokens headroom"
+            );
+            return CompactOutcome::Skipped;
+        }
+    }
+
+    match provider.chat(&request).await {
+        Ok(response) => {
+            let mut summary = response.message.content.clone();
+            if provider.count_tokens(&summary) > max_summary_tokens {
+                summary = truncate_summary_to_budget(provider, &summary, max_summary_tokens);
+            }
+            *running_tokens += response.usage.total_tokens;
+            total_usage.input_tokens += response.usage.input_tokens;
+            total_usage.output_tokens += response.usage.output_tokens;
+            total_usage.total_tokens += response.usage.total_tokens;
+            tracing::info!(
+                dropped_messages = dropped.len(),
+                input_tokens = response.usage.input_tokens,
+                output_tokens = response.usage.output_tokens,
+                summary_chars = summary.len(),
+                "auto-compact: summarized dropped messages"
+            );
+            CompactOutcome::Ok { summary }
+        }
+        Err(e) => {
+            tracing::warn!(
+                reason = %e,
+                "auto-compact failed, falling back to truncation hint"
+            );
+            CompactOutcome::Failed
+        }
+    }
+}
+
+/// Trim `summary` to the largest char prefix that keeps the trimmed result
+/// (including the truncation marker) within `cap_tokens`, using the
+/// provider's token heuristic. Appends a marker so the agent knows the
+/// summary was cut.
+fn truncate_summary_to_budget(provider: &dyn Provider, summary: &str, cap_tokens: u64) -> String {
+    const MARKER: &str = "\n\n[summary truncated to fit token budget]";
+    // Already within budget: pass through untouched.
+    if provider.count_tokens(summary) <= cap_tokens {
+        return summary.to_string();
+    }
+    let chars: Vec<char> = summary.chars().collect();
+    let mut low = 0usize;
+    let mut high = chars.len();
+    while low < high {
+        let mid = (low + high).div_ceil(2);
+        let prefix: String = chars[..mid].iter().collect();
+        let candidate = format!("{}{}", prefix, MARKER);
+        if provider.count_tokens(&candidate) <= cap_tokens {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    let mut trimmed: String = chars[..low].iter().collect();
+    trimmed.push_str(MARKER);
+    trimmed
 }
 
 /// Extract findings from a completed agent response.
@@ -433,6 +634,8 @@ mod tests {
             tool_allowlist: vec!["git".into()],
             token_budget: 100000,
             max_total_tokens: None,
+            auto_compact: false,
+            max_compactions: 3,
             timeout_secs: 60,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],
@@ -855,6 +1058,299 @@ mod tests {
             );
             i += 1;
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Auto-compact
+    // -----------------------------------------------------------------
+
+    /// Shared setup for auto-compact tests: a contract that triggers
+    /// truncation on a huge initial message, with a tool-call then a
+    /// Stop response queued for the agent loop.
+    fn auto_compact_setup(
+        token_budget: u64,
+        max_total_tokens: Option<u64>,
+        auto_compact: bool,
+        max_compactions: u32,
+    ) -> (TempDir, TaskContract, ToolCall, Vec<Message>) {
+        let tmp = TempDir::new().unwrap();
+        let mut contract = test_contract();
+        contract.token_budget = token_budget;
+        contract.max_total_tokens = max_total_tokens;
+        contract.auto_compact = auto_compact;
+        contract.max_compactions = max_compactions;
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        };
+        (
+            tmp,
+            contract,
+            tool_call,
+            vec![Message::new(Role::User, "x".repeat(40000))],
+        )
+    }
+
+    fn tool_call_response(tool_call: &ToolCall) -> ChatResponse {
+        ChatResponse {
+            message: Message::new(Role::Assistant, "Running tool..."),
+            usage: Usage {
+                input_tokens: 5,
+                output_tokens: 5,
+                total_tokens: 10,
+            },
+            finish_reason: FinishReason::ToolCalls,
+            tool_calls: Some(vec![tool_call.clone()]),
+        }
+    }
+
+    fn stop_response(content: &str) -> ChatResponse {
+        ChatResponse {
+            message: Message::new(Role::Assistant, content.to_string()),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_auto_compact_injects_summary() {
+        let (tmp, contract, tool_call, initial) =
+            auto_compact_setup(10000, None, true, 3);
+        let root = tmp.path().to_path_buf();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_response(tool_call_response(&tool_call));
+        mock.add_summary_response(Ok("Summary: found X in file A".to_string()));
+        mock.add_response(stop_response(
+            r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "m", "evidence": "e"}]}"#,
+        ));
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: initial,
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(!result.truncated, "expected a clean run");
+
+        // The summary sits at index 1 — immediately after the system message.
+        let summary_msg = &result.messages[1];
+        assert_eq!(summary_msg.role, Role::User);
+        assert!(
+            summary_msg.content.contains("COMPACTED SUMMARY"),
+            "expected a compacted-summary marker, got: {}",
+            summary_msg.content
+        );
+        assert!(
+            summary_msg.content.contains("Summary: found X in file A"),
+            "expected the LLM summary inside the hint, got: {}",
+            summary_msg.content
+        );
+        assert!(
+            summary_msg.content.contains("archived at"),
+            "expected the archive path in the hint, got: {}",
+            summary_msg.content
+        );
+
+        // The summarization call (mock usage 100 in / 50 out / 150 total)
+        // is included in reported usage.
+        assert_eq!(result.usage.total_tokens, 10 + 30 + 150);
+
+        // Archive still written.
+        let archive_dir = root.join(".clausura").join("archives");
+        let mut found = false;
+        if let Ok(entries) = std::fs::read_dir(&archive_dir) {
+            for entry in entries.flatten() {
+                if entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("context-dump-test-")
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        assert!(found, "archive file should exist after compaction");
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_auto_compact_falls_back_on_llm_error() {
+        let (tmp, contract, tool_call, initial) =
+            auto_compact_setup(10000, None, true, 3);
+        let root = tmp.path().to_path_buf();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_response(tool_call_response(&tool_call));
+        mock.add_summary_response(Err(ProviderError::ServerError("boom".into())));
+        mock.add_response(stop_response(r#"{"findings": []}"#));
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: initial,
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(
+            !result.truncated,
+            "a failed summary call must not mark the run incomplete"
+        );
+
+        // Falls back to the bare "context trimmed" hint.
+        let hint = &result.messages[1];
+        assert!(
+            hint.content.contains("was trimmed"),
+            "expected the bare hint, got: {}",
+            hint.content
+        );
+        assert!(
+            !hint.content.contains("COMPACTED SUMMARY"),
+            "expected no summary on failure, got: {}",
+            hint.content
+        );
+
+        // No usage from the failed summary call.
+        assert_eq!(result.usage.total_tokens, 10 + 30);
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_auto_compact_disabled_by_max_compactions_zero() {
+        // max_compactions = 0 disables compaction even when auto_compact is
+        // on: the queued summary response must never be consumed.
+        let (tmp, contract, tool_call, initial) =
+            auto_compact_setup(10000, None, true, 0);
+        let root = tmp.path().to_path_buf();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_response(tool_call_response(&tool_call));
+        mock.add_summary_response(Ok("SHOULD NOT APPEAR".to_string()));
+        mock.add_response(stop_response(r#"{"findings": []}"#));
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: initial,
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        let hint = &result.messages[1];
+        assert!(
+            hint.content.contains("was trimmed"),
+            "expected the bare hint, got: {}",
+            hint.content
+        );
+        assert!(
+            !hint.content.contains("SHOULD NOT APPEAR"),
+            "compaction must not run with max_compactions = 0, got: {}",
+            hint.content
+        );
+        assert_eq!(result.usage.total_tokens, 10 + 30);
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_auto_compact_respects_max_total_tokens_headroom() {
+        // max_total_tokens too small for a summary call → compaction is
+        // skipped by the quota guard (bare hint), and the queued summary is
+        // never consumed.
+        let (tmp, contract, tool_call, initial) =
+            auto_compact_setup(10000, Some(500), true, 3);
+        let root = tmp.path().to_path_buf();
+        let tools = default_tools(root.clone(), &[], 120, &[]);
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_response(tool_call_response(&tool_call));
+        mock.add_summary_response(Ok("SHOULD NOT APPEAR".to_string()));
+        mock.add_response(stop_response(r#"{"findings": []}"#));
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: initial,
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(!result.truncated);
+        let hint = &result.messages[1];
+        assert!(
+            hint.content.contains("was trimmed"),
+            "expected the bare hint, got: {}",
+            hint.content
+        );
+        assert!(
+            !hint.content.contains("SHOULD NOT APPEAR"),
+            "quota guard must skip compaction, got: {}",
+            hint.content
+        );
+        assert_eq!(result.usage.total_tokens, 10 + 30);
+    }
+
+    #[test]
+    fn test_dropped_to_text_renders_roles_and_tool_results() {
+        let dropped = vec![
+            Message::new(Role::User, "check the diff".to_string()),
+            Message {
+                role: Role::Assistant,
+                content: String::new(),
+                tool_call_id: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_1".into(),
+                    name: "git_diff".into(),
+                    arguments: serde_json::json!({}),
+                }]),
+            },
+            Message::with_tool_call(Role::Tool, "diff output".to_string(), "call_1".into()),
+        ];
+        let text = dropped_to_text(&dropped);
+        assert!(text.contains("User:"));
+        assert!(text.contains("check the diff"));
+        assert!(text.contains("Assistant (tool calls: git_diff):"));
+        assert!(text.contains("Tool result (call_1):"));
+        assert!(text.contains("diff output"));
+    }
+
+    #[test]
+    fn test_truncate_summary_to_budget_trims_oversized_summary() {
+        let mock = MockProvider::new("test");
+        // Mock counts ~1 token per 4 chars.
+        let cap_tokens = 50;
+        let summary = "y".repeat(400); // ~100 tokens by the mock heuristic
+        let trimmed = truncate_summary_to_budget(&mock, &summary, cap_tokens);
+        assert!(
+            mock.count_tokens(&trimmed) <= cap_tokens,
+            "trimmed summary exceeds cap: {} > {}",
+            mock.count_tokens(&trimmed),
+            cap_tokens
+        );
+        assert!(trimmed.ends_with("[summary truncated to fit token budget]"));
+        assert!(trimmed.starts_with('y'));
+
+        // Short summaries pass through untouched.
+        let short = "short summary".to_string();
+        let untouched = truncate_summary_to_budget(&mock, &short, cap_tokens);
+        assert_eq!(untouched, short);
     }
 
     #[tokio::test]

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -74,6 +74,10 @@ struct YamlTaskConfig {
     token_budget: u64,
     #[serde(default)]
     max_total_tokens: Option<u64>,
+    #[serde(default)]
+    auto_compact: bool,
+    #[serde(default = "default_max_compactions")]
+    max_compactions: u32,
     #[serde(default = "default_timeout")]
     timeout_secs: u64,
     #[serde(default = "default_shell_timeout")]
@@ -157,6 +161,10 @@ fn default_shell_timeout() -> u64 {
 
 fn default_max_iterations() -> u32 {
     10
+}
+
+fn default_max_compactions() -> u32 {
+    3
 }
 
 fn default_ambiguity() -> String {
@@ -319,6 +327,8 @@ impl Config {
                     tool_allowlist: vec![],
                     token_budget: default_token_budget(),
                     max_total_tokens: None,
+                    auto_compact: false,
+                    max_compactions: default_max_compactions(),
                     timeout_secs: default_timeout(),
                     shell_timeout_secs: default_shell_timeout(),
                     shell_env_passthrough: vec![],
@@ -355,6 +365,16 @@ impl Config {
             .ok()
             .and_then(|v| v.parse().ok())
             .or(yaml_task.max_total_tokens);
+
+        // Auto-compact: summarize dropped messages instead of bare truncation.
+        let auto_compact = match std::env::var("CLAUSURA_AUTO_COMPACT") {
+            Ok(v) => matches!(v.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+            Err(_) => yaml_task.auto_compact,
+        };
+        let max_compactions = std::env::var("CLAUSURA_MAX_COMPACTIONS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(yaml_task.max_compactions);
 
         let timeout = std::env::var("CLAUSURA_TIMEOUT")
             .ok()
@@ -427,6 +447,8 @@ impl Config {
                 tool_allowlist: yaml_task.tool_allowlist,
                 token_budget,
                 max_total_tokens,
+                auto_compact,
+                max_compactions,
                 timeout_secs: timeout,
                 shell_timeout_secs: shell_timeout,
                 shell_env_passthrough: yaml_task.shell_env_passthrough,
@@ -678,6 +700,8 @@ task:
             std::env::remove_var("CLAUSURA_AMBIGUITY_POLICY");
             std::env::remove_var("CLAUSURA_ON_INCOMPLETE");
             std::env::remove_var("CLAUSURA_SHELL_TIMEOUT");
+            std::env::remove_var("CLAUSURA_AUTO_COMPACT");
+            std::env::remove_var("CLAUSURA_MAX_COMPACTIONS");
         }
     }
 
@@ -1099,6 +1123,145 @@ task:
         .unwrap();
         assert_eq!(config.task.on_incomplete, OnIncompletePolicy::Pass);
         unsafe { std::env::remove_var("CLAUSURA_ON_INCOMPLETE") };
+    }
+
+    #[test]
+    fn test_auto_compact_defaults_off() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(!config.task.auto_compact, "auto_compact must default to off");
+        assert_eq!(config.task.max_compactions, 3);
+    }
+
+    #[test]
+    fn test_auto_compact_from_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  auto_compact: true
+  max_compactions: 5
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(config.task.auto_compact);
+        assert_eq!(config.task.max_compactions, 5);
+    }
+
+    #[test]
+    fn test_auto_compact_env_overrides_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        unsafe {
+            std::env::set_var("CLAUSURA_AUTO_COMPACT", "true");
+            std::env::set_var("CLAUSURA_MAX_COMPACTIONS", "7");
+        };
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  auto_compact: false
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(config.task.auto_compact, "env must override YAML");
+        assert_eq!(config.task.max_compactions, 7);
+        unsafe {
+            std::env::remove_var("CLAUSURA_AUTO_COMPACT");
+            std::env::remove_var("CLAUSURA_MAX_COMPACTIONS");
+        }
+    }
+
+    #[test]
+    fn test_auto_compact_env_false_strings() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        for val in ["0", "false", "no", "off"] {
+            unsafe { std::env::set_var("CLAUSURA_AUTO_COMPACT", val) };
+            let config = Config::load(
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                std::env::current_dir().unwrap(),
+                "output.sarif".into(),
+                false,
+                LogFormat::Json,
+            )
+            .unwrap();
+            assert!(!config.task.auto_compact, "{val} must parse as false");
+        }
+        unsafe { std::env::remove_var("CLAUSURA_AUTO_COMPACT") };
     }
 
     #[test]

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -78,6 +78,8 @@ struct YamlTaskConfig {
     auto_compact: bool,
     #[serde(default = "default_max_compactions")]
     max_compactions: u32,
+    #[serde(default = "default_findings_ledger")]
+    findings_ledger: bool,
     #[serde(default = "default_timeout")]
     timeout_secs: u64,
     #[serde(default = "default_shell_timeout")]
@@ -165,6 +167,10 @@ fn default_max_iterations() -> u32 {
 
 fn default_max_compactions() -> u32 {
     3
+}
+
+fn default_findings_ledger() -> bool {
+    true
 }
 
 fn default_ambiguity() -> String {
@@ -329,6 +335,7 @@ impl Config {
                     max_total_tokens: None,
                     auto_compact: false,
                     max_compactions: default_max_compactions(),
+                    findings_ledger: default_findings_ledger(),
                     timeout_secs: default_timeout(),
                     shell_timeout_secs: default_shell_timeout(),
                     shell_env_passthrough: vec![],
@@ -375,6 +382,10 @@ impl Config {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(yaml_task.max_compactions);
+        let findings_ledger = match std::env::var("CLAUSURA_FINDINGS_LEDGER") {
+            Ok(v) => matches!(v.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+            Err(_) => yaml_task.findings_ledger,
+        };
 
         let timeout = std::env::var("CLAUSURA_TIMEOUT")
             .ok()
@@ -449,6 +460,7 @@ impl Config {
                 max_total_tokens,
                 auto_compact,
                 max_compactions,
+                findings_ledger,
                 timeout_secs: timeout,
                 shell_timeout_secs: shell_timeout,
                 shell_env_passthrough: yaml_task.shell_env_passthrough,
@@ -702,6 +714,7 @@ task:
             std::env::remove_var("CLAUSURA_SHELL_TIMEOUT");
             std::env::remove_var("CLAUSURA_AUTO_COMPACT");
             std::env::remove_var("CLAUSURA_MAX_COMPACTIONS");
+            std::env::remove_var("CLAUSURA_FINDINGS_LEDGER");
         }
     }
 
@@ -1265,6 +1278,111 @@ task:
             assert!(!config.task.auto_compact, "{val} must parse as false");
         }
         unsafe { std::env::remove_var("CLAUSURA_AUTO_COMPACT") };
+    }
+
+    #[test]
+    fn test_findings_ledger_defaults_true() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(
+            config.task.findings_ledger,
+            "findings_ledger must default to true"
+        );
+    }
+
+    #[test]
+    fn test_findings_ledger_from_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+  findings_ledger: false
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(!config.task.findings_ledger);
+    }
+
+    #[test]
+    fn test_findings_ledger_env_overrides_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clean_env_vars();
+        unsafe { std::env::set_var("CLAUSURA_FINDINGS_LEDGER", "false") };
+        let yaml = r#"
+version: "1"
+task:
+  name: test
+  model: gpt-4o
+  vendor: openai
+  token_budget: 8000
+  timeout_secs: 60
+  ambiguity_policy: fail_closed
+"#;
+        let file = write_yaml(yaml);
+        let config = Config::load(
+            Some(file.path()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            std::env::current_dir().unwrap(),
+            "output.sarif".into(),
+            false,
+            LogFormat::Json,
+        )
+        .unwrap();
+        assert!(!config.task.findings_ledger, "env must override default");
+        unsafe { std::env::remove_var("CLAUSURA_FINDINGS_LEDGER") };
     }
 
     #[test]

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -1155,7 +1155,10 @@ task:
             LogFormat::Json,
         )
         .unwrap();
-        assert!(!config.task.auto_compact, "auto_compact must default to off");
+        assert!(
+            !config.task.auto_compact,
+            "auto_compact must default to off"
+        );
         assert_eq!(config.task.max_compactions, 3);
     }
 

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -279,19 +279,22 @@ fn apply_incomplete_policy(
     }
 }
 
-/// Delete archive files for the given task_id after successful execution.
-/// Silently ignores errors — this is best-effort cleanup.
+/// Delete archive and ledger files for the given task_id after successful
+/// execution. Silently ignores errors — this is best-effort cleanup.
 pub fn cleanup_archives(workspace: &Path, task_id: &str) {
     let archives_dir = workspace.join(".clausura").join("archives");
     if !archives_dir.exists() {
         return;
     }
-    let prefix = format!("context-dump-{}-", task_id);
+    let dump_prefix = format!("context-dump-{}-{}", task_id, "");
+    let ledger_prefix = format!("findings-ledger-{}", task_id);
     if let Ok(entries) = std::fs::read_dir(&archives_dir) {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
-            if name_str.starts_with(&prefix) && name_str.ends_with(".log") {
+            let is_dump = name_str.starts_with(&dump_prefix) && name_str.ends_with(".log");
+            let is_ledger = name_str.starts_with(&ledger_prefix) && name_str.ends_with(".jsonl");
+            if is_dump || is_ledger {
                 let _ = std::fs::remove_file(entry.path());
             }
         }

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -918,6 +918,7 @@ pub mod tests {
     pub struct MockProvider {
         model: String,
         responses: Arc<Mutex<VecDeque<Result<ChatResponse, ProviderError>>>>,
+        summary_responses: Arc<Mutex<VecDeque<Result<String, ProviderError>>>>,
         slow_responses: Arc<Mutex<VecDeque<Duration>>>,
     }
 
@@ -926,12 +927,18 @@ pub mod tests {
             Self {
                 model: model.to_string(),
                 responses: Arc::new(Mutex::new(VecDeque::new())),
+                summary_responses: Arc::new(Mutex::new(VecDeque::new())),
                 slow_responses: Arc::new(Mutex::new(VecDeque::new())),
             }
         }
 
         pub fn add_response(&mut self, response: ChatResponse) {
             self.responses.lock().unwrap().push_back(Ok(response));
+        }
+
+        /// Queue a response for a no-tool `chat` call (auto-compact summary).
+        pub fn add_summary_response(&mut self, summary: Result<String, ProviderError>) {
+            self.summary_responses.lock().unwrap().push_back(summary);
         }
 
         pub fn add_slow_response(&mut self, delay: Duration) {
@@ -941,8 +948,28 @@ pub mod tests {
 
     #[async_trait]
     impl Provider for MockProvider {
-        async fn chat(&self, messages: &[Message]) -> Result<ChatResponse, ProviderError> {
-            self.chat_with_tools(messages, &[]).await
+        async fn chat(&self, _messages: &[Message]) -> Result<ChatResponse, ProviderError> {
+            let delay = { self.slow_responses.lock().unwrap().pop_front() };
+            if let Some(delay) = delay {
+                tokio::time::sleep(delay).await;
+                return Err(ProviderError::Timeout("Simulated timeout".into()));
+            }
+            match self.summary_responses.lock().unwrap().pop_front() {
+                Some(Ok(text)) => Ok(ChatResponse {
+                    message: Message::new(Role::Assistant, text),
+                    usage: Usage {
+                        input_tokens: 100,
+                        output_tokens: 50,
+                        total_tokens: 150,
+                    },
+                    finish_reason: FinishReason::Stop,
+                    tool_calls: None,
+                }),
+                Some(Err(e)) => Err(e),
+                None => Err(ProviderError::ServerError(
+                    "No more mock summary responses".into(),
+                )),
+            }
         }
 
         async fn chat_with_tools(

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -400,6 +400,13 @@ pub struct TaskContract {
     /// when `auto_compact` is true.
     #[serde(default = "default_max_compactions")]
     pub max_compactions: u32,
+    /// When true, findings the agent emits during the run are appended to a
+    /// JSON-lines ledger on disk (`{workspace}/.clausura/archives/`). Before
+    /// returning, the final findings are merged with the ledger so findings
+    /// from earlier iterations survive context truncation/compaction. Default
+    /// true; costs no LLM calls and is deterministic.
+    #[serde(default = "default_findings_ledger")]
+    pub findings_ledger: bool,
     pub timeout_secs: u64,
     #[serde(default = "default_shell_timeout_secs")]
     pub shell_timeout_secs: u64,
@@ -429,6 +436,10 @@ fn default_max_iterations() -> u32 {
 
 fn default_max_compactions() -> u32 {
     3
+}
+
+fn default_findings_ledger() -> bool {
+    true
 }
 
 fn default_shell_timeout_secs() -> u64 {
@@ -749,6 +760,7 @@ mod tests {
             max_total_tokens: None,
             auto_compact: false,
             max_compactions: 3,
+            findings_ledger: true,
             timeout_secs: 300,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],
@@ -764,6 +776,7 @@ mod tests {
         assert_eq!(contract.on_incomplete, OnIncompletePolicy::Fail);
         assert!(!contract.auto_compact);
         assert_eq!(contract.max_compactions, 3);
+        assert!(contract.findings_ledger);
     }
 
     #[test]

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -390,6 +390,16 @@ pub struct TaskContract {
     /// incomplete. `None` means no cap.
     #[serde(default)]
     pub max_total_tokens: Option<u64>,
+    /// When true, the agent loop summarizes messages dropped by context
+    /// truncation with an LLM call and injects the summary at the truncation
+    /// boundary instead of a bare "context trimmed" hint. Default false.
+    #[serde(default)]
+    pub auto_compact: bool,
+    /// Per-run cap on auto-compaction LLM calls. Guards against compaction
+    /// loops on long-running tasks. Default 3; 0 disables compaction even
+    /// when `auto_compact` is true.
+    #[serde(default = "default_max_compactions")]
+    pub max_compactions: u32,
     pub timeout_secs: u64,
     #[serde(default = "default_shell_timeout_secs")]
     pub shell_timeout_secs: u64,
@@ -415,6 +425,10 @@ pub struct TaskContract {
 
 fn default_max_iterations() -> u32 {
     10
+}
+
+fn default_max_compactions() -> u32 {
+    3
 }
 
 fn default_shell_timeout_secs() -> u64 {
@@ -733,6 +747,8 @@ mod tests {
             tool_allowlist: vec![],
             token_budget: 32000,
             max_total_tokens: None,
+            auto_compact: false,
+            max_compactions: 3,
             timeout_secs: 300,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],
@@ -746,6 +762,8 @@ mod tests {
         assert_eq!(contract.ambiguity_policy, AmbiguityPolicy::FailClosed);
         assert!(contract.gating_rules.is_empty());
         assert_eq!(contract.on_incomplete, OnIncompletePolicy::Fail);
+        assert!(!contract.auto_compact);
+        assert_eq!(contract.max_compactions, 3);
     }
 
     #[test]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -41,6 +41,9 @@ task:
   token_budget: 32000                # Context-window budget. Drives message truncation.
   max_total_tokens: 200000           # Optional. Cumulative token cap across all LLM calls.
                                      # Unset = no cap. When reached, run stops (incomplete).
+  auto_compact: false                # Optional. Summarize dropped context with an LLM call
+                                     # instead of a bare truncation hint.
+  max_compactions: 3                 # Per-run cap on auto-compact calls. 0 disables.
   timeout_secs: 300                  # Max wall-clock time for the entire run.
   max_iterations: 10                 # Max agent loop iterations (tool calls + LLM turns).
   shell_timeout_secs: 120            # Per-command timeout for shell_exec.
@@ -184,6 +187,25 @@ task:
   token_budget: 32000        # context window budget
   max_total_tokens: 200000   # stop after $X worth of API calls
 ```
+
+### `task.auto_compact`
+
+**Default: false.** When the conversation exceeds `token_budget`, Clausura truncates older messages and injects a bare "context trimmed" hint. With `auto_compact: true`, the dropped messages are instead **summarized with one extra LLM call** and the summary is injected at the truncation boundary — the agent keeps remembering earlier findings, files examined, and decisions across truncation instead of relying on the `read_file`-the-archive hint.
+
+Auto-compact never changes the run's pass/fail semantics:
+
+- The summary call is billed and counts toward `max_total_tokens`, but is **skipped** when the remaining quota is too small to afford it (bare hint is used instead).
+- If the summary call fails or times out, Clausura falls back to the bare hint silently.
+- Summaries are capped at 10% of `token_budget`; oversized output is trimmed to fit.
+- `max_compactions` (default 3) bounds summary calls per run; set it to `0` to disable compaction even with `auto_compact: true`.
+
+```yaml
+task:
+  auto_compact: true       # summarize dropped context (adds one LLM call per compaction)
+  max_compactions: 3       # at most 3 summary calls per run
+```
+
+Env override: `CLAUSURA_AUTO_COMPACT=true`, `CLAUSURA_MAX_COMPACTIONS=5`.
 
 ### `task.timeout_secs`
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -198,7 +198,7 @@ Auto-compact never changes the run's pass/fail semantics:
 
 - The summary call is billed and counts toward `max_total_tokens`, but is **skipped** when the remaining quota is too small to afford it (bare hint is used instead).
 - If the summary call fails or times out, Clausura falls back to the bare hint silently.
-- Summaries are capped at 10% of `token_budget`; oversized output is trimmed to fit.
+- Summaries are sized to the headroom the retained context leaves under the truncation threshold (capped at 10% of `token_budget`); oversized output is trimmed to fit. A compacted context always stays within budget, so a successful compaction can never push the run into "incomplete".
 - `max_compactions` (default 3) bounds summary calls per run; set it to `0` to disable compaction even with `auto_compact: true`.
 
 ```yaml

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,6 +44,8 @@ task:
   auto_compact: false                # Optional. Summarize dropped context with an LLM call
                                      # instead of a bare truncation hint.
   max_compactions: 3                 # Per-run cap on auto-compact calls. 0 disables.
+  findings_ledger: true              # Persist interim findings to a disk ledger and merge
+                                     # them back before the final answer (lossless memory).
   timeout_secs: 300                  # Max wall-clock time for the entire run.
   max_iterations: 10                 # Max agent loop iterations (tool calls + LLM turns).
   shell_timeout_secs: 120            # Per-command timeout for shell_exec.
@@ -206,6 +208,23 @@ task:
 ```
 
 Env override: `CLAUSURA_AUTO_COMPACT=true`, `CLAUSURA_MAX_COMPACTIONS=5`.
+
+### `task.findings_ledger`
+
+**Default: true.** Whenever the agent emits findings in a response, Clausura appends them to `{workspace}/.clausura/archives/findings-ledger-{task_id}.jsonl` (one JSON object per line). When the run finishes, the final findings are merged with the ledger:
+
+- The final response wins on conflicts (same `rule_id` + location + message).
+- Findings from iterations that were truncated out of context are appended back — so context truncation/compaction can never silently drop an already-discovered finding.
+- The merge is deterministic (plain deduplication, no LLM call) and zero-cost.
+
+This is the **lossless complement to auto-compact**: compaction preserves continuity (summary in context), the ledger preserves completeness (findings on disk). It also applies when `auto_compact` is off — bare truncation drops just as much.
+
+```yaml
+task:
+  findings_ledger: true   # default; set false to disable
+```
+
+Env override: `CLAUSURA_FINDINGS_LEDGER=false`.
 
 ### `task.timeout_secs`
 

--- a/docs/research-auto-compact.md
+++ b/docs/research-auto-compact.md
@@ -270,9 +270,12 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 > **已实现 (2026-08-04)**：§7.1 的 Phase 1 已落地为可选开关（默认关闭，行为零变化）：
 > `auto_compact: true/false`、`max_compactions: u32`（默认 3，0 = 关闭），Env
 > `CLAUSURA_AUTO_COMPACT` / `CLAUSURA_MAX_COMPACTIONS`。实现遵循本报告全部关键约束：
-> 触发阈值与截断一致、摘要注入 index 1（User 角色）、摘要上限 = 10% token_budget、
-> compact 计费计入 `max_total_tokens` 且调用前有配额守卫、失败/超时降级为现有截断+提示、
-> 摘要输入对被丢 Tool 消息做文本化以绕过 Anthropic `tool_use_id` 配对问题。
+> 触发阈值与截断一致、摘要注入 index 1（User 角色）、摘要上限按**截断阈值下的剩余空间**
+> 动态计算（`80% 预算 − 保留尾部 token − hint 固定文本`，另设 10% 预算封顶；剩余空间不足
+> 200 token 时跳过 compact）——保证摘要注入后上下文仍低于 80% 阈值，成功 compact 不会
+> 反手把 run 标记 incomplete；compact 计费计入 `max_total_tokens` 且调用前有配额守卫、
+> 失败/超时降级为现有截断+提示、摘要输入对被丢 Tool 消息做文本化以绕过 Anthropic
+> `tool_use_id` 配对问题。
 > Phase 0（确定性 findings 台账）已以**磁盘 ledger** 形式实现（`findings_ledger`，默认 true，
 > 见 §7.2 验收点），并与 compact 形成无损互补：截断/compact 丢掉的早期 findings 由
 > ledger 在终局回读合并，不再依赖摘要或模型自觉。

--- a/docs/research-auto-compact.md
+++ b/docs/research-auto-compact.md
@@ -1,0 +1,233 @@
+# Clausura 自动 Compact（对话摘要压缩）的价值与成本调研
+
+Status: research / proposal（本分支仅调研，无代码改动）
+Branch: `research/auto-compact`
+Date: 2026-08-04
+
+## 1. 结论先行（TL;DR）
+
+- **现状**：Clausura 超预算时的处理是"截断 + 归档 + 提示"。即直接丢弃旧消息（`truncate`），
+  把被丢的消息归档到 `.clausura/archives/`，并在对话里注入一条"上下文被裁剪，可用
+  `read_file` 查看归档"的 User 提示。这是**有损**的：模型会忘掉早期迭代里已经发现的
+  findings、已经看过的文件、正在验证的假设。
+- **auto-compact 的定义**：在触发截断时，额外用一次 LLM 调用把将被丢弃的消息**总结**成一段
+  紧凑摘要，把摘要注入对话（替代裸丢弃），原始消息仍然归档。模型在后续迭代里"记得"
+  发生过什么，代价是每次 compact 多一次 LLM 调用（token 成本 + 延迟 + 非确定性）。
+- **价值判断**：价值**真实但集中**在两类场景——(a) 工具调用多、对话长的任务；(b) token_budget
+  配得比模型上下文小很多的任务。对短任务、大预算（128k+ 上下文）任务，收益趋近于零。
+- **成本判断**：实现成本中等（约 3–5 人日，若先做"确定性 findings 台账"降级版约 1 人日）；
+  每次 compact 的 token/延迟开销占比小（约 +3–10% 计费 token，+5–20s 延迟），
+  但引入了一块新的非确定性表面，与"deterministic gating"哲学需要谨慎调和。
+- **建议**：做成**默认关闭的可选开关** `auto_compact: true`，且**失败必须优雅降级**到现有
+  截断+归档逻辑（compact 失败不能让任务失败）。若追求最低成本，可先做 Phase 0 的
+  "确定性 findings 台账"（不调 LLM，把对话里已有的 findings JSON 汇总成台账注入），
+  再评估是否需要 Phase 1 的 LLM 摘要。
+
+---
+
+## 2. 现状梳理（代码事实）
+
+### 2.1 触发条件与截断算法
+
+- `token_budget` 默认 **32000**（`crates/clausura-core/src/config.rs` `default_token_budget`，
+  可经 `CLAUSURA_TOKEN_BUDGET` / `--token-budget` / YAML 覆盖）。
+- `ContextManager`（`crates/clausura-core/src/context.rs`）：
+  - `count_tokens`：`provider.count_tokens(content)` 之和 + 每条消息 1 token 的固定开销。
+  - token 计数是**启发式**：OpenAI 系 `len/3`，Anthropic `len/3.5`，Custom `len/4`
+    （`provider.rs`）。不是 tiktoken，只用于预算控制，不用于计费。
+  - `should_truncate`：用量 > **80%** 预算时触发。
+  - `truncate`：二分查找，保留"系统消息 + 能装进 **75%** 预算的尾部 N 条"，**保证
+    assistant(tool_calls)→tool 成对不被拆开**，其余全部丢弃。
+  - `keep_last_n` 是纯保留尾部，**没有任何摘要/压缩**。
+
+### 2.2 截断后的处理（`crates/clausura-core/src/agent.rs`）
+
+截断后：
+
+1. 被丢弃消息写入 `.clausura/archives/context-dump-{task_id}-{seq}.log`（JSON Lines，
+   逐条可回放）。
+2. 在**系统消息之后（index 1）**注入一条 User 提示：
+   "⚠️ Context was trimmed... N earlier messages are archived at ... Use `read_file` to
+   inspect if you need context from earlier iterations."
+3. 若截断后仍超预算 → break，整个 run 标记 `truncated = true`，走
+   `extract_findings_lenient`（尽力而为）→ 默认 `on_incomplete: fail` 退出码 2。
+
+### 2.3 相关约束（实现 compact 时必须遵守的既有规则）
+
+- **消息配对**：OpenAI/Anthropic API 拒绝"有 tool_calls 的 assistant 后面没有对应 tool
+  结果"。截断与注入都必须维持这一不变式（现有代码在 `keep_last_n` 与 hint 注入位置都
+  专门处理过）。
+- **Anthropic 消息转换**：`provider.rs::convert_messages_to_anthropic` 把 Tool 消息转成
+  `tool_result`，且 `tool_use_id` 硬编码为 `"unknown"`——**喂给摘要调用的被丢弃 Tool 消息
+  在 Anthropic 侧本来就配对不完整**，这是做摘要时的一个已知脆弱点。
+- **计费**：`max_total_tokens` 只统计 agent 循环里的 `chat_with_tools` 调用；若 compact
+  调用不计入该上限，用户会看到"没到上限却多花钱"；若计入，则 compact 会挤占 agent 迭代
+  的预算，需要明示。
+- **快照/断点**：`SnapshotManager` 保存的是消息数组；compact 后的摘要作为 User 消息自然
+  进入快照，`--resume` 无需特殊处理（但恢复后的后续 compact 触发仍按同一套逻辑）。
+- **工具清单**：read_file、git_diff、shell_exec、list_files、grep（5 个内置工具）。
+  摘要调用本身不应暴露任何工具（无 tool_calls）。
+
+---
+
+## 3. 什么是"给 Clausura 加 auto-compact"
+
+在 agent 循环里，把现有的"截断→归档→提示"升级为：
+
+```
+触发（>80% 预算）
+  ├─ 取将被丢弃的消息段（从 index 1 到保留尾部起点）
+  ├─ 1 次 LLM 摘要调用（无工具）：输入 = 被丢消息 + 摘要指令，输出 = 紧凑摘要
+  ├─ 摘要注入 index 1（User 角色），替换"纯提示"；被丢消息照旧归档
+  └─ 摘要失败/超时 → 回退到现有"提示 + 归档"逻辑（优雅降级，不 fail run）
+```
+
+可配置项（建议）：`auto_compact: true/false`（默认 false）、摘要输出预算上限
+（如 ≤ token_budget 的 10%）、是否把 compact 计费计入 `max_total_tokens`。
+
+---
+
+## 4. 价值分析（Value）
+
+### 4.1 直接价值：保住"过程记忆"，减少有损截断导致的错误结局
+
+当前截断的**真实损失模式**（都是 CI 里踩过的坑）：
+
+1. **丢失已发现 findings**：任务在第 6 轮迭代触发截断，第 1–5 轮发现的 finding 全部丢出
+   上下文。模型在 final Stop 时可能给出空 findings（它真不记得了），或由于提示才去
+   `read_file` 翻归档——但"它得先想起来要去翻、还得知道翻哪一段"。结果是：
+   - `on_incomplete: pass` 下：空 findings 通过 `max_findings: 0` 门禁 → **假通过**；
+   - `on_incomplete: fail` 下：跑完但结果残缺仍退出 2 → **假失败**。
+2. **重复劳动 → 迭代耗尽**：截断后模型忘了看过哪些文件、跑过哪些 git diff，
+   重新执行相同工具调用，`max_iterations` 被空耗 → `FinishReason::Length` 或迭代上限
+   → incomplete。
+
+auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings 列表、已检查文件、当前假设"
+进入后续迭代。对话在语义上是连续的，agent 更可能以干净的 `Stop` 结束并产出完整 findings。
+
+### 4.2 间接价值
+
+- **与现有归档机制正交**：归档照旧，摘要只是"上下文内副本"，审计/回放能力不降级。
+- **可验证性**：摘要进对话、原始消息进归档，两者可对比，compact 质量可事后审计。
+- **门禁确定性不受影响**：gating 仍是纯规则引擎（`rules.rs`），compact 只影响对话内容，
+  不影响 findings 的确定性评估——与 "Why JSON findings instead of free-text" 的设计决策
+  不冲突（前提：compact 失败永不改变 run 的 pass/fail 语义）。
+- **多模型统一收益**：对 token 计数是启发式的三家 provider（OpenAI/Anthropic/Custom）
+  都同样受益，不需要模型侧特判。
+
+### 4.3 价值适用的场景边界（诚实评估）
+
+| 场景 | 收益 |
+|------|------|
+| 长任务（>6 轮工具调用）、diff 大、预算 32k | **高**：这是目前 incomplete 假失败/假通过的重灾区 |
+| 短任务、单轮工具调用、预算富余 | 接近零：大概率永远不会触发截断 |
+| 128k+ 上下文模型 + 大预算 | 低：上下文空间大，截断触发概率低；真要控成本时另说 |
+| 严格审计型 CI（每次运行都要可回放） | 中：归档仍在，摘要可审计，但引入 LLM 摘要这一非确定中间产物 |
+
+---
+
+## 5. 成本分析（Cost）
+
+### 5.1 运行期成本（token / 延迟 / 计费）
+
+以默认预算 32k 为例，触发点 80%（25.6k）、目标 75%（24k）。假设触发时上下文约 30k：
+
+- 被丢弃 ≈ 30k − 24k = **约 6k token**（只多不少，如果一条大工具输出顶进来会更多）。
+- 摘要调用：输入 ≈ 6k + 摘要指令 ~0.3k = **~6.3k**；输出按上限 10% 预算封顶 ~3.2k、
+  实际通常 **0.5–1k**。单次 compact 合计 **~7–9k 计费 token**。
+- 换算成本（粗算）：
+  - DeepSeek 级别（$0.27/M in、$1.10/M out）：单次 ~**$0.003**；
+  - GPT-4o 级别（$2.5/M in、$10/M out）：单次 ~**$0.02**；
+  - 一次跑 2–3 次 compact 的任务：计费 token 增加 **~3–10%**（相对正常 60–200k 总量）。
+- 延迟：6k token 输入的摘要调用约 **5–20s**（慢模型更长），且与 agent 迭代串行。
+- 需要把 compact 调用计入 `max_total_tokens` 与 `timeout_secs` 的账——否则用户对
+  "预算超支/超时"的预期会被悄悄打破。
+
+结论：绝对成本小，但**不是零**，且与任务时长线性叠加；对按次计费/配额紧张的 CI 账户
+需要在文档里给清楚预期。
+
+### 5.2 工程质量成本（实现复杂度）
+
+按文件逐项评估：
+
+| 改动点 | 复杂度 | 说明 |
+|--------|--------|------|
+| `Provider` 增加摘要入口 | 低 | 复用 `chat`（无工具）；但需区分"agent 调用"与"compact 调用"的 usage 记账 |
+| `agent.rs` 循环集成 | 中 | 在截断分支先尝试摘要；摘要消息注入 index 1（保持 assistant→tool 配对不变式） |
+| 失败降级路径 | 中 | 摘要调用出错/超时/返回空 → 回退到现有"提示+归档"，**绝不能 fail run**；要写测试覆盖 |
+| usage 记账 | 中 | 新 `Usage` 条目、计入 `max_total_tokens` 的开关、日志可观测（`tracing`） |
+| Anthropic 转换 | 中 | `convert_messages_to_anthropic` 对 Tool 消息 `tool_use_id: "unknown"`，被丢 Tool 消息喂给摘要调用时配对本就残缺——需在喂给摘要前清洗或跳过纯 tool 结果 |
+| 配置/校验/文档 | 低 | 新增字段的 serde default、YAML 校验、`docs/guide/*` 与 README 更新 |
+| 测试 | 中 | `MockProvider` 需支持串行返回摘要响应；现有 13 处 `add_response` 用例要核对调用顺序；新增"compact 成功/降级/连续 compact"用例 |
+
+净估：**Phase 1 约 3–5 人日**（含测试与文档）。
+
+### 5.3 非确定性 / 正确性风险（最值得警惕的成本）
+
+- **摘要是有损且非确定的**：摘要可能漏掉关键 finding，甚至"脑补"一个不存在的结论，
+  后续迭代会信任它。这与 Clausura "bounded, deterministic" 的核心卖点有张力。
+- **提示注入强化面**：被摘要的消息本身来自（不可信的）仓库内容，摘要模型的改写可能
+  **强化**注入的指令。缓解：摘要只作 User 消息（不是 system）、摘要调用不给工具、
+  gating 永不信任 LLM 散文。
+- **摘要质量不可测**：没有客观指标；只能靠抽查归档对比。需要日志记录每次 compact 的
+  摘要与被丢消息，供事后审计。
+
+### 5.4 维护成本
+
+- 每多一个开关就是一份长期兼容承诺（默认值、行为、文档）。
+- 与后续"真正的 tokenizer / 自适应预算"等功能叠加时，触发逻辑会互相纠缠，需要保持
+  单一路径（compact 只在"将要截断"这一种情况下发生）。
+
+---
+
+## 6. 备选方案（Alternatives）
+
+| 方案 | 成本 | 效果 | 点评 |
+|------|------|------|------|
+| **A. 现状**：截断+归档+提示 | 0 | 有损；incomplete 结局多 | 基线 |
+| **B. 确定性 findings 台账（Phase 0）** | ~1 人日 | 中 | **不调 LLM**：从对话中已有的 assistant findings JSON（`extract_findings` 已能解析）提取汇总，注入"截止目前 N 条 finding"台账。直接消灭"丢 findings"这个最大痛点，零额外计费、零非确定性 |
+| **C. LLM 摘要 compact（Phase 1）** | 3–5 人日 | 高 | 本调研主体方案；可选开关 + 优雅降级 |
+| **D. 只压缩工具输出** | 中 | 中 | 工具输出是上下文膨胀主因；已有 32KB/1000 行截断，可再降。但模型可能因此重新请求 → 需配合台账 |
+| **E. 换真实 tokenizer / 调大预算** | 低 | 中 | tiktoken 让触发更可预测；128k 预算直接让截断少发生。是**今天最便宜的缓解手段**，应作为 compact 的前置/并行项 |
+| **F. 混合**：B（台账）默认开 + C（摘要）可选 | 1 + 3–5 人日 | 最高 | 建议终态：台账兜底记忆，摘要增强连续性 |
+
+---
+
+## 7. 建议与实施路线
+
+### 7.1 建议
+
+1. **先做 Phase 0（确定性 findings 台账，~1 人日）**：零 LLM 成本、零非确定性，
+   直接修复"截断丢 findings → 假通过/假失败"这一最痛问题。落地简单：在截断注入点，
+   用现有 `extract_findings` 从保留/丢弃消息中提取 findings 摘要成台账注入。
+2. **Phase 1（LLM 摘要 compact）做成默认关闭的可选开关**：
+   - 配置：`auto_compact: true`（默认 false，行为零变化、向后兼容）；
+   - 触发：与截断同一阈值（>80% 预算），一次任务最多 N 次（防死循环）；
+   - 摘要上限：≤ token_budget 的 10%，且摘要后仍须通过 `should_truncate` 检查；
+   - 记账：compact 调用单独记 usage，默认**计入** `max_total_tokens`，日志明示；
+   - 降级：摘要失败/超时 → 回退现状（提示+归档），run 状态不受影响；
+   - 注入位置：index 1，User 角色，维持 assistant→tool 配对不变式；
+   - 摘要指令：要求**逐条保留 findings**（rule_id/severity/message），禁止发挥。
+3. **并行做 E（预算默认值/文档）**：把 `token_budget` 默认值与模型上下文窗口对齐
+   （如默认提到 64k），减少 compact 触发频次。
+
+### 7.2 验收要点（若实施）
+
+- 触发 compact 后，后续 `Stop` 响应的 findings 与归档内容对得上（抽查）。
+- compact 调用失败、超时、连续触发时，run 的 exit code 与 `on_incomplete` 语义不变。
+- `max_total_tokens` 上限在 compact 开启时仍精确生效。
+- Anthropic vendor 下被丢 Tool 消息不导致摘要调用 400/配对错乱。
+- `--resume` 恢复含摘要的对话后行为一致。
+- 归档目录清理逻辑（成功时删除）不受影响。
+
+---
+
+## 8. 参考（代码位置）
+
+- `crates/clausura-core/src/context.rs` — 预算跟踪、截断算法、归档
+- `crates/clausura-core/src/agent.rs` — agent 循环、截断注入、findings 提取
+- `crates/clausura-core/src/provider.rs` — provider trait、启发式 token 计数、Anthropic 消息转换
+- `crates/clausura-core/src/config.rs` / `types.rs` — `TaskContract`、默认值、校验
+- `crates/clausura-core/src/snapshot.rs` — 快照/断点（compact 摘要随消息自然持久化）
+- `docs/guide/overview.md`、`docs/guide/troubleshooting.md`、`README.md` — 现状文档与
+  "context exhausted" 排障路径

--- a/docs/research-auto-compact.md
+++ b/docs/research-auto-compact.md
@@ -1,8 +1,12 @@
 # Clausura 自动 Compact（对话摘要压缩）的价值与成本调研
 
-Status: research / proposal（本分支仅调研，无代码改动）
+Status: implemented on this branch (originally research / proposal)
 Branch: `research/auto-compact`
 Date: 2026-08-04
+
+> **Update (2026-08-04):** Phase 1 (LLM 摘要 compact) 已在本分支实现：
+> `auto_compact`（默认 false）+ `max_compactions`（默认 3）已落地，含配额守卫与
+> 失败降级。详见 §7.1 与 §9。本报告其余部分保留为设计依据与成本记录。
 
 ## 1. 结论先行（TL;DR）
 
@@ -257,6 +261,14 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 
 ## 8. 建议与实施路线
 
+> **已实现（2026-08-04）**：§7.1 的 Phase 1 已落地为可选开关（默认关闭，行为零变化）：
+> `auto_compact: true/false`、`max_compactions: u32`（默认 3，0 = 关闭），Env
+> `CLAUSURA_AUTO_COMPACT` / `CLAUSURA_MAX_COMPACTIONS`。实现遵循本报告全部关键约束：
+> 触发阈值与截断一致、摘要注入 index 1（User 角色）、摘要上限 = 10% token_budget、
+> compact 计费计入 `max_total_tokens` 且调用前有配额守卫、失败/超时降级为现有截断+提示、
+> 摘要输入对被丢 Tool 消息做文本化以绕过 Anthropic `tool_use_id` 配对问题。
+> Phase 0（确定性 findings 台账）尚未实施，可作后续低成本增强。
+
 ### 7.1 建议
 
 1. **先做 Phase 0（确定性 findings 台账，~1 人日）**：零 LLM 成本、零非确定性，
@@ -288,9 +300,12 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 ## 9. 参考（代码位置）
 
 - `crates/clausura-core/src/context.rs` — 预算跟踪、截断算法、归档
-- `crates/clausura-core/src/agent.rs` — agent 循环、截断注入、findings 提取
-- `crates/clausura-core/src/provider.rs` — provider trait、启发式 token 计数、Anthropic 消息转换
-- `crates/clausura-core/src/config.rs` / `types.rs` — `TaskContract`、默认值、校验
+- `crates/clausura-core/src/agent.rs` — agent 循环、截断注入、auto-compact（`try_compact`、
+  `dropped_to_text`、`compact_request_messages`、`truncate_summary_to_budget`）、findings 提取
+- `crates/clausura-core/src/provider.rs` — provider trait、启发式 token 计数、Anthropic 消息转换、
+  MockProvider 摘要队列
+- `crates/clausura-core/src/config.rs` / `types.rs` — `TaskContract`（新增 `auto_compact` /
+  `max_compactions`）、默认值、YAML/Env 解析与校验
 - `crates/clausura-core/src/snapshot.rs` — 快照/断点（compact 摘要随消息自然持久化）
 - `docs/guide/overview.md`、`docs/guide/troubleshooting.md`、`README.md` — 现状文档与
   "context exhausted" 排障路径

--- a/docs/research-auto-compact.md
+++ b/docs/research-auto-compact.md
@@ -70,7 +70,69 @@ Date: 2026-08-04
 
 ---
 
-## 3. 什么是"给 Clausura 加 auto-compact"
+## 3. 三者关系：token_budget / max_total_tokens / auto_compact
+
+这三个概念历史上就被混淆过（v1.2.0 之前把累计计费 token 误当成上下文预算，导致
+正常 run 被误判 incomplete，见 commit `1f88d76`）。建议在文档与 README 里把它们
+显式区分开。
+
+### 3.1 各自职责边界
+
+| 概念 | 控制什么 | 默认值 | 触发后的行为 |
+|------|---------|--------|-------------|
+| `token_budget` | **单次请求**的上下文大小上限（system + 消息历史，含将来注入的摘要） | 32000 | 用量 >80% 触发截断，压回 75% 以内；压不住 → incomplete |
+| `max_total_tokens` | **整次运行**累计计费 token 上限（所有 LLM 调用 `usage.total_tokens` 之和） | None（无上限） | 累计达到 → 停止 agent 循环 → incomplete |
+| `auto_compact`（提案） | 在 `token_budget` 触发截断时，**用摘要替换裸丢弃**的处理策略 | false（默认关） | 触发一次 LLM 摘要调用，把被丢消息总结注入对话 |
+
+一句话：`token_budget` 管"单次请求多大"，`max_total_tokens` 管"总共花多少"，
+`auto_compact` 管"预算逼近时旧消息怎么处理"。前两者是**约束**，compact 是**策略**。
+
+### 3.2 交互关系（关键点）
+
+1. **触发链**：`auto_compact` **只由 `token_budget` 触发**（>80% 阈值），与
+   `max_total_tokens` 无触发关系。`max_total_tokens` 到达时无论上下文多空都停——
+   compact 救不了它。
+2. **计费链**：compact 调用是真实 LLM 调用，其 usage 应**计入** `max_total_tokens`
+   （默认），否则用户会看到"没到配额却多花钱"。但计入后必须**防死循环**：调用前检查
+   剩余配额，若不足以完成一次 compact，应跳过 compact 直接走降级截断——否则
+   compact 自己把配额打满，反而比不 compact 更早中断 run。
+3. **预算链**：compact 的产物（摘要）**回填 `token_budget`**——摘要注入后仍须通过
+   `should_truncate` 检查；摘要大小应设上限（建议 ≤ `token_budget` 的 10%）。
+   compact 不改变 `token_budget` 本身，只是让"被丢掉的记忆"以低成本形式留在预算内。
+4. **终止语义不变**：两种终止（`token_budget` 压不住 / `max_total_tokens` 到达）都
+   标记 incomplete，`on_incomplete` 策略不变。compact 只降低"截断后失忆 → 重复工具
+   调用 → 长度/迭代超限"的**概率**，不改变任何终止条件本身。
+5. **总量净效应不确定**：
+   - 不 compact：后续请求 input 更小，但失忆导致重复工具调用 → 请求数变多；
+   - compact：后续请求 input 多一段摘要，但记忆连续 → 请求数减少；
+   - 净 token 可能是节省（长任务），也可能是支出（短任务恰好触发一次）。
+   这正是"默认关闭 + 用户按场景开启"的原因。
+
+### 3.3 判定顺序（每次迭代）
+
+```
+迭代开始
+├─ max_total_tokens 已达? ──是──▶ break → incomplete
+├─ token_budget 用量 >80%? ──否──▶ 正常 chat_with_tools
+│   └─是
+│       ├─ auto_compact 开 & 剩余配额够一次 compact & 未超 compact 次数上限?
+│       │    是 → 摘要调用（计入 max_total_tokens）→ 摘要注入 index 1 → 归档原始消息
+│       │    否 → 现有截断 + 提示 + 归档（降级）
+│       └─ 截断/摘要后仍 >80%? ──是──▶ break → incomplete
+└─ 正常推进
+```
+
+### 3.4 配置层面的显式化建议
+
+- 文档用表格明确"谁管什么"，并给典型组合示例：
+  `token_budget: 32000, max_total_tokens: 200000, auto_compact: true`——单请求 ≤32k、
+  整轮 ≤200k、预算逼近时摘要续命。
+- 明确说明一个**反直觉现象**：`max_total_tokens` 设得接近 `token_budget`（如 32000）时，
+  `auto_compact` 基本不会生效（配额被 agent 自身调用先耗尽），属正常，不是 bug。
+
+---
+
+## 4. 什么是"给 Clausura 加 auto-compact"
 
 在 agent 循环里，把现有的"截断→归档→提示"升级为：
 
@@ -87,7 +149,7 @@ Date: 2026-08-04
 
 ---
 
-## 4. 价值分析（Value）
+## 5. 价值分析（Value）
 
 ### 4.1 直接价值：保住"过程记忆"，减少有损截断导致的错误结局
 
@@ -126,7 +188,7 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 
 ---
 
-## 5. 成本分析（Cost）
+## 6. 成本分析（Cost）
 
 ### 5.1 运行期成本（token / 延迟 / 计费）
 
@@ -140,7 +202,7 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
   - GPT-4o 级别（$2.5/M in、$10/M out）：单次 ~**$0.02**；
   - 一次跑 2–3 次 compact 的任务：计费 token 增加 **~3–10%**（相对正常 60–200k 总量）。
 - 延迟：6k token 输入的摘要调用约 **5–20s**（慢模型更长），且与 agent 迭代串行。
-- 需要把 compact 调用计入 `max_total_tokens` 与 `timeout_secs` 的账——否则用户对
+- 需要把 compact 调用计入 `max_total_tokens` 与 `timeout_secs` 的账（关系细节见 §3.2）——否则用户对
   "预算超支/超时"的预期会被悄悄打破。
 
 结论：绝对成本小，但**不是零**，且与任务时长线性叠加；对按次计费/配额紧张的 CI 账户
@@ -180,7 +242,7 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 
 ---
 
-## 6. 备选方案（Alternatives）
+## 7. 备选方案（Alternatives）
 
 | 方案 | 成本 | 效果 | 点评 |
 |------|------|------|------|
@@ -193,7 +255,7 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 
 ---
 
-## 7. 建议与实施路线
+## 8. 建议与实施路线
 
 ### 7.1 建议
 
@@ -205,6 +267,7 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
    - 触发：与截断同一阈值（>80% 预算），一次任务最多 N 次（防死循环）；
    - 摘要上限：≤ token_budget 的 10%，且摘要后仍须通过 `should_truncate` 检查；
    - 记账：compact 调用单独记 usage，默认**计入** `max_total_tokens`，日志明示；
+     调用前须检查剩余配额，不足则跳过 compact 走降级截断（见 §3.2 计费链）；
    - 降级：摘要失败/超时 → 回退现状（提示+归档），run 状态不受影响；
    - 注入位置：index 1，User 角色，维持 assistant→tool 配对不变式；
    - 摘要指令：要求**逐条保留 findings**（rule_id/severity/message），禁止发挥。
@@ -222,7 +285,7 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 
 ---
 
-## 8. 参考（代码位置）
+## 9. 参考（代码位置）
 
 - `crates/clausura-core/src/context.rs` — 预算跟踪、截断算法、归档
 - `crates/clausura-core/src/agent.rs` — agent 循环、截断注入、findings 提取

--- a/docs/research-auto-compact.md
+++ b/docs/research-auto-compact.md
@@ -7,6 +7,12 @@ Date: 2026-08-04
 > **Update (2026-08-04):** Phase 1 (LLM 摘要 compact) 已在本分支实现：
 > `auto_compact`（默认 false）+ `max_compactions`（默认 3）已落地，含配额守卫与
 > 失败降级。详见 §7.1 与 §9。本报告其余部分保留为设计依据与成本记录。
+>
+> **Update 2 (2026-08-04)**：新增**磁盘 findings ledger**（`findings_ledger`，默认 true）——
+> 运行中每轮响应出现的 findings 追加到 `.clausura/archives/findings-ledger-{task_id}.jsonl`，
+> 终局 Stop 时确定性合并回最终 findings（去重键 rule_id+location+message，最终响应优先）。
+> 这是 compact 的**无损互补**：compact 保上下文连续性，ledger 保结果完整性，零 LLM 成本、
+> 确定性、可审计。顺带修复了 ToolCalls 分支丢弃 assistant content 的信息丢失点。
 
 ## 1. 结论先行（TL;DR）
 
@@ -261,13 +267,15 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 
 ## 8. 建议与实施路线
 
-> **已实现（2026-08-04）**：§7.1 的 Phase 1 已落地为可选开关（默认关闭，行为零变化）：
+> **已实现 (2026-08-04)**：§7.1 的 Phase 1 已落地为可选开关（默认关闭，行为零变化）：
 > `auto_compact: true/false`、`max_compactions: u32`（默认 3，0 = 关闭），Env
 > `CLAUSURA_AUTO_COMPACT` / `CLAUSURA_MAX_COMPACTIONS`。实现遵循本报告全部关键约束：
 > 触发阈值与截断一致、摘要注入 index 1（User 角色）、摘要上限 = 10% token_budget、
 > compact 计费计入 `max_total_tokens` 且调用前有配额守卫、失败/超时降级为现有截断+提示、
 > 摘要输入对被丢 Tool 消息做文本化以绕过 Anthropic `tool_use_id` 配对问题。
-> Phase 0（确定性 findings 台账）尚未实施，可作后续低成本增强。
+> Phase 0（确定性 findings 台账）已以**磁盘 ledger** 形式实现（`findings_ledger`，默认 true，
+> 见 §7.2 验收点），并与 compact 形成无损互补：截断/compact 丢掉的早期 findings 由
+> ledger 在终局回读合并，不再依赖摘要或模型自觉。
 
 ### 7.1 建议
 
@@ -294,6 +302,14 @@ auto-compact 直接缓解上述两种结局：摘要携带"已发现 findings �
 - Anthropic vendor 下被丢 Tool 消息不导致摘要调用 400/配对错乱。
 - `--resume` 恢复含摘要的对话后行为一致。
 - 归档目录清理逻辑（成功时删除）不受影响。
+
+**已实现 (Update 2) —— findings ledger 验收：**
+
+- 早期迭代的 findings（与 tool call 同响应）在后续被截断/compact 后，终局 Stop 仍能合并回最终结果；
+- 合并确定性：同 rule_id+location+message 去重，最终响应优先，ledger 独有项追加；
+- `findings_ledger: false` 时行为与旧版完全一致（不写文件、不合并）；
+- 成功退出（exit 0）时 ledger 与归档一并清理；失败时保留可审计；
+- ToolCalls 分支保留 assistant content（修复信息丢失点），中间轮 findings 草稿得以落盘。
 
 ---
 


### PR DESCRIPTION
# feat: auto-compact — LLM summarization of truncated context (opt-in)

## Summary

When a conversation exceeds `token_budget`, Clausura previously **dropped** older messages and injected a bare "context trimmed" hint. With `auto_compact: true`, dropped messages are now **summarized with a single no-tool LLM call** and the summary is injected at the truncation boundary — the agent keeps remembering earlier findings, files examined, and decisions across truncation.

This branch started as a research branch ([docs/research-auto-compact.md](docs/research-auto-compact.md)) analyzing the value/cost of auto-compact, then implemented it following the report's constraints.

## Design highlights

- **New config** (defaults = zero behavior change):
  - `auto_compact: bool` — default `false`
  - `max_compactions: u32` — default `3` (per-run cap, `0` disables)
  - YAML + env: `CLAUSURA_AUTO_COMPACT` / `CLAUSURA_MAX_COMPACTIONS`
- **Quota guard**: the summary call is **skipped** when it wouldn't fit under the remaining `max_total_tokens`, so compaction can never cut a run short earlier than bare truncation would.
- **Graceful degradation**: summarization failure/timeout falls back to the existing truncation hint; compaction never fails or marks a run incomplete.
- **Budget chain**: summary capped at 10% of `token_budget`, trimmed to fit if oversized; injected at index 1 (right after system message), preserving assistant→tool pairing.
- **Billing**: summary call usage is added to `running_tokens` (`max_total_tokens`) and reported usage, logged via `tracing`.
- **Provider portability**: dropped messages are rendered as plain text for the summary call (avoids Anthropic `tool_result` pairing fragility); the full transcript is still archived as before.

## Explicit relationship (documented)

- `token_budget` — how large the **active conversation** can be (per-request)
- `max_total_tokens` — total **billed tokens** across the run
- `auto_compact` — the **strategy** when `token_budget` is approached; it never changes either budget's termination semantics

## Tests

+10 new (6 agent-loop/unit: summary injection, LLM-error fallback, `max_compactions=0` guard, `max_total_tokens` headroom guard, `dropped_to_text` rendering, summary trimming; 4 config parsing). All **304 core + 5 CLI + 1 integration** tests pass; clippy clean.

## Documentation

- README (config example + "Context truncation, archiving, and auto-compact" section)
- `docs/guide/configuration.md` (`task.auto_compact` / `task.max_compactions` + env overrides)
- `docs/research-auto-compact.md` status updated to reflect the implementation

## Commits

1. `a4bd5d7` docs: research value & cost of auto-compact for context management
2. `4e6b6e2` docs: make token_budget / max_total_tokens / auto_compact relationship explicit
3. `b6dcf1a` feat: auto-compact — LLM summarization of truncated context (opt-in)
