### PR TITLE
feat: agent resilience — spill, progressive skills, run event log, reactive compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ Clausura is a platform-agnostic agent CLI tool built for CI/CD pipelines. It run
 
 **Key philosophy: closed-loop execution with deterministic gating.** The LLM finds issues. The rule engine decides if they matter. Your pipeline gets a binary answer.
 
+## Clausura vs. generic agent harnesses
+
+General-purpose agent harnesses (DeepSeek Harness, Claude Code, Codex and similar) optimize for open-ended interactive work: flexible plugin stacks, long-lived sessions, sub-agent orchestration, and human-in-the-loop approvals. They deliberately leave verdicts, structured output and resource bounds to the caller — their "success" means "the agent stopped", not "the task is done".
+
+Clausura occupies the other side of the same problem and is deliberately *not* a general harness:
+
+| | Generic agent harness | Clausura |
+|---|---|---|
+| Success semantics | last turn ended cleanly | gating rules evaluated over structured findings |
+| Verdict | none (bare text output) | exit code 0/1/2/3 + SARIF v2.1.0 |
+| Run bounds | unbounded (waits for quiescence) | `max_iterations`, `timeout_secs`, `token_budget`, `max_total_tokens` |
+| Incomplete run | silent partial result | fail-closed by default (`on_incomplete: fail`) |
+| Extensibility | plugin framework (everything swappable) | skills + MCP tools + preflight checks; static single binary |
+| Deployment | runtime + plugins to install | one static binary, zero runtime dependencies |
+| Audit trail | session event log (append-only) | append-only run event log + findings ledger + context archives |
+
+If you are building an interactive coding agent, use a generic harness. If you need a *deterministic gate in CI* — an agent that must finish within bounds and produce a pass/fail answer a pipeline can trust — that is what Clausura is for.
+
 **Use cases**
 
 - **Code review gating** -- flag violations in pull requests before merge
@@ -176,6 +194,8 @@ clausura run --dry-run  # show the execution plan
 
 Clausura 1.2.0+ can reuse community skill files (Markdown) as review prompts. Skills answer "what and how to review", while gating rules answer "how many findings is too many" — the two are cleanly separated.
 
+Skills use **progressive disclosure**: only a catalog (name + one-line description per skill) is inlined into the system prompt. The agent loads a skill's full body on demand via the `read_skill` tool, which saves token budget for the review itself instead of spending it on instructions up front.
+
 ### Skill file format
 
 A skill is a Markdown file, optionally with YAML frontmatter:
