### PR TITLE
chore: harden dependency gates and fix security advisories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Test
         run: cargo test --workspace
@@ -60,6 +60,17 @@ jobs:
 
       - name: Run cargo audit
         run: cargo audit
+
+  deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
 
   build:
     name: Build (${{ matrix.os }})

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Test
         run: cargo test --workspace
@@ -60,6 +60,17 @@ jobs:
 
       - name: Run cargo audit
         run: cargo audit
+
+  deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
 
   build:
     name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -79,14 +79,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "assert-json-diff"
@@ -129,17 +129,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -296,7 +285,6 @@ version = "1.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "atty",
  "clap",
  "clausura-core",
  "colored",
@@ -457,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -643,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -698,15 +686,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1105,7 +1084,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1129,7 +1108,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1554,7 +1533,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1728,7 +1707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1796,7 +1775,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2374,28 +2353,6 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt release clean
+.PHONY: build test lint fmt deny release clean
 
 build:
 	cargo build --workspace
@@ -7,11 +7,14 @@ test:
 	cargo test --workspace
 
 lint:
-	cargo clippy --workspace -- -D warnings
+	cargo clippy --workspace --all-targets -- -D warnings
 
 fmt:
 	cargo fmt --all
 	cargo fmt --check --all
+
+deny:
+	cargo deny check
 
 release:
 	cargo build --release

--- a/crates/clausura-cli/Cargo.toml
+++ b/crates/clausura-cli/Cargo.toml
@@ -14,7 +14,6 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
 colored = "2"
-atty = "0.2"
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/clausura-cli/src/main.rs
+++ b/crates/clausura-cli/src/main.rs
@@ -3,6 +3,7 @@ use colored::*;
 use commands::eval::EvalArgs;
 use commands::run::RunArgs;
 use commands::snapshot::SnapshotArgs;
+use std::io::IsTerminal;
 
 mod commands;
 
@@ -37,7 +38,7 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    colored::control::set_override(atty::is(atty::Stream::Stderr));
+    colored::control::set_override(std::io::stderr().is_terminal());
 
     let cli = Cli::parse();
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,33 @@
+# Configuration for `cargo deny check` — dependency policy gate.
+# Docs: https://embarkstudios.github.io/cargo-deny/
+# Runs locally via `make deny`; wired into CI in .github/workflows/main.yml and pr.yml.
+
+[advisories]
+# Security advisories are also gated by `cargo audit` (see .cargo/audit.toml).
+# Keep both ignore lists in sync; leave empty by default.
+ignore = []
+
+[bans]
+# The tree retains some intentional minor-version duplicates (mostly windows-*
+# platform crates, plus transitive range overlaps such as thiserror 1.x/2.x and
+# base64 0.21/0.22). Security-relevant aspects are covered by advisory checks,
+# so duplicates are a warning rather than a hard error.
+multiple-versions = "warn"
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unlicense",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## Summary

Quality-gate hardening pass on the repo's own CI, based on the ROI research for clippy / rustfmt / cargo audit:

**P0 — fix the currently-red cargo audit gate** (main branch was failing since RUSTSEC-2026-0258 was published 2026-08-17):
- `h2` 0.4.14 → 0.4.19 (RUSTSEC-2026-0258, unbounded empty DATA frames DoS on the reqwest→hyper path)
- `anyhow` 1.0.102 → 1.0.104 (RUSTSEC-2026-0190, `Error::downcast_mut` unsoundness)
- drop `atty` 0.2.14 (RUSTSEC-2021-0145 + RUSTSEC-2024-0375, unmaintained) — replaced by `std::io::IsTerminal`, zero-dep equivalent

**P1 — align clippy gating**: CI ran `cargo clippy --workspace` while the pre-commit hook used `--all-targets`, so test code could bypass CI. Now consistent in main.yml, pr.yml, and Makefile.

**P3 — add cargo-deny**: new `deny.toml` (advisories gate, license allowlist, `unknown-registry`/`unknown-git` denied, `multiple-versions` left as warning — 20 duplicate groups are mostly windows-* platform crates) plus a `deny` job in both workflows using the official `EmbarkStudios/cargo-deny-action@v2`. `make deny` for local runs.

## Verification (all local)

| check | result |
|---|---|
| cargo fmt --all -- --check | ✅ |
| cargo clippy --workspace --all-targets -- -D warnings | ✅ |
| cargo audit | ✅ 0 vulnerabilities (was 1 + 3 warnings) |
| cargo deny check | ✅ advisories / bans / licenses / sources all ok |
| cargo test --workspace | ✅ 354 + 1 integration tests |