### PR TITLE
chore: local regression entrypoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy to .env and fill in your key. .env is git-ignored.
+#
+# Any OpenAI-compatible endpoint works: set CLAUSURA_VENDOR to a known
+# shorthand (openai | deepseek | groq | ollama | anthropic) and, for custom
+# endpoints, CLAUSURA_BASE_URL.
+export CLAUSURA_API_KEY=sk-your-key-here
+export CLAUSURA_VENDOR=deepseek
+export CLAUSURA_MODEL=deepseek-chat

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt deny release clean
+.PHONY: build test lint fmt deny release clean regression
 
 build:
 	cargo build --workspace
@@ -21,3 +21,12 @@ release:
 
 clean:
 	cargo clean
+
+# Local regression: run the sharded-audit eval scenario against a live LLM.
+# Credentials come from .env (git-ignored — copy .env.example). Costs real
+# tokens; baseline-diff a previous report with:
+#   make regression OUT="--baseline eval-results/eval-report.json"
+regression: build
+	. ./.env && ./target/debug/clausura eval --config eval/eval.yaml \
+		--scenario sharded-security-audit --model "$${CLAUSURA_MODEL}" \
+		--out-dir eval-results $(OUT)


### PR DESCRIPTION
Adds `make regression`: loads credentials from a git-ignored `.env` (see `.env.example`), builds, and runs the `sharded-security-audit` eval scenario (sharded + monolithic variants) against a live LLM, writing the report to `eval-results/`. Baseline diffing via `make regression OUT="--baseline eval-results/eval-report.json"`.

First run on this entrypoint (deepseek-chat):

| variant | exit | recall | tokens | time |
|---|---|---|---|---|
| sharded | 1 | 100% | 35,572 | 16.1s |
| monolithic | 2 (context_limit) | 0% | 5,293 | 3.9s |

Matches the GLM-5.3-Flash baseline from #24. Real keys never enter the repo (`.env` is git-ignored; only the placeholder example is committed).