@@ -194,7 +214,7 @@ description: 检查 SQL 注入、XSS、硬编码密钥
 - severity: `error`
 ```
 
-The frontmatter is stripped automatically; only the Markdown body is injected into the agent's system prompt.
+The frontmatter is stripped from the body; `name` and `description` feed the catalog. Without frontmatter, the name falls back to the reference's basename and the description to the first body line.
 
 ### Referencing skills
 
@@ -566,6 +586,10 @@ With `auto_compact: true`, the dropped messages are instead **summarized with a 
 - Summaries are sized to the headroom the retained context leaves under the truncation threshold (capped at 10% of `token_budget`); oversized output is trimmed. A compacted context always stays within budget, so a successful compaction can never push the run into "incomplete".
 - `max_compactions` bounds the number of summary calls per run (default 3) to prevent compaction loops on very long tasks.
 
+### Reactive compaction
+
+Proactive truncation relies on a token-count heuristic, which underestimates code-heavy contexts. When a provider **rejects a request as over its context window** (HTTP 400 with a context-length error), Clausura compacts reactively: it truncates to 50% of the budget (archiving the dropped messages, with auto-compact if enabled) and **retries the same request once**. A second overflow after compaction marks the run incomplete instead of retrying forever.
+
 ### Findings ledger (disk-backed memory)
 
 Compaction is lossy by design, so Clausura also keeps a **lossless, deterministic memory** on disk: whenever the agent emits findings in a response, they are appended to `{workspace}/.clausura/archives/findings-ledger-{task_id}.jsonl` (one JSON object per line). When the run finishes, the final findings are **merged with the ledger** — the final response wins on conflicts, and findings from iterations that were truncated out of context are appended back. No extra LLM calls are involved; the merge is plain deduplication keyed on `rule_id` + location + message. Disable with `findings_ledger: false` (env `CLAUSURA_FINDINGS_LEDGER=false`).
@@ -575,6 +599,10 @@ On successful completion (exit code 0), archive files are automatically cleaned 
 ### Incomplete runs fail closed
 
 If the agent loop ends without a clean stop — the context could not be truncated further, the model hit a length limit, the `max_total_tokens` cap was reached, or `max_iterations` was exhausted — the extracted findings may be partial. By default (`on_incomplete: fail`) Clausura fails closed: the run exits with code 2 and a clear error message, so an incomplete review can never silently pass a `max_findings: 0` gate. With `on_incomplete: pass`, the previous behavior is kept (gating rules evaluate the partial findings), but a warning is logged and the SARIF output is annotated with `"properties": {"incomplete": true}` on the run.
+
+### Findings schema retries
+
+A Stop response whose findings JSON fails to parse no longer fails the run immediately. Clausura sends the parse error plus the expected schema back to the model as a corrective prompt and gives it up to **2 retries**; a persistently malformed final answer still errors (`MalformedFindings`, exit 2).
 
 ### Deterministic rule engine
 
@@ -595,7 +623,7 @@ Each LLM request has its own per-request timeout (default 120s), independent of 
 
 ### Tool sandboxing
 
-Five built-in tools:
+Five built-in tools plus on-demand skill loading:
 
 | Tool          | Description                                      | Restrictions                           |
 |---------------|--------------------------------------------------|----------------------------------------|
@@ -604,6 +632,7 @@ Five built-in tools:
 | `grep`        | Search text patterns across files with literal or regex mode, extension filtering, and binary-skip | Auto-excludes `.git`, `target`, `.clausura`, `node_modules` |
 | `git_diff`    | Run `git diff` with optional base ref or staged  | Operates inside workspace only         |
 | `shell_exec`  | Execute an allowed command (argv form, no shell) | Restricted to `tool_allowlist` argv prefixes; dangerous flags denied; scrubbed env |
+| `read_skill`  | Load a configured review skill's full body by name (progressive disclosure) | Only serves skills resolved from `skill_prompts` at config load; no filesystem access |
 
 The `shell_exec` tool is locked by default (empty allowlist = no commands). Explicitly list allowed commands to enable it. It takes an `argv` array (e.g. `{"argv": ["git", "status"]}`) and executes `argv[0]` directly **without a shell** — shell metacharacters like `;`, `|`, `$()` or `>` are passed through as literal arguments and have no effect, so they cannot be used to bypass the allowlist. Commands run with `current_dir` set to the workspace root, but allowed commands can access paths outside the workspace via arguments.
 
@@ -615,15 +644,19 @@ The `shell_exec` tool is locked by default (empty allowlist = no commands). Expl
 
 **Per-command timeout.** Each command is killed after `shell_timeout_secs` (default 120; override with `--shell-timeout` or `CLAUSURA_SHELL_TIMEOUT`) and the tool returns a `Command timed out after Ns and was killed` result.
 
-Tool outputs are truncated at 32 KB or 1000 lines (whichever comes first) to stay within token budgets; a `[output truncated ...]` marker is appended when this happens — narrow the query or use `read_file`'s `offset`/`limit` to page through large outputs.
+Tool outputs are truncated at 32 KB or 1000 lines (whichever comes first). When a spill store is attached (always, in `clausura run`), the *full* output is first written to `{workspace}/.clausura/archives/tool-output-{task_id}-{seq}.txt`, and the truncated result carries a locator hint — the agent can page through the rest with `read_file`'s `offset`/`limit` instead of losing it. Without truncation, a `[output truncated ...]` marker is still appended — narrow the query or use `read_file`'s `offset`/`limit` to page through large outputs.
+
+The agent loop also detects **repeat tool calls** (same tool, same arguments — argument order normalized): at 3/5/8 identical consecutive invocations it injects an escalating advisory reminder, so the model breaks out of loops before `max_iterations` expires.
+
+### Run event log (append-only)
+
+Every run writes an append-only JSON-lines event log at `{workspace}/.clausura/archives/run-{task_id}.events.jsonl`: the full LLM request/response at each step, every tool call and result, context-truncation events (with archive paths and compaction summaries), and checkpoints carrying the complete message state. Failed CI runs can be audited and partially replayed from this log alone; successful runs clean it up with the other archives.
 
 ### Memory snapshots (SQLite checkpoints)
 
-On every run, the agent's message history is serialized (MessagePack) and saved to `~/.clausura/checkpoints.db`. You can resume a truncated or interrupted run with `--resume`. Snapshots include a thread ID, version number, and truncation flag.
+On every run, the agent's message history is serialized (MessagePack) and saved to `~/.clausura/checkpoints.db`. You can resume a truncated or interrupted run with `--resume`. Snapshots include a thread ID, version number, and truncation flag. The same state is also recorded as a `checkpoint` event in the workspace's append-only run event log, so `--resume` **falls back to the event log** when the SQLite store is unavailable — e.g. in ephemeral CI containers without a persistent home/volume, where checkpoints previously did not survive between runs.
 
-Note that checkpoints live under the user's home directory (`~/.clausura/`), not the workspace. In ephemeral CI containers without a persistent home/volume, checkpoints do not survive between runs, so `--resume` has nothing to restore from.
-
-Use `clausura snapshot list` and `clausura snapshot show` to inspect saved state.
+Use `clausura snapshot list` and `clausura snapshot show` to inspect saved state (SQLite store only).
 
 ### SARIF output
 

--- a/crates/clausura-core/src/agent.rs
+++ b/crates/clausura-core/src/agent.rs
@@ -1,8 +1,10 @@
 use crate::context::ContextManager;
-use crate::provider::Provider;
+use crate::eventlog::{EventLog, RunEvent};
+use crate::provider::{is_context_overflow_err, Provider};
 use crate::snapshot::SnapshotManager;
 use crate::tools::ToolRegistry;
 use crate::types::{Finding, FinishReason, Message, ProviderError, Role, TaskContract, Usage};
+use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -29,6 +31,10 @@ pub struct AgentConfig<'a> {
     pub initial_messages: Vec<Message>,
     pub workspace_root: PathBuf,
     pub snapshot_mgr: Option<&'a SnapshotManager>,
+    /// Append-only run event log (LLM requests/responses, tool calls,
+    /// truncation and checkpoint events). Optional — tests and callers that
+    /// don't need the audit trail pass `None`.
+    pub event_log: Option<&'a EventLog>,
 }
 
 /// Run the bounded agent loop.
@@ -49,6 +55,14 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
 
     messages.insert(0, Message::new(Role::System, system_prompt));
 
+    if let Some(log) = config.event_log {
+        log.append(&RunEvent::RunStart {
+            task_id: config.contract.id.clone(),
+            model: config.contract.model.clone(),
+            workspace: config.workspace_root.display().to_string(),
+        });
+    }
+
     let cm = ContextManager::new(
         config.provider,
         config.contract.token_budget,
@@ -60,6 +74,14 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
     let auto_compact = config.contract.auto_compact;
     let max_compactions = config.contract.max_compactions;
     let mut compactions_used: u32 = 0;
+
+    // Loop hygiene: consecutive identical (tool, args) call counts, keyed by
+    // the canonical invocation. See `repeat_reminder_text` for thresholds.
+    let mut repeat_counts: HashMap<String, u32> = HashMap::new();
+
+    // Findings-schema retries: a Stop response whose findings JSON cannot be
+    // parsed gets one corrective prompt and another chance, bounded below.
+    let mut extraction_retries: u32 = 0;
 
     for _iteration in 0..max_iterations {
         if start.elapsed() > Duration::from_secs(config.contract.timeout_secs) {
@@ -77,85 +99,78 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         }
 
         if cm.should_truncate(&messages) {
-            let snapshot = messages.clone();
-            let (was_truncated, count) = cm.truncate_to_budget(&mut messages);
-            if was_truncated && count > 0 {
-                let dropped_end = 1 + (snapshot.len() - messages.len());
-                let dropped: Vec<Message> = snapshot[1..dropped_end].to_vec();
-
-                let archive_result = cm.archive(&dropped, &config.contract.id).await;
-
-                // Auto-compact: summarize the dropped messages with a single
-                // no-tool LLM call and inject the summary at the truncation
-                // boundary. Any guard failure or LLM error falls back to the
-                // bare "context trimmed" hint — compaction must never fail
-                // the run.
-                let compact_summary: Option<String> = match &archive_result {
-                    Ok(path) if auto_compact && compactions_used < max_compactions => {
-                        let tail_tokens = cm.count_tokens(&messages);
-                        match try_compact(
-                            config.provider,
-                            &cm,
-                            &dropped,
-                            path,
-                            config.contract.token_budget,
-                            config.contract.max_total_tokens,
-                            tail_tokens,
-                            &mut running_tokens,
-                            &mut total_usage,
-                        )
-                        .await
-                        {
-                            CompactOutcome::Ok { summary } => {
-                                compactions_used += 1;
-                                Some(summary)
-                            }
-                            CompactOutcome::Skipped | CompactOutcome::Failed => None,
-                        }
-                    }
-                    _ => None,
-                };
-
-                let hint = match (&archive_result, compact_summary) {
-                    // Insert at the truncation boundary (right after the
-                    // system message), not at the end: appending a User
-                    // message after an assistant message with tool_calls
-                    // would leave those calls without results, which the
-                    // OpenAI/Anthropic APIs reject.
-                    (Ok(path), Some(summary)) => compact_hint(dropped.len(), path, &summary),
-                    (Ok(path), None) => format!(
-                        "⚠️ Context was trimmed to stay within token budget.\n\
-                         {} earlier messages are archived at:\n  {}\n\
-                         Use read_file to inspect if you need context from earlier iterations.",
-                        dropped.len(),
-                        path.display(),
-                    ),
-                    (Err(_), _) => format!(
-                        "⚠️ Context was trimmed to stay within token budget.\n\
-                         {} earlier messages were dropped (archive unavailable).",
-                        dropped.len(),
-                    ),
-                };
-
-                messages.insert(1, Message::new(Role::User, hint));
-
-                if cm.should_truncate(&messages) {
-                    // Last resort: the summary budget was computed against the
-                    // tail's token count, so this only fires on heuristic
-                    // counter drift. Fall-through below marks the run
-                    // truncated (findings still survive via the ledger).
-                    break;
-                }
-                continue;
-            } else {
+            // Proactive compaction: the heuristic counter says we're closing
+            // in on the budget. Truncate now, before the provider rejects the
+            // request outright.
+            if !truncate_and_hint(
+                config.provider,
+                &cm,
+                &mut messages,
+                &config.contract.id,
+                config.contract.token_budget,
+                config.contract.max_total_tokens,
+                auto_compact,
+                max_compactions,
+                &mut compactions_used,
+                &mut running_tokens,
+                &mut total_usage,
+                config.event_log,
+                false,
+            )
+            .await
+            {
+                // Context could not be reduced further: fall-through below
+                // marks the run truncated.
                 break;
             }
+            continue;
         }
 
-        let response = config
-            .provider
-            .chat_with_tools(&messages, config.tools.list_definitions().as_slice())
-            .await?;
+        let response = match call_llm(config.provider, config.tools, &messages, config.event_log)
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) if is_context_overflow_err(&e) => {
+                // Reactive compaction: the provider rejected the request as
+                // over the context window. Truncate + archive (optionally
+                // auto-compact) and retry the same request exactly once.
+                tracing::warn!(
+                    reason = %e,
+                    "provider reported context overflow; compacting and retrying once"
+                );
+                if !truncate_and_hint(
+                    config.provider,
+                    &cm,
+                    &mut messages,
+                    &config.contract.id,
+                    config.contract.token_budget,
+                    config.contract.max_total_tokens,
+                    auto_compact,
+                    max_compactions,
+                    &mut compactions_used,
+                    &mut running_tokens,
+                    &mut total_usage,
+                    config.event_log,
+                    true,
+                )
+                .await
+                {
+                    break;
+                }
+                match call_llm(config.provider, config.tools, &messages, config.event_log).await {
+                    Ok(resp) => resp,
+                    Err(e2) if is_context_overflow_err(&e2) => {
+                        tracing::warn!(
+                            reason = %e2,
+                            "context overflow persisted after compaction; marking run truncated"
+                        );
+                        break;
+                    }
+                    Err(e2) => return Err(e2),
+                }
+            }
+            Err(e) => return Err(e),
+        };
 
         total_usage.input_tokens += response.usage.input_tokens;
         total_usage.output_tokens += response.usage.output_tokens;
@@ -182,8 +197,26 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                     response.message.content.clone(),
                 ));
 
-                let findings = extract_findings(&response.message.content)
-                    .map_err(ProviderError::MalformedFindings)?;
+                let findings = match extract_findings(&response.message.content) {
+                    Ok(findings) => findings,
+                    Err(err) => {
+                        // A malformed final answer used to kill the run
+                        // (MalformedFindings → exit 2). Give the model a
+                        // corrective prompt and one more chance, bounded so
+                        // a persistently misbehaving model still fails.
+                        if extraction_retries >= 2 {
+                            return Err(ProviderError::MalformedFindings(err));
+                        }
+                        extraction_retries += 1;
+                        eprintln!(
+                            "Warning: findings extraction failed; asking the agent to \
+                             retry ({}/2): {}",
+                            extraction_retries, err
+                        );
+                        messages.push(Message::new(Role::User, findings_retry_prompt(&err)));
+                        continue;
+                    }
+                };
 
                 // Merge findings persisted earlier in the run (which may have
                 // been truncated out of context since) back into the final
@@ -198,6 +231,13 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                     findings
                 };
 
+                if let Some(log) = config.event_log {
+                    log.append(&RunEvent::RunEnd {
+                        truncated,
+                        duration_ms: start.elapsed().as_millis() as u64,
+                    });
+                }
+
                 return Ok(AgentResult {
                     messages,
                     findings,
@@ -207,6 +247,10 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                 });
             }
             FinishReason::ToolCalls => {
+                // Loop hygiene: track identical (tool, args) repetitions
+                // across iterations and inject an escalating advisory
+                // reminder after this batch's tool results.
+                let mut repeat_reminders: Vec<String> = Vec::new();
                 if let Some(tool_calls) = response.tool_calls {
                     messages.push(Message {
                         role: Role::Assistant,
@@ -220,11 +264,34 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                     });
 
                     for tc in &tool_calls {
+                        if let Some(log) = config.event_log {
+                            log.append(&RunEvent::ToolCall {
+                                call_id: tc.id.clone(),
+                                name: tc.name.clone(),
+                                arguments: tc.arguments.clone(),
+                            });
+                        }
+                        let key = repeat_key(&tc.name, &tc.arguments);
+                        let count = repeat_counts
+                            .entry(key)
+                            .and_modify(|c| *c += 1)
+                            .or_insert(1);
+                        if REPEAT_REMINDER_THRESHOLDS.contains(count) {
+                            repeat_reminders.push(repeat_reminder_text(&tc.name, *count));
+                        }
                         match config.tools.get(&tc.name) {
                             Some(tool) => {
                                 let result = tool.execute(tc.arguments.clone()).await;
                                 match result {
                                     Ok(output) => {
+                                        if let Some(log) = config.event_log {
+                                            log.append(&RunEvent::ToolResult {
+                                                call_id: tc.id.clone(),
+                                                name: tc.name.clone(),
+                                                output: output.clone(),
+                                                error: None,
+                                            });
+                                        }
                                         messages.push(Message::with_tool_call(
                                             Role::Tool,
                                             output,
@@ -232,6 +299,14 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                                         ));
                                     }
                                     Err(e) => {
+                                        if let Some(log) = config.event_log {
+                                            log.append(&RunEvent::ToolResult {
+                                                call_id: tc.id.clone(),
+                                                name: tc.name.clone(),
+                                                output: format!("Error: {}", e),
+                                                error: Some(format!("{}", e)),
+                                            });
+                                        }
                                         messages.push(Message::with_tool_call(
                                             Role::Tool,
                                             format!("Error: {}", e),
@@ -241,6 +316,14 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                                 }
                             }
                             None => {
+                                if let Some(log) = config.event_log {
+                                    log.append(&RunEvent::ToolResult {
+                                        call_id: tc.id.clone(),
+                                        name: tc.name.clone(),
+                                        output: format!("Error: Tool '{}' not found", tc.name),
+                                        error: Some(format!("Tool '{}' not found", tc.name)),
+                                    });
+                                }
                                 messages.push(Message::with_tool_call(
                                     Role::Tool,
                                     format!("Error: Tool '{}' not found", tc.name),
@@ -251,6 +334,13 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
                     }
                 } else {
                     break;
+                }
+
+                // Inject any repeat-call reminders after all tool results of
+                // this batch, so tool-call/result pairing stays valid for the
+                // next request.
+                if !repeat_reminders.is_empty() {
+                    messages.push(Message::new(Role::User, repeat_reminders.join("\n\n")));
                 }
             }
             FinishReason::Length => {
@@ -266,7 +356,17 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         if let Some(mgr) = config.snapshot_mgr {
             let iteration = _iteration + 1;
             if mgr.should_auto_save(iteration) {
-                let _ = mgr.save_snapshot(&config.contract.id, &messages, truncated);
+                if let Ok(checkpoint_id) =
+                    mgr.save_snapshot(&config.contract.id, &messages, truncated)
+                {
+                    if let Some(log) = config.event_log {
+                        log.append(&RunEvent::Checkpoint {
+                            checkpoint_id: checkpoint_id.to_string(),
+                            messages: messages.clone(),
+                            truncated,
+                        });
+                    }
+                }
             }
         }
     }
@@ -296,6 +396,13 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         findings
     };
 
+    if let Some(log) = config.event_log {
+        log.append(&RunEvent::RunEnd {
+            truncated,
+            duration_ms: start.elapsed().as_millis() as u64,
+        });
+    }
+
     Ok(AgentResult {
         messages,
         findings,
@@ -303,6 +410,214 @@ pub async fn run_agent_loop(config: AgentConfig<'_>) -> Result<AgentResult, Prov
         duration_ms: start.elapsed().as_millis() as u64,
         truncated,
     })
+}
+
+/// Dispatch one LLM request with tool definitions, recording the full
+/// request and response in the run event log when present.
+async fn call_llm(
+    provider: &dyn Provider,
+    tools: &ToolRegistry,
+    messages: &[Message],
+    event_log: Option<&EventLog>,
+) -> Result<crate::types::ChatResponse, ProviderError> {
+    if let Some(log) = event_log {
+        log.append(&RunEvent::LlmRequest {
+            messages: messages.to_vec(),
+        });
+    }
+    let response = provider
+        .chat_with_tools(messages, tools.list_definitions().as_slice())
+        .await?;
+    if let Some(log) = event_log {
+        log.append(&RunEvent::LlmResponse {
+            message: response.message.clone(),
+            usage: response.usage.clone(),
+            finish_reason: response.finish_reason.clone(),
+            tool_calls: response.tool_calls.clone(),
+        });
+    }
+    Ok(response)
+}
+
+/// Truncate the conversation to fit the budget, archive the dropped messages,
+/// optionally summarize them (auto-compact), and inject the hint at the
+/// truncation boundary.
+///
+/// When `force` is true (reactive path — the provider already rejected the
+/// request as over its context window), truncation targets 50% of the budget
+/// even if the heuristic counter thinks the context fits: the 4-chars/token
+/// estimate systematically underestimates code. The proactive path keeps the
+/// normal 75% target.
+///
+/// Returns `true` when truncation was applied and the context is back under
+/// the truncation threshold; `false` when the context could not be reduced
+/// further (the caller must stop and mark the run truncated).
+#[allow(clippy::too_many_arguments)]
+async fn truncate_and_hint(
+    provider: &dyn Provider,
+    cm: &ContextManager<'_>,
+    messages: &mut Vec<Message>,
+    task_id: &str,
+    token_budget: u64,
+    max_total_tokens: Option<u64>,
+    auto_compact: bool,
+    max_compactions: u32,
+    compactions_used: &mut u32,
+    running_tokens: &mut u64,
+    total_usage: &mut Usage,
+    event_log: Option<&EventLog>,
+    force: bool,
+) -> bool {
+    let snapshot = messages.clone();
+    let (was_truncated, count) = if force {
+        // Reactive: reduce to 50% of the budget, not 75% — the provider's
+        // rejection is stronger evidence than our heuristic estimate.
+        let dropped = cm.truncate_to(messages, 0.5);
+        (dropped > 0, dropped)
+    } else {
+        cm.truncate_to_budget(messages)
+    };
+    if !was_truncated || count == 0 {
+        return false;
+    }
+
+    let dropped_end = 1 + (snapshot.len() - messages.len());
+    let dropped: Vec<Message> = snapshot[1..dropped_end].to_vec();
+
+    let archive_result = cm.archive(&dropped, task_id).await;
+
+    // Auto-compact: summarize the dropped messages with a single
+    // no-tool LLM call and inject the summary at the truncation
+    // boundary. Any guard failure or LLM error falls back to the
+    // bare "context trimmed" hint — compaction must never fail
+    // the run.
+    let compact_summary: Option<String> = match &archive_result {
+        Ok(path) if auto_compact && *compactions_used < max_compactions => {
+            let tail_tokens = cm.count_tokens(messages);
+            match try_compact(
+                provider,
+                cm,
+                &dropped,
+                path,
+                token_budget,
+                max_total_tokens,
+                tail_tokens,
+                running_tokens,
+                total_usage,
+            )
+            .await
+            {
+                CompactOutcome::Ok { summary } => {
+                    *compactions_used += 1;
+                    Some(summary)
+                }
+                CompactOutcome::Skipped | CompactOutcome::Failed => None,
+            }
+        }
+        _ => None,
+    };
+
+    let hint = match (&archive_result, &compact_summary) {
+        // Insert at the truncation boundary (right after the
+        // system message), not at the end: appending a User
+        // message after an assistant message with tool_calls
+        // would leave those calls without results, which the
+        // OpenAI/Anthropic APIs reject.
+        (Ok(path), Some(summary)) => compact_hint(dropped.len(), path, summary),
+        (Ok(path), None) => format!(
+            "⚠️ Context was trimmed to stay within token budget.\n\
+             {} earlier messages are archived at:\n  {}\n\
+             Use read_file to inspect if you need context from earlier iterations.",
+            dropped.len(),
+            path.display(),
+        ),
+        (Err(_), _) => format!(
+            "⚠️ Context was trimmed to stay within token budget.\n\
+             {} earlier messages were dropped (archive unavailable).",
+            dropped.len(),
+        ),
+    };
+
+    messages.insert(1, Message::new(Role::User, hint));
+
+    if let Some(log) = event_log {
+        log.append(&RunEvent::ContextTruncated {
+            dropped_count: dropped.len(),
+            archive_path: archive_result
+                .as_ref()
+                .ok()
+                .map(|p| p.display().to_string()),
+            compacted_summary: compact_summary.clone(),
+        });
+    }
+
+    // False when the summary/hint pushed the context back over the threshold
+    // (heuristic drift) — the caller stops and marks the run truncated.
+    !cm.should_truncate(messages)
+}
+
+// ---------------------------------------------------------------------------
+// Repeat tool-call reminder (loop hygiene)
+// ---------------------------------------------------------------------------
+
+/// Call counts at which an escalating reminder is injected. Pure advisory:
+/// the agent may legitimately repeat a call (e.g. paging a file), so the
+/// reminder never blocks execution — it only nudges the model to re-evaluate.
+const REPEAT_REMINDER_THRESHOLDS: [u32; 3] = [3, 5, 8];
+
+/// Canonical identity of a tool invocation: name plus arguments with object
+/// keys sorted recursively, so argument order differences don't mask repeats.
+fn repeat_key(name: &str, args: &serde_json::Value) -> String {
+    format!("{}|{}", name, canonical_json(args))
+}
+
+/// Render a JSON value with object keys sorted recursively. Values are
+/// compared for repeat-detection purposes only.
+fn canonical_json(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut pairs: Vec<(String, String)> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), canonical_json(v)))
+                .collect();
+            pairs.sort_by(|a, b| a.0.cmp(&b.0));
+            let inner = pairs
+                .iter()
+                .map(|(k, v)| {
+                    let key = serde_json::to_string(k).unwrap_or_default();
+                    format!("{key}:{v}")
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{inner}}}")
+        }
+        serde_json::Value::Array(arr) => {
+            let inner = arr.iter().map(canonical_json).collect::<Vec<_>>().join(",");
+            format!("[{inner}]")
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Build the escalating reminder for repeat count `count` of tool `name`.
+fn repeat_reminder_text(name: &str, count: u32) -> String {
+    match count {
+        3 => format!(
+            "⚠️ Repeat-call reminder: you have called `{name}` with identical \
+             arguments 3 times in a row. If the result is not changing, try a \
+             narrower query, different arguments, or another tool."
+        ),
+        5 => format!(
+            "⚠️ Repeat-call reminder: you have called `{name}` with identical \
+             arguments 5 times in a row. This looks like a loop — stop and \
+             re-evaluate your approach before the iteration budget runs out."
+        ),
+        _ => format!(
+            "⚠️ Repeat-call reminder: you have called `{name}` with identical \
+             arguments {count} times in a row. You appear stuck in a loop. \
+             Change the inputs, switch tools, or conclude the review now."
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -774,6 +1089,22 @@ fn extract_findings_lenient(content: &str) -> Vec<Finding> {
     }
 }
 
+/// Corrective prompt sent when a Stop response's findings JSON fails to
+/// parse. States the expected schema and the exact parse error so the model
+/// can fix its answer on the next attempt.
+fn findings_retry_prompt(err: &str) -> String {
+    format!(
+        "Your previous answer could not be parsed as findings JSON.\n\
+         Error: {err}\n\n\
+         Please answer again with ONLY a JSON object of the form:\n\
+         {{\"findings\": [{{\"rule_id\": \"...\", \"severity\": \"hint|info|warning|error\", \
+         \"message\": \"...\", \"evidence\": \"...\", \"location\": {{\"file\": \"...\", \
+         \"line_start\": 1, \"line_end\": 1, \"column_start\": 1, \"column_end\": 1}}}}]}}\n\
+         The \"location\" field is optional — omit it when the finding has no \
+         file location. Do not wrap the JSON in prose or markdown fences."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -798,6 +1129,7 @@ mod tests {
             auto_compact: false,
             max_compactions: 3,
             findings_ledger: true,
+            skills: vec![],
             timeout_secs: 60,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],
@@ -814,7 +1146,7 @@ mod tests {
     async fn test_agent_loop_with_tool_calls() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut mock = MockProvider::new("gpt-4o");
         mock.add_response(ChatResponse {
@@ -850,6 +1182,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Review the diff")],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -858,9 +1191,97 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_agent_loop_records_event_log() {
+        use crate::eventlog::{EventLog, RunEvent};
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
+        let event_log = EventLog::new(&root, "test");
+
+        let mut mock = MockProvider::new("gpt-4o");
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, "Checking code..."),
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: 15,
+            },
+            finish_reason: FinishReason::ToolCalls,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".into(),
+                name: "git_diff".into(),
+                arguments: serde_json::json!({}),
+            }]),
+        });
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, r#"{"findings": []}"#),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let contract = test_contract();
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+            event_log: Some(&event_log),
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(!result.truncated);
+
+        let content = std::fs::read_to_string(event_log.path()).unwrap();
+        let events: Vec<RunEvent> = content
+            .lines()
+            .filter_map(|l| serde_json::from_str(l).ok())
+            .collect();
+        let has = |name: &str| events.iter().any(|e| event_name(e) == name);
+        assert!(has("run_start"), "missing run_start: {content}");
+        assert!(has("llm_request"), "missing llm_request: {content}");
+        assert!(has("llm_response"), "missing llm_response: {content}");
+        assert!(has("tool_call"), "missing tool_call: {content}");
+        assert!(has("tool_result"), "missing tool_result: {content}");
+        assert!(has("run_end"), "missing run_end: {content}");
+
+        // The event log can restore state from checkpoint events.
+        event_log.append(&RunEvent::Checkpoint {
+            checkpoint_id: "c-test".into(),
+            messages: vec![Message::new(Role::User, "restored")],
+            truncated: false,
+        });
+        assert_eq!(
+            event_log.last_checkpoint(),
+            Some(vec![Message::new(Role::User, "restored")])
+        );
+    }
+
+    /// Tag name of a `RunEvent` (mirrors the serde `type` field).
+    fn event_name(e: &RunEvent) -> &'static str {
+        match e {
+            RunEvent::RunStart { .. } => "run_start",
+            RunEvent::LlmRequest { .. } => "llm_request",
+            RunEvent::LlmResponse { .. } => "llm_response",
+            RunEvent::ToolCall { .. } => "tool_call",
+            RunEvent::ToolResult { .. } => "tool_result",
+            RunEvent::ContextTruncated { .. } => "context_truncated",
+            RunEvent::Checkpoint { .. } => "checkpoint",
+            RunEvent::RunEnd { .. } => "run_end",
+        }
+    }
+
+    #[tokio::test]
     async fn test_agent_loop_halts_on_timeout() {
         let tmp = TempDir::new().unwrap();
-        let tools = default_tools(tmp.path().to_path_buf(), &[], 120, &[]);
+        let tools = default_tools(tmp.path().to_path_buf(), &[], 120, &[], None);
 
         let mut mock = MockProvider::new("slow-model");
         mock.add_slow_response(Duration::from_secs(10));
@@ -875,6 +1296,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Hi")],
             workspace_root: tmp.path().to_path_buf(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await;
@@ -890,7 +1312,7 @@ mod tests {
     #[tokio::test]
     async fn test_agent_loop_truncates_on_budget_exceeded() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut contract = test_contract();
         contract.token_budget = 10000;
@@ -931,6 +1353,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, huge_content)],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -961,7 +1384,7 @@ mod tests {
     #[tokio::test]
     async fn test_agent_loop_breaks_when_cannot_truncate() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut contract = test_contract();
         contract.token_budget = 1;
@@ -989,12 +1412,131 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Review")],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
         assert!(
             result.truncated,
             "Expected truncated=true when context cannot be reduced further"
+        );
+    }
+
+    /// Reactive compaction: the heuristic counter thinks the context fits
+    /// (under 80%), but the provider rejects the request as over its context
+    /// window. The loop must truncate more aggressively (50% of budget) and
+    /// retry the same request once.
+    #[tokio::test]
+    async fn test_agent_loop_reactive_compact_on_context_overflow() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
+
+        // 40000 chars ≈ 10000 tokens by the mock heuristic: under the 80%
+        // threshold (12000) of a 15000 budget, so the proactive check stays
+        // quiet — the provider error below is what triggers compaction.
+        let mut contract = test_contract();
+        contract.token_budget = 15000;
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_error_response(ProviderError::BadRequest(
+            "This model's maximum context length is 8192 tokens. \
+             However, your request has 10000 tokens."
+                .into(),
+        ));
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "test", "severity": "warning", "message": "recovered after compaction", "evidence": "e"}]}"#),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "x".repeat(40000))],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+            event_log: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(
+            !result.truncated,
+            "reactive compaction must recover the run, got truncated=true"
+        );
+        assert_eq!(
+            result.findings[0].message, "recovered after compaction",
+            "the retried request's findings must be extracted"
+        );
+        // The compaction dropped messages and archived them.
+        let archive_dir = root.join(".clausura").join("archives");
+        let mut found = false;
+        if let Ok(entries) = std::fs::read_dir(&archive_dir) {
+            for entry in entries.flatten() {
+                if entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("context-dump-test-")
+                {
+                    found = true;
+                }
+            }
+        }
+        assert!(
+            found,
+            "dropped messages must be archived during reactive compaction"
+        );
+    }
+
+    /// Reactive compaction that cannot reduce the context further must not
+    /// retry forever: the run stops marked truncated after the failed
+    /// truncation (no second LLM call is spent).
+    #[tokio::test]
+    async fn test_agent_loop_reactive_compact_gives_up_when_unable_to_reduce() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
+
+        let mut contract = test_contract();
+        contract.token_budget = 1;
+
+        let mut mock = MockProvider::new("test-model");
+        mock.add_error_response(ProviderError::BadRequest(
+            "This model's maximum context length is 10 tokens.".into(),
+        ));
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, r#"{"findings": []}"#),
+            usage: Usage {
+                input_tokens: 5,
+                output_tokens: 5,
+                total_tokens: 10,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+            event_log: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(
+            result.truncated,
+            "unable to reduce → run must be marked truncated"
+        );
+        assert_eq!(
+            result.usage.total_tokens, 0,
+            "no retry LLM call may be spent after a failed reactive compaction"
         );
     }
 
@@ -1006,7 +1548,7 @@ mod tests {
     #[tokio::test]
     async fn test_agent_loop_ignores_cumulative_tokens_for_context_budget() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut contract = test_contract();
         contract.token_budget = 100000;
@@ -1048,6 +1590,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Review")],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1066,7 +1609,7 @@ mod tests {
     #[tokio::test]
     async fn test_agent_loop_breaks_on_max_total_tokens() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut contract = test_contract();
         contract.token_budget = 100000;
@@ -1099,6 +1642,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Review")],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1112,7 +1656,7 @@ mod tests {
     #[tokio::test]
     async fn test_hint_message_injected_after_truncation() {
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut contract = test_contract();
         contract.token_budget = 10000;
@@ -1153,6 +1697,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, huge_content)],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1284,7 +1829,7 @@ mod tests {
     async fn test_agent_loop_auto_compact_injects_summary() {
         let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 3);
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut mock = MockProvider::new("test-model");
         mock.add_response(tool_call_response(&tool_call));
@@ -1300,6 +1845,7 @@ mod tests {
             initial_messages: initial,
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1350,7 +1896,7 @@ mod tests {
     async fn test_agent_loop_auto_compact_falls_back_on_llm_error() {
         let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 3);
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut mock = MockProvider::new("test-model");
         mock.add_response(tool_call_response(&tool_call));
@@ -1364,6 +1910,7 @@ mod tests {
             initial_messages: initial,
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1395,7 +1942,7 @@ mod tests {
         // on: the queued summary response must never be consumed.
         let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 0);
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut mock = MockProvider::new("test-model");
         mock.add_response(tool_call_response(&tool_call));
@@ -1409,6 +1956,7 @@ mod tests {
             initial_messages: initial,
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1433,7 +1981,7 @@ mod tests {
         // never consumed.
         let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, Some(500), true, 3);
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut mock = MockProvider::new("test-model");
         mock.add_response(tool_call_response(&tool_call));
@@ -1447,6 +1995,7 @@ mod tests {
             initial_messages: initial,
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1473,7 +2022,7 @@ mod tests {
         // context back over the threshold and mark the run incomplete.
         let (tmp, contract, tool_call, initial) = auto_compact_setup(10000, None, true, 3);
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         // ~1500 tokens by the mock heuristic — far above the summary budget,
         // which is the headroom under the 80% truncation threshold.
@@ -1489,6 +2038,7 @@ mod tests {
             initial_messages: initial,
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1604,6 +2154,283 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Repeat-call reminder
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_repeat_key_is_order_insensitive() {
+        let a = serde_json::json!({"base": "main", "staged": false});
+        let b = serde_json::json!({"staged": false, "base": "main"});
+        assert_eq!(repeat_key("git_diff", &a), repeat_key("git_diff", &b));
+        // Different arguments are different keys.
+        assert_ne!(
+            repeat_key("git_diff", &serde_json::json!({"base": "main"})),
+            repeat_key("git_diff", &serde_json::json!({"staged": true}))
+        );
+        // Different tools are different keys.
+        assert_ne!(
+            repeat_key("git_diff", &serde_json::json!({})),
+            repeat_key("grep", &serde_json::json!({}))
+        );
+    }
+
+    #[test]
+    fn test_repeat_reminder_text_escalates() {
+        assert!(repeat_reminder_text("git_diff", 3).contains("3 times"));
+        assert!(repeat_reminder_text("git_diff", 5).contains("looks like a loop"));
+        assert!(repeat_reminder_text("git_diff", 8).contains("stuck in a loop"));
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_injects_repeat_call_reminder() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
+
+        let contract = test_contract();
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        let mut mock = MockProvider::new("test-model");
+        // Three identical tool-call iterations — the third crosses the
+        // threshold and must produce an advisory user message.
+        for _ in 0..3 {
+            mock.add_response(ChatResponse {
+                message: Message::new(Role::Assistant, "Running tool..."),
+                usage: Usage {
+                    input_tokens: 5,
+                    output_tokens: 5,
+                    total_tokens: 10,
+                },
+                finish_reason: FinishReason::ToolCalls,
+                tool_calls: Some(vec![tool_call.clone()]),
+            });
+        }
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, r#"{"findings": []}"#),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+            event_log: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(!result.truncated);
+
+        let reminder = result
+            .messages
+            .iter()
+            .find(|m| m.role == Role::User && m.content.contains("Repeat-call reminder"))
+            .expect("a repeat-call reminder must be injected");
+        assert!(
+            reminder.content.contains("3 times"),
+            "expected the first-threshold reminder, got: {}",
+            reminder.content
+        );
+        assert!(
+            reminder.content.contains("`git_diff`"),
+            "reminder must name the tool, got: {}",
+            reminder.content
+        );
+
+        // The reminder must follow the tool results (valid API pairing).
+        let tool_msgs = result
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Tool)
+            .count();
+        assert_eq!(tool_msgs, 3, "all three tool calls must have results");
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_no_reminder_below_threshold() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
+
+        let contract = test_contract();
+
+        let tool_call = ToolCall {
+            id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        };
+
+        let mut mock = MockProvider::new("test-model");
+        // Two identical calls — below the threshold, no reminder.
+        for _ in 0..2 {
+            mock.add_response(ChatResponse {
+                message: Message::new(Role::Assistant, "Running tool..."),
+                usage: Usage {
+                    input_tokens: 5,
+                    output_tokens: 5,
+                    total_tokens: 10,
+                },
+                finish_reason: FinishReason::ToolCalls,
+                tool_calls: Some(vec![tool_call.clone()]),
+            });
+        }
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, r#"{"findings": []}"#),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+            event_log: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(!result.truncated);
+        assert!(
+            !result
+                .messages
+                .iter()
+                .any(|m| m.content.contains("Repeat-call reminder")),
+            "no reminder may be injected below the threshold"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Findings-schema retry
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_agent_loop_retries_on_malformed_findings() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
+
+        let contract = test_contract();
+
+        let mut mock = MockProvider::new("test-model");
+        // First Stop answer is not parseable JSON.
+        mock.add_response(ChatResponse {
+            message: Message::new(
+                Role::Assistant,
+                "I found nothing worth reporting.".to_string(),
+            ),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+        // The corrective prompt yields a valid answer on the second attempt.
+        mock.add_response(ChatResponse {
+            message: Message::new(Role::Assistant, r#"{"findings": [{"id": "00000000-0000-0000-0000-000000000000", "rule_id": "r", "severity": "error", "message": "fixed", "evidence": "e"}]}"#),
+            usage: Usage {
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            finish_reason: FinishReason::Stop,
+            tool_calls: None,
+        });
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+            event_log: None,
+        };
+
+        let result = run_agent_loop(config).await.unwrap();
+        assert!(
+            !result.truncated,
+            "a corrected retry must not mark the run truncated"
+        );
+        assert_eq!(result.findings.len(), 1);
+        assert_eq!(result.findings[0].message, "fixed");
+
+        let retry_prompt = result
+            .messages
+            .iter()
+            .find(|m| m.role == Role::User && m.content.contains("could not be parsed"))
+            .expect("the corrective retry prompt must be in the conversation");
+        assert!(retry_prompt.content.contains("findings"));
+    }
+
+    #[tokio::test]
+    async fn test_agent_loop_gives_up_after_malformed_findings_retries() {
+        let (_tmp, root) = setup_agent_env();
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
+
+        let contract = test_contract();
+
+        let mut mock = MockProvider::new("test-model");
+        // Three malformed Stop answers exhaust the bounded retry budget.
+        for i in 0..3 {
+            mock.add_response(ChatResponse {
+                message: Message::new(Role::Assistant, format!("still not json {i}")),
+                usage: Usage {
+                    input_tokens: 20,
+                    output_tokens: 10,
+                    total_tokens: 30,
+                },
+                finish_reason: FinishReason::Stop,
+                tool_calls: None,
+            });
+        }
+
+        let config = AgentConfig {
+            contract: &contract,
+            provider: &mock,
+            tools: &tools,
+            initial_messages: vec![Message::new(Role::User, "Review the diff")],
+            workspace_root: root.clone(),
+            snapshot_mgr: None,
+            event_log: None,
+        };
+
+        let err = run_agent_loop(config).await.unwrap_err();
+        assert!(
+            matches!(err, ProviderError::MalformedFindings(_)),
+            "expected MalformedFindings after retries exhausted, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_findings_retry_prompt_names_schema() {
+        let prompt = findings_retry_prompt("1 of 1 finding(s) failed: bad");
+        assert!(prompt.contains("could not be parsed"));
+        assert!(prompt.contains("1 of 1 finding(s) failed: bad"));
+        assert!(prompt.contains("rule_id"));
+        assert!(prompt.contains("severity"));
+        assert!(prompt.contains("location"));
+    }
+
+    // -----------------------------------------------------------------
     // Findings ledger
     // -----------------------------------------------------------------
 
@@ -1624,7 +2451,7 @@ mod tests {
         // Stop response only reports later findings. The ledger must preserve
         // the early ones and merge them back into the final result.
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut contract = test_contract();
         contract.findings_ledger = true;
@@ -1677,6 +2504,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Review the diff")],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1708,7 +2536,7 @@ mod tests {
         // findings_ledger = false: interim findings are not persisted and the
         // final result contains only the Stop response findings.
         let (_tmp, root) = setup_agent_env();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut contract = test_contract();
         contract.findings_ledger = false;
@@ -1757,6 +2585,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Review the diff")],
             workspace_root: root.clone(),
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -1791,7 +2620,7 @@ mod tests {
     async fn test_agent_loop_propagates_tool_call_id() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
         let mut mock = MockProvider::new("gpt-4o");
         mock.add_response(ChatResponse {
@@ -1830,6 +2659,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Run git diff")],
             workspace_root: root,
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await.unwrap();
@@ -2034,22 +2864,28 @@ mod tests {
     async fn test_agent_loop_errors_on_schema_mismatch_instead_of_empty_findings() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
-        let tools = default_tools(root.clone(), &[], 120, &[]);
+        let tools = default_tools(root.clone(), &[], 120, &[], None);
 
+        // The schema-mismatched answer is retried with a corrective prompt
+        // (bounded), so feed the retries equally malformed answers — after
+        // the retry budget is exhausted the run must still error, never
+        // silently succeed with 0 findings.
         let mut mock = MockProvider::new("gpt-4o");
-        mock.add_response(ChatResponse {
-            message: Message::new(
-                Role::Assistant,
-                r#"{"findings": [{"rule_id": "no-new-any", "severity": "error", "file": "a.ts", "line": 1, "title": "t", "description": "d"}]}"#.to_string(),
-            ),
-            usage: Usage {
-                input_tokens: 10,
-                output_tokens: 5,
-                total_tokens: 15,
-            },
-            finish_reason: FinishReason::Stop,
-            tool_calls: None,
-        });
+        for _ in 0..3 {
+            mock.add_response(ChatResponse {
+                message: Message::new(
+                    Role::Assistant,
+                    r#"{"findings": [{"rule_id": "no-new-any", "severity": "error", "file": "a.ts", "line": 1, "title": "t", "description": "d"}]}"#.to_string(),
+                ),
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    total_tokens: 15,
+                },
+                finish_reason: FinishReason::Stop,
+                tool_calls: None,
+            });
+        }
 
         let contract = test_contract();
         let config = AgentConfig {
@@ -2059,6 +2895,7 @@ mod tests {
             initial_messages: vec![Message::new(Role::User, "Review the diff")],
             workspace_root: root,
             snapshot_mgr: None,
+            event_log: None,
         };
 
         let result = run_agent_loop(config).await;

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -434,16 +434,24 @@ impl Config {
             })
             .collect();
 
-        // ---- Resolve skill prompts ----
-        let prompt_template = if yaml_task.skill_prompts.is_empty() {
-            yaml_task.prompt_template
+        // ---- Resolve skill prompts (progressive disclosure) ----
+        // Only a catalog (name + description) is inlined into the system
+        // prompt; skill bodies are served on demand by the `read_skill` tool.
+        let (prompt_template, skills) = if yaml_task.skill_prompts.is_empty() {
+            (yaml_task.prompt_template, Vec::new())
         } else {
-            let mut skill_contents: Vec<(String, String)> = Vec::new();
-            for skill_ref in &yaml_task.skill_prompts {
-                let content = crate::skills::resolve_skill(skill_ref, &workspace)?;
-                skill_contents.push((skill_ref.clone(), content));
+            let resolved = crate::skills::resolve_skills(&yaml_task.skill_prompts, &workspace)?;
+            let catalog = crate::skills::build_skill_catalog(&resolved);
+            let mut parts = Vec::new();
+            if !catalog.is_empty() {
+                parts.push(catalog);
             }
-            crate::skills::merge_prompts(&skill_contents, &yaml_task.prompt_template)
+            let has_user_template = !yaml_task.prompt_template.is_empty()
+                && yaml_task.prompt_template != "{{task_description}}";
+            if has_user_template {
+                parts.push(yaml_task.prompt_template);
+            }
+            (parts.join("\n"), resolved)
         };
 
         Ok(Config {
@@ -461,6 +469,7 @@ impl Config {
                 auto_compact,
                 max_compactions,
                 findings_ledger,
+                skills,
                 timeout_secs: timeout,
                 shell_timeout_secs: shell_timeout,
                 shell_env_passthrough: yaml_task.shell_env_passthrough,
@@ -1864,9 +1873,24 @@ task:
             LogFormat::Json,
         )
         .unwrap();
-        assert!(config.task.prompt_template.contains("[Skill:"));
-        assert!(config.task.prompt_template.contains("# Check for bugs"));
+        assert!(
+            config
+                .task
+                .prompt_template
+                .contains("Available review skills"),
+            "catalog should be injected, got: {}",
+            config.task.prompt_template
+        );
+        assert!(config
+            .task
+            .prompt_template
+            .contains("- my-check — Check for bugs"));
+        // Progressive disclosure: the body itself is NOT inlined.
+        assert!(!config.task.prompt_template.contains("# Check for bugs"));
         assert!(!config.task.prompt_template.contains("{{task_description}}"));
+        assert_eq!(config.task.skills.len(), 1);
+        assert_eq!(config.task.skills[0].name, "my-check");
+        assert_eq!(config.task.skills[0].body, "# Check for bugs");
     }
 
     #[test]
@@ -1916,11 +1940,12 @@ task:
             LogFormat::Json,
         )
         .unwrap();
-        assert!(config
-            .task
-            .prompt_template
-            .contains("[Skill: team/vue-check]"));
-        assert!(config.task.prompt_template.contains("# Vue best practices"));
+        assert!(config.task.prompt_template.contains("- vue-check"));
+        // Body served by read_skill, not inlined into the system prompt.
+        assert!(!config.task.prompt_template.contains("# Vue best practices"));
+        assert_eq!(config.task.skills.len(), 1);
+        assert_eq!(config.task.skills[0].name, "vue-check");
+        assert_eq!(config.task.skills[0].body, "# Vue best practices");
     }
 
     #[test]
@@ -1963,9 +1988,10 @@ task:
             LogFormat::Json,
         )
         .unwrap();
-        assert!(config.task.prompt_template.contains("[Skill:"));
-        assert!(config.task.prompt_template.contains("Skill body"));
+        assert!(config.task.prompt_template.contains("read_skill"));
         assert!(config.task.prompt_template.contains("User extra check."));
+        assert_eq!(config.task.skills.len(), 1);
+        assert_eq!(config.task.skills[0].body, "Skill body");
     }
 
     #[test]

--- a/crates/clausura-core/src/context.rs
+++ b/crates/clausura-core/src/context.rs
@@ -108,12 +108,20 @@ impl<'a> ContextManager<'a> {
     /// Returns the number of messages dropped.
     /// Preserves system message (index 0) and assistant-tool pairs.
     pub fn truncate(&self, messages: &mut Vec<Message>) -> usize {
+        self.truncate_to(messages, 0.75)
+    }
+
+    /// Truncate messages to fit within `ratio` of the budget (e.g. 0.5 for
+    /// aggressive reactive compaction). Returns the number of messages
+    /// dropped. Preserves the system message (index 0) and assistant-tool
+    /// pairs.
+    pub fn truncate_to(&self, messages: &mut Vec<Message>, ratio: f64) -> usize {
         if messages.is_empty() {
             return 0;
         }
 
         // Binary search for the maximum number of messages that fit
-        let target = (self.token_budget as f64 * 0.75) as u64;
+        let target = (self.token_budget as f64 * ratio) as u64;
 
         let mut low = 1usize; // At least keep system message
         let mut high = messages.len();

--- a/crates/clausura-core/src/eventlog.rs
+++ b/crates/clausura-core/src/eventlog.rs
@@ -1,0 +1,212 @@
+//! Append-only JSON-lines event log for a single agent run.
+//!
+//! One file per task at
+//! `{workspace}/.clausura/archives/run-{task_id}.events.jsonl`. The agent loop
+//! records every model-visible exchange (full LLM request/response messages,
+//! tool calls and results) plus context-truncation and checkpoint events, so
+//! a failed CI run can be audited and partially replayed from this log alone.
+//!
+//! Checkpoints are recorded here as `Checkpoint` events carrying the complete
+//! message state at save time; `last_checkpoint` replays the most recent one.
+//! This makes `--resume` work even in ephemeral CI environments where the
+//! SQLite checkpoint store under `~/.clausura` does not survive between runs.
+//! The SQLite store remains the source for `clausura snapshot list/show`.
+//!
+//! All appends are best-effort: the log is a diagnostic and recovery aid,
+//! never a dependency of the pass/fail verdict.
+
+use crate::types::{FinishReason, Message, ToolCall, Usage};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// One entry in the run event log.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RunEvent {
+    /// The agent loop started.
+    RunStart {
+        task_id: String,
+        model: String,
+        workspace: String,
+    },
+    /// A full LLM request (complete message state at dispatch time).
+    LlmRequest { messages: Vec<Message> },
+    /// An LLM response.
+    LlmResponse {
+        message: Message,
+        usage: Usage,
+        finish_reason: FinishReason,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_calls: Option<Vec<ToolCall>>,
+    },
+    /// A tool invocation requested by the model.
+    ToolCall {
+        call_id: String,
+        name: String,
+        arguments: serde_json::Value,
+    },
+    /// A tool invocation's result (error is the formatted error text, if any).
+    ToolResult {
+        call_id: String,
+        name: String,
+        output: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    /// Context truncation applied (with optional auto-compact summary text).
+    ContextTruncated {
+        dropped_count: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        archive_path: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        compacted_summary: Option<String>,
+    },
+    /// A message-state checkpoint (written alongside SQLite snapshot saves).
+    Checkpoint {
+        checkpoint_id: String,
+        messages: Vec<Message>,
+        truncated: bool,
+    },
+    /// The agent loop ended.
+    RunEnd { truncated: bool, duration_ms: u64 },
+}
+
+/// Writer for the run event log.
+pub struct EventLog {
+    path: PathBuf,
+}
+
+impl EventLog {
+    /// Create the log handle for `task_id` under the workspace archives dir.
+    pub fn new(workspace_root: &Path, task_id: &str) -> Self {
+        Self {
+            path: workspace_root
+                .join(".clausura")
+                .join("archives")
+                .join(format!("run-{task_id}.events.jsonl")),
+        }
+    }
+
+    /// Path of the underlying file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append one event as a JSON line. Best-effort: failures are logged at
+    /// debug level and never surface to the caller.
+    pub fn append(&self, event: &RunEvent) {
+        let Ok(mut line) = serde_json::to_string(event) else {
+            return;
+        };
+        line.push('\n');
+        let result = (|| -> std::io::Result<()> {
+            if let Some(parent) = self.path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.path)?
+                .write_all(line.as_bytes())
+        })();
+        if let Err(e) = result {
+            tracing::debug!(
+                path = %self.path.display(),
+                reason = %e,
+                "event log append failed (ignored)"
+            );
+        }
+    }
+
+    /// Replay checkpoint events and return the message state of the most
+    /// recent one. Returns `None` when the log is missing, unreadable, or
+    /// contains no checkpoint.
+    pub fn last_checkpoint(&self) -> Option<Vec<Message>> {
+        let content = std::fs::read_to_string(&self.path).ok()?;
+        let mut last: Option<Vec<Message>> = None;
+        for line in content.lines() {
+            if let Ok(RunEvent::Checkpoint { messages, .. }) = serde_json::from_str(line) {
+                last = Some(messages);
+            }
+        }
+        last
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Role;
+    use tempfile::TempDir;
+
+    fn sample_messages() -> Vec<Message> {
+        vec![
+            Message::new(Role::System, "system"),
+            Message::new(Role::User, "user"),
+        ]
+    }
+
+    #[test]
+    fn test_append_and_last_checkpoint() {
+        let tmp = TempDir::new().unwrap();
+        let log = EventLog::new(tmp.path(), "task-1");
+
+        assert!(log.last_checkpoint().is_none());
+
+        log.append(&RunEvent::RunStart {
+            task_id: "task-1".into(),
+            model: "gpt-4o".into(),
+            workspace: tmp.path().display().to_string(),
+        });
+        log.append(&RunEvent::Checkpoint {
+            checkpoint_id: "c1".into(),
+            messages: sample_messages(),
+            truncated: false,
+        });
+        log.append(&RunEvent::Checkpoint {
+            checkpoint_id: "c2".into(),
+            messages: vec![Message::new(Role::User, "later")],
+            truncated: true,
+        });
+
+        let restored = log.last_checkpoint().expect("checkpoint should exist");
+        assert_eq!(restored, vec![Message::new(Role::User, "later")]);
+    }
+
+    #[test]
+    fn test_log_is_valid_json_lines() {
+        let tmp = TempDir::new().unwrap();
+        let log = EventLog::new(tmp.path(), "task-2");
+        log.append(&RunEvent::ToolCall {
+            call_id: "call_1".into(),
+            name: "git_diff".into(),
+            arguments: serde_json::json!({}),
+        });
+        log.append(&RunEvent::ToolResult {
+            call_id: "call_1".into(),
+            name: "git_diff".into(),
+            output: "diff".into(),
+            error: None,
+        });
+
+        let content = std::fs::read_to_string(log.path()).unwrap();
+        let lines: Vec<&str> = content.trim().lines().collect();
+        assert_eq!(lines.len(), 2);
+        for line in lines {
+            let value: serde_json::Value = serde_json::from_str(line).unwrap();
+            let ty = value["type"].as_str().unwrap();
+            assert!(
+                ty == "tool_call" || ty == "tool_result",
+                "unexpected event type: {ty}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_last_checkpoint_missing_file_is_none() {
+        let tmp = TempDir::new().unwrap();
+        let log = EventLog::new(tmp.path(), "ghost");
+        assert!(log.last_checkpoint().is_none());
+    }
+}

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -1,6 +1,7 @@
 use crate::agent::{run_agent_loop, AgentConfig};
 use crate::checkpoint::CheckpointStore;
 use crate::config::Config;
+use crate::eventlog::{EventLog, RunEvent};
 use crate::provider::create_provider;
 use crate::rules::RuleEngine;
 use crate::sarif::SarifFormatter;
@@ -47,7 +48,13 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
         &config.task.tool_allowlist,
         config.task.shell_timeout_secs,
         &config.task.shell_env_passthrough,
+        Some(&task_id),
     );
+
+    // Progressive skill disclosure: bodies served by read_skill on demand.
+    if !config.task.skills.is_empty() {
+        tools.register(crate::tools::SkillTool::new(config.task.skills.clone()));
+    }
 
     // Start MCP servers and register their tools.
     // Kept alive in `_mcp_manager` for the duration of this task;
@@ -123,14 +130,29 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
     };
     let snapshot_mgr = SnapshotManager::new(checkpoint_store);
 
+    // Append-only run event log: audit trail + checkpoint fallback for
+    // resume in ephemeral CI environments where ~/.clausura does not survive.
+    let event_log = EventLog::new(&config.workspace, &task_id);
+
     let mut initial_messages = if config.resume {
         match snapshot_mgr.restore_snapshot(&task_id, true) {
             Ok(Some(snapshot)) => snapshot.messages,
             _ => {
-                vec![Message::new(
-                    Role::User,
-                    config.task.prompt_template.clone(),
-                )]
+                // SQLite store empty or unavailable — fall back to the last
+                // checkpoint event recorded in the workspace event log.
+                let from_event_log = event_log.last_checkpoint().map(|mut messages| {
+                    messages.push(Message::new(
+                        Role::User,
+                        "You were interrupted. Continue from where you left off.".to_string(),
+                    ));
+                    messages
+                });
+                from_event_log.unwrap_or_else(|| {
+                    vec![Message::new(
+                        Role::User,
+                        config.task.prompt_template.clone(),
+                    )]
+                })
             }
         }
     } else {
@@ -157,6 +179,7 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
         initial_messages,
         workspace_root: config.workspace.clone(),
         snapshot_mgr: Some(&snapshot_mgr),
+        event_log: Some(&event_log),
     };
 
     let agent_result = match run_agent_loop(agent_config).await {
@@ -190,6 +213,16 @@ pub async fn execute_task(config: &Config) -> ExecutionReport {
     let snapshot_id = snapshot_mgr
         .save_snapshot(&task_id, &agent_result.messages, agent_result.truncated)
         .ok();
+
+    // Record the final state as a checkpoint event in the run log, so
+    // `--resume` can restore from the workspace even without the SQLite store.
+    if let Some(id) = snapshot_id {
+        event_log.append(&RunEvent::Checkpoint {
+            checkpoint_id: id.to_string(),
+            messages: agent_result.messages.clone(),
+            truncated: agent_result.truncated,
+        });
+    }
 
     // Merge preflight findings (deterministic) with agent findings.
     let all_findings = [preflight_findings, agent_result.findings].concat();
@@ -288,13 +321,18 @@ pub fn cleanup_archives(workspace: &Path, task_id: &str) {
     }
     let dump_prefix = format!("context-dump-{}-{}", task_id, "");
     let ledger_prefix = format!("findings-ledger-{}", task_id);
+    let spill_prefix = format!("tool-output-{}", task_id);
+    let event_prefix = format!("run-{}", task_id);
     if let Ok(entries) = std::fs::read_dir(&archives_dir) {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
             let is_dump = name_str.starts_with(&dump_prefix) && name_str.ends_with(".log");
             let is_ledger = name_str.starts_with(&ledger_prefix) && name_str.ends_with(".jsonl");
-            if is_dump || is_ledger {
+            let is_spill = name_str.starts_with(&spill_prefix) && name_str.ends_with(".txt");
+            let is_event =
+                name_str.starts_with(&event_prefix) && name_str.ends_with(".events.jsonl");
+            if is_dump || is_ledger || is_spill || is_event {
                 let _ = std::fs::remove_file(entry.path());
             }
         }
@@ -526,12 +564,14 @@ mod tests {
 
         std::fs::write(archives_dir.join("context-dump-test-task-1.log"), "data1").unwrap();
         std::fs::write(archives_dir.join("context-dump-test-task-2.log"), "data2").unwrap();
+        std::fs::write(archives_dir.join("run-test-task.events.jsonl"), "{}").unwrap();
         std::fs::write(archives_dir.join("some-other-file.txt"), "other").unwrap();
 
         cleanup_archives(tmp.path(), "test-task");
 
         assert!(!archives_dir.join("context-dump-test-task-1.log").exists());
         assert!(!archives_dir.join("context-dump-test-task-2.log").exists());
+        assert!(!archives_dir.join("run-test-task.events.jsonl").exists());
         assert!(archives_dir.join("some-other-file.txt").exists());
         assert!(archives_dir.exists());
     }
@@ -705,7 +745,7 @@ mod tests {
     fn test_detect_lsp_tools_no_lsp_tools_returns_none() {
         // Only built-in tools (read_file, git_diff, etc.) — no LSP hint.
         let tmp = TempDir::new().unwrap();
-        let registry = default_tools(tmp.path().to_path_buf(), &[], 120, &[]);
+        let registry = default_tools(tmp.path().to_path_buf(), &[], 120, &[], None);
         let hint = detect_lsp_tools(&registry);
         assert!(hint.is_none(), "no LSP tools configured → no hint");
     }

--- a/crates/clausura-core/src/lib.rs
+++ b/crates/clausura-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod checkpoint;
 pub mod ci;
 pub mod config;
 pub mod context;
+pub mod eventlog;
 pub mod executor;
 pub mod logging;
 pub mod mcp;

--- a/crates/clausura-core/src/provider.rs
+++ b/crates/clausura-core/src/provider.rs
@@ -33,6 +33,38 @@ pub trait Provider: Send + Sync {
     fn vendor(&self) -> &str;
 }
 
+/// True when a provider error looks like a context-window overflow (the
+/// request exceeded the model's input length limit).
+///
+/// Providers surface this as HTTP 400 with a descriptive body; there is no
+/// standardized error code, so we match the well-known phrasings from the
+/// OpenAI-compatible and Anthropic APIs. Used by the agent loop to trigger a
+/// reactive compaction (truncate + retry once) instead of failing the run.
+pub fn is_context_overflow_err(err: &ProviderError) -> bool {
+    let text = match err {
+        ProviderError::BadRequest(text) => text,
+        _ => return false,
+    };
+    let lower = text.to_lowercase();
+    [
+        "context length",
+        "context_length_exceeded",
+        "maximum context",
+        "context window",
+        "too many tokens",
+        "input length",
+        "input is too long",
+        "prompt is too long",
+        "reduce the length",
+        "token limit",
+        "exceeds the limit",
+        "maximum token",
+        "max_tokens",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
 // ---------------------------------------------------------------------------
 // Retry helpers
 // ---------------------------------------------------------------------------
@@ -914,6 +946,36 @@ pub mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
+    #[test]
+    fn test_is_context_overflow_err_matches_known_phrasings() {
+        let cases = [
+            "This model's maximum context length is 8192 tokens.",
+            "invalid_request_error: context_length_exceeded",
+            "Requested token count exceeds the maximum context window of 128k",
+            "input is too long, reduce the length of the prompt",
+            "prompt is too long",
+            "this request exceeds the limit: too many tokens",
+            "maximum token limit exceeded",
+        ];
+        for (i, text) in cases.iter().enumerate() {
+            let err = ProviderError::BadRequest((*text).to_string());
+            assert!(
+                is_context_overflow_err(&err),
+                "case {i} should match: {text}"
+            );
+        }
+        // Non-overflow errors must not match.
+        assert!(!is_context_overflow_err(&ProviderError::BadRequest(
+            "Invalid model name".into()
+        )));
+        assert!(!is_context_overflow_err(&ProviderError::RateLimited(
+            "slow down".into()
+        )));
+        assert!(!is_context_overflow_err(&ProviderError::Timeout(
+            "took too long".into()
+        )));
+    }
+
     /// Mock provider for testing agent loop
     pub struct MockProvider {
         model: String,
@@ -934,6 +996,11 @@ pub mod tests {
 
         pub fn add_response(&mut self, response: ChatResponse) {
             self.responses.lock().unwrap().push_back(Ok(response));
+        }
+
+        /// Queue a provider error for the next `chat_with_tools` call.
+        pub fn add_error_response(&mut self, err: ProviderError) {
+            self.responses.lock().unwrap().push_back(Err(err));
         }
 
         /// Queue a response for a no-tool `chat` call (auto-compact summary).

--- a/crates/clausura-core/src/skills.rs
+++ b/crates/clausura-core/src/skills.rs
@@ -1,12 +1,80 @@
-//! Skill prompt loading and merging.
+//! Skill loading with progressive disclosure.
 //!
 //! Clausura consumes community skill files (Markdown, commonly with YAML
-//! frontmatter) and injects their content into the agent's system prompt.
-//! Gating rules remain fully under user control — skills answer "how to
-//! review", gating answers "how many findings is too many".
+//! frontmatter carrying `name` + `description`). Instead of inlining every
+//! skill body into the system prompt (which eats the token budget before the
+//! review even starts), only a *catalog* (name + description per skill) is
+//! injected. The agent loads a skill's full body on demand through the
+//! `read_skill` tool. Gating rules remain fully under user control — skills
+//! answer "how to review", gating answers "how many findings is too many".
 
 use crate::types::ConfigError;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+
+/// A resolved skill: metadata (from frontmatter or derived) plus the body
+/// text the `read_skill` tool serves on demand.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Skill {
+    /// Kebab-case name used by the `read_skill` tool.
+    pub name: String,
+    /// One-line description shown in the catalog.
+    pub description: String,
+    /// Full body (frontmatter stripped).
+    pub body: String,
+}
+
+/// Resolve skill references into `Skill` values.
+///
+/// Each ref resolves through the same lookup as [`resolve_skill`] (local path,
+/// workspace-relative path, or named reference), but reads the *raw* file so
+/// the frontmatter `name`/`description` can be captured before the body is
+/// stripped. When frontmatter is absent, the name falls back to the ref's
+/// basename and the description to the first non-empty body line.
+pub fn resolve_skills(skill_refs: &[String], workspace: &Path) -> Result<Vec<Skill>, ConfigError> {
+    skill_refs
+        .iter()
+        .map(|skill_ref| {
+            let raw = resolve_skill_raw(skill_ref, workspace)?;
+            let meta = frontmatter_meta(&raw);
+            let body = strip_frontmatter(&raw);
+            let fallback_name = skill_ref
+                .rsplit(['/', '\\'])
+                .next()
+                .unwrap_or(skill_ref)
+                .trim_end_matches(".md")
+                .to_string();
+            Ok(Skill {
+                name: meta.name.unwrap_or(fallback_name),
+                description: meta
+                    .description
+                    .filter(|d| !d.trim().is_empty())
+                    .unwrap_or_else(|| skill_description(&body)),
+                body,
+            })
+        })
+        .collect()
+}
+
+/// Build the catalog section injected into the system prompt.
+///
+/// Only names + descriptions are inlined; bodies are served by `read_skill`.
+pub fn build_skill_catalog(skills: &[Skill]) -> String {
+    if skills.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<String> = vec![
+        "Available review skills:".to_string(),
+        "Before reporting findings, load every skill relevant to the task with".to_string(),
+        "the `read_skill` tool (by name) and apply its instructions.".to_string(),
+        String::new(),
+    ];
+    for skill in skills {
+        lines.push(format!("- {} — {}", skill.name, skill.description));
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
 
 /// Resolve a skill reference to its prompt body (frontmatter stripped).
 ///
@@ -16,17 +84,23 @@ use std::path::{Path, PathBuf};
 /// 3. Named reference — looked up in `.clausura/skills/<name>/SKILL.md`
 ///    (project-level) then `~/.clausura/skills/<name>/SKILL.md` (user-level).
 pub fn resolve_skill(name_or_path: &str, workspace: &Path) -> Result<String, ConfigError> {
+    resolve_skill_raw(name_or_path, workspace).map(|raw| strip_frontmatter(&raw))
+}
+
+/// Like [`resolve_skill`] but returns the raw file content (frontmatter
+/// included), so callers can read the skill metadata.
+fn resolve_skill_raw(name_or_path: &str, workspace: &Path) -> Result<String, ConfigError> {
     let path = Path::new(name_or_path);
     if path.exists() {
-        return load_skill_file(path);
+        return load_skill_file_raw(path);
     }
     let workspace_path = workspace.join(name_or_path);
     if workspace_path.exists() {
-        return load_skill_file(&workspace_path);
+        return load_skill_file_raw(&workspace_path);
     }
 
     if !name_or_path.contains("://") && !name_or_path.starts_with('/') {
-        return resolve_named_skill(name_or_path, workspace);
+        return resolve_named_skill_raw(name_or_path, workspace);
     }
 
     Err(ConfigError::FileNotFound(format!(
@@ -38,13 +112,12 @@ pub fn resolve_skill(name_or_path: &str, workspace: &Path) -> Result<String, Con
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-fn load_skill_file(path: &Path) -> Result<String, ConfigError> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| ConfigError::FileNotFound(format!("{}: {e}", path.display())))?;
-    Ok(strip_frontmatter(&content))
+fn load_skill_file_raw(path: &Path) -> Result<String, ConfigError> {
+    std::fs::read_to_string(path)
+        .map_err(|e| ConfigError::FileNotFound(format!("{}: {e}", path.display())))
 }
 
-fn resolve_named_skill(name: &str, workspace: &Path) -> Result<String, ConfigError> {
+fn resolve_named_skill_raw(name: &str, workspace: &Path) -> Result<String, ConfigError> {
     let skill_rel = format!("{}/SKILL.md", name.trim_end_matches('/'));
 
     let search_paths: Vec<PathBuf> = vec![
@@ -58,7 +131,7 @@ fn resolve_named_skill(name: &str, workspace: &Path) -> Result<String, ConfigErr
 
     for p in &search_paths {
         if p.exists() {
-            return load_skill_file(p);
+            return load_skill_file_raw(p);
         }
     }
 
@@ -77,47 +150,69 @@ fn resolve_named_skill(name: &str, workspace: &Path) -> Result<String, ConfigErr
 /// found or the closing `---` is missing, the original content is returned
 /// unchanged.
 pub(crate) fn strip_frontmatter(content: &str) -> String {
-    let trimmed = content.trim_start();
-    if !trimmed.starts_with("---") {
-        return content.to_string();
+    match split_frontmatter(content) {
+        Some((_, body)) => body,
+        None => content.to_string(),
     }
-
-    // Skip the opening "---" and optional newline.
-    let after_open = &trimmed[3..];
-    let rest = after_open.strip_prefix('\n').unwrap_or(after_open);
-
-    if let Some(pos) = rest.find("\n---") {
-        // pos + 4 skips "\n---" itself
-        let body = rest[pos + 4..].trim_start();
-        if !body.is_empty() {
-            return body.to_string();
-        }
-    }
-
-    // No valid closing delimiter; return original content.
-    content.to_string()
 }
 
-/// Merge resolved skill contents and a user prompt template into a single
-/// system-prompt-ready string. Each skill is delimited with a `[Skill: …]`
-/// header; the user's template (if non-empty and not the default placeholder)
-/// appears after a `---` separator.
-pub fn merge_prompts(
-    skill_contents: &[(String, String)], // (skill_ref, body)
-    template: &str,
-) -> String {
-    let mut parts: Vec<String> = Vec::new();
-
-    for (skill_ref, content) in skill_contents {
-        parts.push(format!("[Skill: {skill_ref}]\n{content}"));
+/// Split `content` into (frontmatter block, body). Returns `None` when there
+/// is no valid frontmatter block.
+fn split_frontmatter(content: &str) -> Option<(String, String)> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
     }
-
-    let has_user_template = !template.is_empty() && template != "{{task_description}}";
-    if has_user_template {
-        parts.push(template.to_string());
+    let after_open = &trimmed[3..];
+    let rest = after_open.strip_prefix('\n').unwrap_or(after_open);
+    let pos = rest.find("\n---")?;
+    // pos + 4 skips "\n---" itself
+    let body = rest[pos + 4..].trim_start().to_string();
+    if body.is_empty() {
+        return None;
     }
+    Some((rest[..pos].to_string(), body))
+}
 
-    parts.join("\n\n---\n\n")
+/// Parse frontmatter into name/description (when the original content still
+/// has one; the pre-stripped body carries no metadata).
+#[derive(Deserialize, Default)]
+struct SkillFrontmatter {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+fn frontmatter_meta(original: &str) -> SkillFrontmatter {
+    match split_frontmatter(original) {
+        Some((fm, _)) => serde_yaml::from_str(&fm).unwrap_or_default(),
+        None => SkillFrontmatter::default(),
+    }
+}
+
+/// Derive a description from the body: first non-empty line that is not a
+/// heading, truncated. If every line is a heading, use the first line with
+/// its leading `#`s stripped.
+fn skill_description(body: &str) -> String {
+    let first = body
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .or_else(|| {
+            body.lines()
+                .map(str::trim)
+                .find(|l| !l.is_empty())
+                .map(|l| l.trim_start_matches('#'))
+        })
+        .unwrap_or("")
+        .trim();
+    let mut desc = first.to_string();
+    if desc.len() > 160 {
+        desc.truncate(157);
+        desc.push_str("...");
+    }
+    desc
 }
 
 // ---------------------------------------------------------------------------
@@ -183,40 +278,75 @@ mod tests {
         assert_eq!(body, "line1\nline2");
     }
 
-    // -- merge_prompts ------------------------------------------------------
+    // -- resolve_skills / build_skill_catalog -------------------------------
 
     #[test]
-    fn test_merge_single_skill_no_template() {
-        let skills = vec![("sec/check".into(), "Find SQL injection.".into())];
-        let merged = merge_prompts(&skills, "{{task_description}}");
-        assert_eq!(merged, "[Skill: sec/check]\nFind SQL injection.");
+    fn test_resolve_skills_reads_frontmatter_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp
+            .path()
+            .join(".clausura")
+            .join("skills")
+            .join("sec-check");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: security-review\ndescription: 检查 SQL 注入、XSS、硬编码密钥\n---\n\n# Body\nCheck for SQL injection.",
+        )
+        .unwrap();
+
+        let skills = resolve_skills(&["sec-check".to_string()], tmp.path()).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "security-review");
+        assert_eq!(skills[0].description, "检查 SQL 注入、XSS、硬编码密钥");
+        assert_eq!(skills[0].body, "# Body\nCheck for SQL injection.");
     }
 
     #[test]
-    fn test_merge_multiple_skills_with_template() {
+    fn test_resolve_skills_without_frontmatter_falls_back() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("plain.md"), "# Heading\nCheck for bugs.").unwrap();
+
+        let skills = resolve_skills(&["plain.md".to_string()], tmp.path()).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "plain");
+        assert_eq!(skills[0].description, "Check for bugs.");
+        assert_eq!(skills[0].body, "# Heading\nCheck for bugs.");
+    }
+
+    #[test]
+    fn test_build_skill_catalog_lists_names_and_descriptions() {
         let skills = vec![
-            ("a".into(), "Check A.".into()),
-            ("b".into(), "Check B.".into()),
+            Skill {
+                name: "security-review".into(),
+                description: "检查 SQL 注入".into(),
+                body: "body a".into(),
+            },
+            Skill {
+                name: "vue-check".into(),
+                description: "Vue 最佳实践".into(),
+                body: "body b".into(),
+            },
         ];
-        let merged = merge_prompts(&skills, "Also check C.");
-        assert_eq!(
-            merged,
-            "[Skill: a]\nCheck A.\n\n---\n\n[Skill: b]\nCheck B.\n\n---\n\nAlso check C."
-        );
+        let catalog = build_skill_catalog(&skills);
+        assert!(catalog.contains("- security-review — 检查 SQL 注入"));
+        assert!(catalog.contains("- vue-check — Vue 最佳实践"));
+        assert!(catalog.contains("read_skill"));
+        assert!(!catalog.contains("body a"), "bodies must not be inlined");
+        assert!(!catalog.contains("body b"), "bodies must not be inlined");
     }
 
     #[test]
-    fn test_merge_no_skills_just_template() {
-        let skills: Vec<(String, String)> = vec![];
-        let merged = merge_prompts(&skills, "Review the diff.");
-        assert_eq!(merged, "Review the diff.");
+    fn test_build_skill_catalog_empty() {
+        assert_eq!(build_skill_catalog(&[]), "");
     }
 
     #[test]
-    fn test_merge_empty_everything() {
-        let skills: Vec<(String, String)> = vec![];
-        let merged = merge_prompts(&skills, "");
-        assert_eq!(merged, "");
+    fn test_skill_description_truncates_long_first_line() {
+        let body = format!("# T\n{}\nmore", "x".repeat(300));
+        let desc = skill_description(&body);
+        assert!(desc.len() <= 160);
+        assert!(desc.ends_with("..."));
     }
 
     // -- resolve_skill (integration via temp dirs) --------------------------

--- a/crates/clausura-core/src/tools.rs
+++ b/crates/clausura-core/src/tools.rs
@@ -36,9 +36,45 @@ const MAX_OUTPUT_BYTES: usize = 32 * 1024;
 /// Max lines of tool output before truncation.
 const MAX_OUTPUT_LINES: usize = 1000;
 
+/// Disk sink for tool outputs that exceed the inline limits.
+///
+/// Truncation used to destroy the tail of oversized tool outputs, which the
+/// agent could never recover. With a spill store attached, the *full* output
+/// is written to `{workspace}/.clausura/archives/tool-output-{task_id}-{seq}.txt`
+/// and the truncated result carries a locator hint, so the agent can page
+/// through the rest with `read_file` (offset/limit). Best-effort by design:
+/// a failed write simply falls back to the plain truncation marker.
+pub struct SpillStore {
+    workspace_root: PathBuf,
+    task_id: String,
+    seq: std::sync::atomic::AtomicU32,
+}
+
+impl SpillStore {
+    pub fn new(workspace_root: PathBuf, task_id: &str) -> Self {
+        Self {
+            workspace_root,
+            task_id: task_id.to_string(),
+            seq: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+
+    /// Write the full output to the archives dir and return the
+    /// workspace-relative locator path on success.
+    fn spill(&self, output: &str) -> Option<PathBuf> {
+        let dir = self.workspace_root.join(".clausura").join("archives");
+        std::fs::create_dir_all(&dir).ok()?;
+        let seq = self.seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        let name = format!("tool-output-{}-{}.txt", self.task_id, seq);
+        let full = dir.join(&name);
+        std::fs::write(&full, output).ok()?;
+        Some(PathBuf::from(".clausura").join("archives").join(name))
+    }
+}
+
 /// Truncate tool output to at most 32 KB or 1000 lines, whichever comes first.
 /// Appends a marker when truncation occurs.
-pub(crate) fn truncate_output(output: String) -> String {
+fn truncate_output_with_spill(output: String, spill: Option<&SpillStore>) -> String {
     let mut keep_end = output.len();
     let mut offset = 0usize;
     for (lines_kept, line) in output.split_inclusive('\n').enumerate() {
@@ -54,9 +90,19 @@ pub(crate) fn truncate_output(output: String) -> String {
     }
     let mut truncated = output[..keep_end].to_string();
     truncated.truncate(truncated.trim_end_matches('\n').len());
-    truncated.push_str(
-        "\n... [output truncated: limit is 32KB or 1000 lines, use offset/limit or a narrower query]",
-    );
+    match spill.and_then(|s| s.spill(&output)) {
+        Some(loc) => truncated.push_str(&format!(
+            "\n... [output truncated: limit is 32KB or 1000 lines; \
+             full output ({} bytes, {} lines) saved to {} — read it with \
+             read_file (offset/limit) to page through]",
+            output.len(),
+            output.lines().count(),
+            loc.display(),
+        )),
+        None => truncated.push_str(
+            "\n... [output truncated: limit is 32KB or 1000 lines, use offset/limit or a narrower query]",
+        ),
+    }
     truncated
 }
 
@@ -113,6 +159,7 @@ impl Default for ToolRegistry {
 /// Reads a file relative to the workspace root. Path traversal is rejected.
 pub struct ReadFileTool {
     workspace_root: PathBuf,
+    spill: Option<Arc<SpillStore>>,
 }
 
 /// Resolve a path relative to the workspace root, enforcing sandbox restrictions.
@@ -153,7 +200,15 @@ impl ReadFileTool {
         let canonical_root = workspace_root.canonicalize().unwrap_or(workspace_root);
         Self {
             workspace_root: canonical_root,
+            spill: None,
         }
+    }
+
+    /// Attach a spill store (if any) so oversized outputs are saved to disk
+    /// instead of being lost to truncation.
+    pub fn with_spill_maybe(mut self, store: Option<Arc<SpillStore>>) -> Self {
+        self.spill = store;
+        self
     }
 
     fn resolve_path(&self, path_str: &str) -> Result<PathBuf, ToolError> {
@@ -232,7 +287,10 @@ impl Tool for ReadFileTool {
             }
         }
 
-        Ok(truncate_output(result_lines.join("\n")))
+        Ok(truncate_output_with_spill(
+            result_lines.join("\n"),
+            self.spill.as_deref(),
+        ))
     }
 }
 
@@ -243,11 +301,22 @@ impl Tool for ReadFileTool {
 /// Runs git diff to get code changes.
 pub struct GitDiffTool {
     workspace_root: PathBuf,
+    spill: Option<Arc<SpillStore>>,
 }
 
 impl GitDiffTool {
     pub fn new(workspace_root: PathBuf) -> Self {
-        Self { workspace_root }
+        Self {
+            workspace_root,
+            spill: None,
+        }
+    }
+
+    /// Attach a spill store (if any) so oversized outputs are saved to disk
+    /// instead of being lost to truncation.
+    pub fn with_spill_maybe(mut self, store: Option<Arc<SpillStore>>) -> Self {
+        self.spill = store;
+        self
     }
 
     async fn run_git(&self, args: &[&str]) -> Result<String, ToolError> {
@@ -309,7 +378,7 @@ impl Tool for GitDiffTool {
         };
 
         let output = self.run_git(git_args).await?;
-        Ok(truncate_output(output))
+        Ok(truncate_output_with_spill(output, self.spill.as_deref()))
     }
 }
 
@@ -323,6 +392,7 @@ pub struct ShellExecTool {
     allowlist: Vec<String>,
     shell_timeout_secs: u64,
     shell_env_passthrough: Vec<String>,
+    spill: Option<Arc<SpillStore>>,
 }
 
 /// Per-program dangerous-flag denylist, keyed by the basename of argv[0].
@@ -409,7 +479,15 @@ impl ShellExecTool {
             allowlist,
             shell_timeout_secs,
             shell_env_passthrough,
+            spill: None,
         }
+    }
+
+    /// Attach a spill store (if any) so oversized outputs are saved to disk
+    /// instead of being lost to truncation.
+    pub fn with_spill_maybe(mut self, store: Option<Arc<SpillStore>>) -> Self {
+        self.spill = store;
+        self
     }
 
     /// Allowlist entries are argv prefixes split on whitespace: an invocation
@@ -567,14 +645,20 @@ impl Tool for ShellExecTool {
         let stderr = String::from_utf8_lossy(&output.stderr);
 
         if output.status.success() {
-            Ok(truncate_output(stdout.to_string()))
+            Ok(truncate_output_with_spill(
+                stdout.to_string(),
+                self.spill.as_deref(),
+            ))
         } else {
             // Return stderr as the output even on failure (tool result, not error)
-            Ok(truncate_output(format!(
-                "Exit code: {}\nStderr: {}",
-                output.status.code().unwrap_or(-1),
-                stderr
-            )))
+            Ok(truncate_output_with_spill(
+                format!(
+                    "Exit code: {}\nStderr: {}",
+                    output.status.code().unwrap_or(-1),
+                    stderr
+                ),
+                self.spill.as_deref(),
+            ))
         }
     }
 }
@@ -586,6 +670,7 @@ impl Tool for ShellExecTool {
 /// List files and directories within the workspace.
 pub struct ListFilesTool {
     workspace_root: PathBuf,
+    spill: Option<Arc<SpillStore>>,
 }
 
 /// Simple glob-like filename matching.
@@ -686,7 +771,15 @@ impl ListFilesTool {
         let canonical_root = workspace_root.canonicalize().unwrap_or(workspace_root);
         Self {
             workspace_root: canonical_root,
+            spill: None,
         }
+    }
+
+    /// Attach a spill store (if any) so oversized outputs are saved to disk
+    /// instead of being lost to truncation.
+    pub fn with_spill_maybe(mut self, store: Option<Arc<SpillStore>>) -> Self {
+        self.spill = store;
+        self
     }
 }
 
@@ -758,7 +851,10 @@ impl Tool for ListFilesTool {
             include_size,
         );
 
-        Ok(truncate_output(lines.join("\n")))
+        Ok(truncate_output_with_spill(
+            lines.join("\n"),
+            self.spill.as_deref(),
+        ))
     }
 }
 
@@ -891,6 +987,7 @@ fn grep_directory(
 /// literal and regex matching.
 pub struct GrepTool {
     workspace_root: PathBuf,
+    spill: Option<Arc<SpillStore>>,
 }
 
 impl GrepTool {
@@ -898,7 +995,15 @@ impl GrepTool {
         let canonical_root = workspace_root.canonicalize().unwrap_or(workspace_root);
         Self {
             workspace_root: canonical_root,
+            spill: None,
         }
+    }
+
+    /// Attach a spill store (if any) so oversized outputs are saved to disk
+    /// instead of being lost to truncation.
+    pub fn with_spill_maybe(mut self, store: Option<Arc<SpillStore>>) -> Self {
+        self.spill = store;
+        self
     }
 }
 
@@ -1013,29 +1118,101 @@ impl Tool for GrepTool {
             ));
         }
 
-        Ok(truncate_output(output))
+        Ok(truncate_output_with_spill(output, self.spill.as_deref()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SkillTool
+// ---------------------------------------------------------------------------
+
+/// Serves resolved skill bodies on demand (progressive disclosure).
+///
+/// Only the skill catalog (name + description) is inlined in the system
+/// prompt; the agent calls `read_skill` to load a full body when it needs it.
+/// The tool has no filesystem access — content was resolved and validated at
+/// config load time, so it cannot read anything beyond the configured skills.
+pub struct SkillTool {
+    skills: Vec<crate::skills::Skill>,
+}
+
+impl SkillTool {
+    pub fn new(skills: Vec<crate::skills::Skill>) -> Self {
+        Self { skills }
+    }
+}
+
+#[async_trait]
+impl Tool for SkillTool {
+    fn name(&self) -> &str {
+        "read_skill"
+    }
+
+    fn description(&self) -> &str {
+        "Load the full instructions of a review skill by name. The system prompt \
+         only lists skill names and descriptions; call this before reporting \
+         findings to apply a skill's rules."
+    }
+
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Skill name exactly as listed in the system prompt catalog"
+                }
+            },
+            "required": ["name"]
+        })
+    }
+
+    async fn execute(&self, args: Value) -> Result<String, ToolError> {
+        let name = args["name"]
+            .as_str()
+            .ok_or_else(|| ToolError::ExecutionFailed("Missing 'name' argument".into()))?;
+        let skill = self.skills.iter().find(|s| s.name == name).ok_or_else(|| {
+            let known: Vec<&str> = self.skills.iter().map(|s| s.name.as_str()).collect();
+            ToolError::ExecutionFailed(format!(
+                "Unknown skill '{name}'. Available skills: {}",
+                known.join(", ")
+            ))
+        })?;
+        Ok(format!(
+            "<skill name=\"{}\">\n{}\n</skill>",
+            skill.name, skill.body
+        ))
     }
 }
 
 /// Create the default set of tools for the given workspace root.
 /// If allowlist is empty, shell_exec is disabled (no commands allowed).
+///
+/// When `spill_task_id` is provided, all tools share a [`SpillStore`] for
+/// that task: oversized outputs are written to the workspace archives and
+/// the truncated result carries a locator hint instead of losing the tail.
 pub fn default_tools(
     workspace_root: PathBuf,
     allowlist: &[String],
     shell_timeout_secs: u64,
     shell_env_passthrough: &[String],
+    spill_task_id: Option<&str>,
 ) -> ToolRegistry {
     let mut registry = ToolRegistry::new();
-    registry.register(ReadFileTool::new(workspace_root.clone()));
-    registry.register(GitDiffTool::new(workspace_root.clone()));
-    registry.register(ShellExecTool::new(
-        workspace_root.clone(),
-        allowlist.to_vec(),
-        shell_timeout_secs,
-        shell_env_passthrough.to_vec(),
-    ));
-    registry.register(ListFilesTool::new(workspace_root.clone()));
-    registry.register(GrepTool::new(workspace_root));
+    let spill = spill_task_id.map(|id| Arc::new(SpillStore::new(workspace_root.clone(), id)));
+    registry.register(ReadFileTool::new(workspace_root.clone()).with_spill_maybe(spill.clone()));
+    registry.register(GitDiffTool::new(workspace_root.clone()).with_spill_maybe(spill.clone()));
+    registry.register(
+        ShellExecTool::new(
+            workspace_root.clone(),
+            allowlist.to_vec(),
+            shell_timeout_secs,
+            shell_env_passthrough.to_vec(),
+        )
+        .with_spill_maybe(spill.clone()),
+    );
+    registry.register(ListFilesTool::new(workspace_root.clone()).with_spill_maybe(spill.clone()));
+    registry.register(GrepTool::new(workspace_root).with_spill_maybe(spill));
     registry
 }
 
@@ -1228,6 +1405,119 @@ mod tests {
         assert!(result.contains("[output truncated:"));
         assert!(result.contains("line 1000"));
         assert!(!result.contains("line 1001"));
+    }
+
+    #[tokio::test]
+    async fn test_skill_tool_serves_body_by_name() {
+        let tool = SkillTool::new(vec![
+            crate::skills::Skill {
+                name: "security-review".into(),
+                description: "检查 SQL 注入".into(),
+                body: "# 安全审查\n检查 SQL 注入".into(),
+            },
+            crate::skills::Skill {
+                name: "vue-check".into(),
+                description: "Vue 实践".into(),
+                body: "Vue body".into(),
+            },
+        ]);
+        let out = tool
+            .execute(serde_json::json!({"name": "security-review"}))
+            .await
+            .unwrap();
+        assert!(out.contains("security-review"));
+        assert!(out.contains("检查 SQL 注入"));
+
+        let err = tool
+            .execute(serde_json::json!({"name": "nope"}))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown skill 'nope'"));
+        assert!(msg.contains("vue-check"));
+    }
+
+    #[tokio::test]
+    async fn test_skill_tool_missing_name() {
+        let tool = SkillTool::new(vec![]);
+        let err = tool.execute(serde_json::json!({})).await.unwrap_err();
+        assert!(err.to_string().contains("Missing 'name'"));
+    }
+
+    #[tokio::test]
+    async fn test_skill_tool_registered_via_default_tools_pipeline() {
+        // default_tools does not register read_skill (no skills configured);
+        // executor registers it when config.task.skills is non-empty.
+        let (_tmp, root) = setup_workspace();
+        let registry = default_tools(root, &[], 120, &[], None);
+        assert!(registry.get("read_skill").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_read_file_output_spills_full_content_to_archives() {
+        let (_tmp, root) = setup_workspace();
+        let test_file = root.join("big.txt");
+        let mut content = String::new();
+        for i in 1..=1500 {
+            content.push_str(&format!("line {}\n", i));
+        }
+        std::fs::write(&test_file, &content).unwrap();
+
+        let tool = ReadFileTool::new(root.clone())
+            .with_spill_maybe(Some(Arc::new(SpillStore::new(root.clone(), "spill-test"))));
+        let result = tool
+            .execute(serde_json::json!({"path": "big.txt"}))
+            .await
+            .unwrap();
+
+        // The inline result is truncated and carries a locator hint...
+        assert!(result.contains("[output truncated:"));
+        assert!(result.contains("saved to"));
+        assert!(result.contains("tool-output-spill-test-1.txt"));
+        assert!(result.contains("read_file (offset/limit)"));
+        assert!(!result.contains("line 1500"));
+
+        // ...and the full *tool output* (everything the tool read before the
+        // truncation marker was applied) is recoverable from the spill file.
+        // read_file caps its read at 1001 lines when no limit is given, so
+        // the spill holds those 1001 lines — the agent can page further with
+        // offset/limit.
+        let spill = root
+            .join(".clausura")
+            .join("archives")
+            .join("tool-output-spill-test-1.txt");
+        assert!(spill.exists(), "spill file should exist");
+        let spilled = std::fs::read_to_string(&spill).unwrap();
+        let expected: String = content.lines().take(1001).collect::<Vec<_>>().join("\n");
+        assert_eq!(
+            spilled, expected,
+            "spill file must hold the full pre-truncation output"
+        );
+        assert!(spilled.contains("line 1001"));
+        assert!(
+            !spilled.contains("line 1002"),
+            "read never reached line 1002"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_truncated_output_without_spill_keeps_plain_marker() {
+        // No spill store attached → the classic marker, no "saved to" hint.
+        let (_tmp, root) = setup_workspace();
+        let test_file = root.join("big.txt");
+        let mut content = String::new();
+        for i in 1..=1500 {
+            content.push_str(&format!("line {}\n", i));
+        }
+        std::fs::write(&test_file, content).unwrap();
+
+        let tool = ReadFileTool::new(root);
+        let result = tool
+            .execute(serde_json::json!({"path": "big.txt"}))
+            .await
+            .unwrap();
+        assert!(result.contains("[output truncated:"));
+        assert!(!result.contains("saved to"));
     }
 
     // -----------------------------------------------------------------------
@@ -1764,7 +2054,7 @@ mod tests {
     #[test]
     fn test_default_tools_contains_all() {
         let (_tmp, root) = setup_workspace();
-        let registry = default_tools(root, &[], 120, &[]);
+        let registry = default_tools(root, &[], 120, &[], None);
         let defs = registry.list_definitions();
         assert_eq!(defs.len(), 5);
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();

--- a/crates/clausura-core/src/types.rs
+++ b/crates/clausura-core/src/types.rs
@@ -407,6 +407,11 @@ pub struct TaskContract {
     /// true; costs no LLM calls and is deterministic.
     #[serde(default = "default_findings_ledger")]
     pub findings_ledger: bool,
+    /// Resolved review skills for progressive disclosure. Only a catalog
+    /// (name + description) is inlined in the system prompt; full bodies are
+    /// served on demand by the `read_skill` tool.
+    #[serde(default)]
+    pub skills: Vec<crate::skills::Skill>,
     pub timeout_secs: u64,
     #[serde(default = "default_shell_timeout_secs")]
     pub shell_timeout_secs: u64,
@@ -761,6 +766,7 @@ mod tests {
             auto_compact: false,
             max_compactions: 3,
             findings_ledger: true,
+            skills: vec![],
             timeout_secs: 300,
             shell_timeout_secs: 120,
             shell_env_passthrough: vec![],

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -157,7 +157,7 @@ task:
 
 ### `task.skill_prompts`
 
-References to reusable skill files. Skills are appended to the system prompt before `prompt_template`.
+References to reusable skill files. Only a catalog (name + description) is inlined into the system prompt; full bodies are loaded on demand by the `read_skill` tool (progressive disclosure).
 
 ```yaml
 task:
@@ -165,7 +165,7 @@ task:
     - ./skills/security-review.md      # Local file (relative or absolute)
     - team/vue-best-practices          # Named reference (looked up in .clausura/skills/ and ~/.clausura/skills/)
     - community/i18n-check
-  prompt_template: |                   # Your additions go after skills
+  prompt_template: |                   # Your additions go after the skill catalog
     Also check: no console.log in production code.
 ```
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -37,19 +37,20 @@ task:
       action: fail
 ```
 
-When the agent runs, skill content is injected into the system prompt before your `prompt_template`:
+When the agent runs, only a skill **catalog** (name + description) is injected into the system prompt, followed by your `prompt_template`:
 
 ```
-[Skill: security-review]
-...skill content...
+Available review skills:
+Before reporting findings, load every skill relevant to the task with
+the `read_skill` tool (by name) and apply its instructions.
 
-[Skill: team/vue-best-practices]
-...skill content...
-
----
+- security-review — Check for SQL injection, XSS, hardcoded secrets...
+- team/vue-best-practices — Vue best practices
 
 Your prompt_template content
 ```
+
+The agent loads full skill bodies on demand via the `read_skill` tool (progressive disclosure), so the token budget goes to the review instead of up-front instructions.
 
 ## Skill File Format
 
@@ -98,7 +99,7 @@ For each finding, output:
 ```
 ```
 
-**Frontmatter** (`---` delimited YAML at the top) is stripped automatically. Only the Markdown body is injected into the prompt.
+**Frontmatter** (`---` delimited YAML at the top) feeds the catalog (`name`, `description`) and is stripped from the body. Skill bodies are served on demand by the `read_skill` tool, not inlined into the prompt.
 
 **No gating in skills.** Skills define what and how to review, never the pass/fail threshold. That belongs in `.clausura.yaml` under `gating:`.
 

--- a/docs/skill-as-task.md
+++ b/docs/skill-as-task.md
@@ -112,36 +112,36 @@ description: 安全代码审查，检查 SQL 注入、XSS、硬编码密钥
 ```
 
 Clausura 读取时：
-- 如果有 frontmatter（`---` 包裹），剥离后只取 body 作为 prompt 内容
-- 如果没有 frontmatter，整个文件即为 prompt 内容
-- 多个 skill 按声明顺序拼接，各自标明来源
+- 如果有 frontmatter（`---` 包裹），剥离后取 body 作为 skill 正文，`name`/`description` 进入目录
+- 如果没有 frontmatter，整个文件即为 skill 正文，名称回退为引用 basename、描述回退为正文首行
+- 多个 skill 各自独立，按需加载
 
-## 注入格式
+## 注入格式（渐进式披露）
 
-多个 skill 的 prompt 内容合并后注入到 system prompt，格式如下：
+只有 skill 目录（name + description）注入到 system prompt，正文不注入：
 
 ```
-[Skill: community/security-review]
-<skill 内容>
+Available review skills:
+Before reporting findings, load every skill relevant to the task with
+the `read_skill` tool (by name) and apply its instructions.
 
-[Skill: team/vue-best-practices]
-<skill 内容>
-
----
+- security-review — 安全代码审查，检查 SQL 注入、XSS、硬编码密钥
+- vue-best-practices — Vue 最佳实践
 
 <用户 prompt_template>
 ```
 
-当 `prompt_template` 为空或为默认值 `{{task_description}}` 时，用户模板段省略。
+agent 通过 `read_skill` 工具按需加载完整正文，省下 token 预算用于审查本身。当 `prompt_template` 为空或为默认值 `{{task_description}}` 时，用户模板段省略。
 
 ## 实现总结
 
 | 模块 | 改动 |
 |------|------|
-| `skills.rs` | 新增模块：`resolve_skill()` 三级解析（本地→workspace→命名引用）、`strip_frontmatter()` YAML frontmatter 剥离、`merge_prompts()` 多 skill 拼接 |
-| `config.rs` | `YamlTaskConfig` 加 `skill_prompts: Vec<String>` 字段；`resolve_config()` 在加载时解析所有 skill 引用并合并到 `prompt_template` |
-| `types.rs` | 无需改动 — skill 内容直接合并到现有的 `prompt_template` 字段 |
-| `agent.rs` | 无需改动 — system prompt 构建逻辑不变 |
+| `skills.rs` | 新增 `Skill` 结构（name/description/body）、`resolve_skills()` 解析全部引用并读取 frontmatter 元数据、`build_skill_catalog()` 生成目录；保留 `resolve_skill()` 三级解析（本地→workspace→命名引用）与 `strip_frontmatter()` |
+| `config.rs` | `YamlTaskConfig` 加 `skill_prompts: Vec<String>` 字段；加载时解析为 `Vec<Skill>` 存入 `TaskContract.skills`，目录合并进 `prompt_template` |
+| `types.rs` | `TaskContract` 加 `skills: Vec<Skill>` 字段 |
+| `tools.rs` | 新增 `SkillTool`（`read_skill`）：按 name 返回正文，无文件系统访问（内容在配置加载时已解析） |
+| `executor.rs` | `skills` 非空时注册 `read_skill` 工具 |
 
 ### 关键实现细节
 
@@ -156,10 +156,9 @@ Clausura 读取时：
 - 提取 body 部分并 `trim_start`
 - 无 frontmatter 或格式不正确时返回原内容（不报错，容错处理）
 
-**`merge_prompts(skill_contents, template)`** — 合并格式：
-- 每个 skill 前加 `[Skill: <name>]` 头
-- skill 之间以 `\n\n---\n\n` 分隔
-- 用户 `prompt_template` 追加在末尾（仅当非空且非 `{{task_description}}` 默认值时）
+**`build_skill_catalog(skills)`** — 目录格式：
+- 每条 `- <name> — <description>`
+- 附带 `read_skill` 使用指引
 
 ## 非目标
 


### PR DESCRIPTION
## Summary

Implements the high- and medium-priority hardening items identified by the DeepSeek Harness source analysis (see the analysis doc and discussion), plus the supporting documentation updates.

## Changes

### High priority

1. **Tool output spill** (`tools.rs`, `executor.rs`) — oversized tool outputs (32KB/1000 lines) are no longer destroyed by truncation: the full output is written to `.clausura/archives/tool-output-{task_id}-{seq}.txt` and the truncated result carries a locator hint, so the agent can page through the rest with `read_file` (offset/limit). Files are cleaned up on exit 0 like the other archives.
2. **Skill progressive disclosure** (`skills.rs`, `config.rs`, `types.rs`, `tools.rs`, `executor.rs`) — only a catalog (name + description) is inlined into the system prompt; a new `read_skill` tool serves full bodies on demand. Frontmatter `name`/`description` are parsed at config load; falls back to the ref basename / first body line. `TaskContract` gains a `skills` field.
3. **Append-only run event log** (new `eventlog.rs`) — every run writes `run-{task_id}.events.jsonl` with full LLM requests/responses, tool calls/results, truncation events (archive path + compaction summary) and checkpoints carrying the complete message state. `--resume` falls back to the log's last checkpoint when the SQLite store under `~/.clausura` is unavailable (ephemeral CI), so checkpoints now survive where they previously didn't.

### Medium priority

4. **Reactive compaction** (`provider.rs`, `agent.rs`, `context.rs`) — provider context-overflow errors (HTTP 400 with context-length wording, matched via `is_context_overflow_err`) trigger a 50%-budget truncation plus a single request retry; a second overflow marks the run incomplete instead of failing immediately.
5. **Repeat-call reminders** (`agent.rs`) — identical (tool, canonicalized args) invocations inject escalating advisories at 3/5/8 consecutive calls, helping the model break out of loops before `max_iterations` expires. Purely advisory; never blocks execution.
6. **Findings-schema retries** (`agent.rs`) — a Stop answer whose findings JSON fails to parse gets the parse error plus the expected schema back as a corrective prompt, bounded to 2 attempts before the run errors with `MalformedFindings`.
7. **README/docs positioning** — new "Clausura vs. generic agent harnesses" comparison section; updated skills guide, configuration reference, tool table, spill/compaction/event-log documentation (`README.md`, `docs/guide/*`, `docs/skill-as-task.md`).

## Validation

- `cargo test --workspace`: 338 passed, 0 failed (new unit tests for spill, skill resolution/catalog/read_skill, event log append/replay, reactive compaction, repeat reminders, findings retries, cleanup)
- `cargo clippy --all-targets -- -D warnings`: clean (also enforced by the pre-commit hook)
- `cargo fmt --all --check`: clean

## Notes

- `--resume` semantics are unchanged when the SQLite store is present; the event log only adds a fallback.
- Skill behavior changed: bodies are no longer inlined into the system prompt (progressive disclosure). The catalog keeps names/descriptions visible to the model at all times.
