### PR TITLE
fix: review committed PR changes and preserve CI reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,16 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      - name: Test Action orchestration
+        if: runner.os == 'Linux'
+        run: python3 scripts/test_action.py
+
       - name: Test
         run: cargo test --workspace
+
+      - name: Test PR review with mock provider
+        if: runner.os == 'Linux'
+        run: python3 scripts/test_ci_review.py
 
   audit:
     name: Security Audit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,8 +34,16 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      - name: Test Action orchestration
+        if: runner.os == 'Linux'
+        run: python3 scripts/test_action.py
+
       - name: Test
         run: cargo test --workspace
+
+      - name: Test PR review with mock provider
+        if: runner.os == 'Linux'
+        run: python3 scripts/test_ci_review.py
 
   audit:
     name: Security Audit

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ clausura run
 ```bash
 clausura run --validate-config
 clausura run --dry-run  # show the execution plan
+clausura run --base origin/main  # committed PR changes; fetch the base/history first
 ```
 
 ### Exit codes
@@ -362,6 +363,7 @@ clausura run [OPTIONS]
       --timeout <SECS>      Timeout override
       --max-iterations <N>  Max agent loop iterations  [default: 10]
       --shell-timeout <SECS>  Per-command shell_exec timeout  [default: 120]
+      --base <REF>             Review merge-base(REF, HEAD)..HEAD (also overrides sharding.base)
       --workspace <PATH>    Workspace root            [default: cwd]
       --output <PATH>       SARIF output path          [default: clausura-output.sarif]
       --summary <PATH>      Machine-readable run summary JSON (status, reason, findings count, usage)
@@ -403,67 +405,68 @@ Clausura auto-detects your CI environment using well-known environment variables
 
 ### GitHub Actions
 
-Use the composite action directly:
+Use a full PR workflow, including checkout of the PR head and history:
 
 ```yaml
-- uses: liuyanghejerry/Clausura@v1
-  with:
-    config: .clausura.yaml
-    api_key: ${{ secrets.LLM_API_KEY }}
-    model: gpt-4o
-    vendor: openai
-    token_budget: 32000
-    timeout: 300
-    version: latest        # optional: release version to install (e.g. "1.0.8", default "latest")
+# Copy to .github/workflows/clausura.yml in the repository to review.
+# Use an Action ref and binary release containing --base (after v1.7.0).
+name: Clausura Review
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  review:
+    # Fork PRs and Dependabot do not receive the model secret in this workflow.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Install configured MCP servers / language servers here, before review.
+      - name: Review committed PR changes
+        id: clausura
+        uses: liuyanghejerry/Clausura@v1
+        with:
+          config: .clausura.yaml
+          api_key: ${{ secrets.LLM_API_KEY }}
+          base: ${{ github.event.pull_request.base.sha }}
 ```
 
-The action downloads the matching release binary for the runner's OS/arch (Linux and macOS, x86_64 and aarch64), verifies it against the release's SHA256 `checksums.txt`, and adds it to `PATH` before running.
+The updated Action / `--base` behavior requires a release after v1.7.0 containing
+these changes. Until then, build this branch; see the
+[CI guide](docs/guide/ci-integration.md) for the direct-binary path.
 
-Or run via the binary:
+The Action reviews `merge-base(base, HEAD)..HEAD`, uploads SARIF, summary JSON
+(when available), the execution log and exit code, then preserves the review's
+pass/fail result. Missing history fails before model calls. Install MCP and
+language servers **before** invoking the Action. Fork/Dependabot PRs are skipped
+in this secret-backed example; arrange separate trusted review for them.
 
-```yaml
-- name: Run Clausura
-  run: clausura run
-  env:
-    CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
-```
+See the [complete workflow](examples/github-actions-review.yml) and
+[CI guide](docs/guide/ci-integration.md) for optional code-scanning upload, matrix
+artifact names, permissions, direct binary and Docker usage.
 
-### GitLab CI
+### GitLab CI, Jenkins and generic CI
 
-```yaml
-clausura-review:
-  image: ghcr.io/liuyanghejerry/clausura:latest
-  script:
-    - clausura run
-  variables:
-    CLAUSURA_API_KEY: $LLM_API_KEY
-    CLAUSURA_MODEL: "gpt-4o"
-```
-
-### Jenkins
-
-```groovy
-stage('Code Review') {
-    environment {
-        CLAUSURA_API_KEY = credentials('llm-api-key')
-    }
-    steps {
-        sh 'clausura run --model gpt-4o'
-    }
-}
-```
-
-### Generic CI
-
-Set `CI=true` and the relevant `CI_*` environment variables:
+CI detection supplies metadata; select the committed review range explicitly:
 
 ```bash
-export CI=true
-export CLAUSURA_API_KEY=sk-...
-clausura run
+# Ensure the base ref and full history are available in the checkout.
+clausura run --base origin/main --summary clausura-summary.json
 ```
 
-Custom context variables for Generic CI: `CI_REPO`, `CI_PR_NUMBER`, `CI_COMMIT_SHA`, `CI_BRANCH`.
+On GitLab MR pipelines use `--base "$CI_MERGE_REQUEST_DIFF_BASE_SHA"` with
+`GIT_DEPTH: "0"`; on Jenkins fetch the target branch before passing its ref.
+Upload existing SARIF/summary files even on failure. The
+[CI integration guide](docs/guide/ci-integration.md) contains platform examples.
+
+Without `--base`, non-sharded CLI runs retain working-tree diff behavior.
+For sharded runs, `--base` overrides the configured `sharding.base`.
 
 ### Supported platforms
 
@@ -550,14 +553,10 @@ RUN npm i -g typescript-language-server
 RUN pip install pyright
 ```
 
-For GitHub Actions:
+For GitHub Actions, add these dependency steps **between checkout and the
+Clausura Action** in the complete workflow above:
 
 ```yaml
-- uses: liuyanghejerry/Clausura@v1
-  with:
-    config: .clausura.yaml
-    api_key: ${{ secrets.LLM_API_KEY }}
-
 - name: Install agent-lsp
   run: curl -fsSL https://raw.githubusercontent.com/blackwell-systems/agent-lsp/main/install.sh | sh
 
@@ -568,10 +567,16 @@ For GitHub Actions:
     pip install pyright
 
 - name: Run review with LSP
-  run: clausura run
-  env:
-    CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+  id: clausura
+  uses: liuyanghejerry/Clausura@v1
+  with:
+    config: examples/mcp-lsp-review.yaml
+    api_key: ${{ secrets.LLM_API_KEY }}
+    base: ${{ github.event.pull_request.base.sha }}
 ```
+
+The Action installs Clausura and executes the review once; it is not an
+install-only step. MCP tools/preflight currently require the non-sharded path.
 
 ## Architecture
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,18 @@ inputs:
     description: 'Path to .clausura.yaml config file'
     required: false
     default: '.clausura.yaml'
+  base:
+    description: 'Review merge-base(base, HEAD)..HEAD; defaults to the pull request base SHA'
+    required: false
+    default: ${{ github.event.pull_request.base.sha }}
+  artifact_name:
+    description: 'Unique report artifact name (set per invocation when running multiple reviews)'
+    required: false
+    default: clausura-review-${{ github.job }}-${{ github.run_attempt }}
+  upload_artifact:
+    description: 'Upload SARIF, summary JSON and execution log even when review fails'
+    required: false
+    default: 'true'
   model:
     description: 'Override the LLM model'
     required: false
@@ -26,6 +38,20 @@ inputs:
   timeout:
     description: 'Override timeout in seconds'
     required: false
+
+outputs:
+  exit_code:
+    description: 'Clausura exit code: 0 pass, 1 violation, 2 runtime error/incomplete, 3 config error'
+    value: ${{ steps.review.outputs.exit-code }}
+  sarif:
+    description: 'SARIF path (file may be absent on setup/config errors)'
+    value: ${{ steps.review.outputs.report-dir }}/output.sarif
+  sarif_exists:
+    description: 'Whether this invocation produced a SARIF file'
+    value: ${{ steps.review.outputs.sarif-exists }}
+  summary:
+    description: 'Run summary JSON path (file may be absent on setup/config errors)'
+    value: ${{ steps.review.outputs.report-dir }}/summary.json
 
 runs:
   using: 'composite'
@@ -85,14 +111,33 @@ runs:
       shell: bash
       run: clausura --version
 
-    - run: clausura run --config ${{ inputs.config }}
+    - name: Run review and record verdict
+      id: review
       shell: bash
       env:
-        CLAUSURA_API_KEY: ${{ inputs.api_key }}
-        CLAUSURA_MODEL: ${{ inputs.model }}
-        CLAUSURA_VENDOR: ${{ inputs.vendor }}
-        CLAUSURA_TOKEN_BUDGET: ${{ inputs.token_budget }}
-        CLAUSURA_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_CONFIG: ${{ inputs.config }}
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_API_KEY: ${{ inputs.api_key }}
+        INPUT_MODEL: ${{ inputs.model }}
+        INPUT_VENDOR: ${{ inputs.vendor }}
+        INPUT_TOKEN_BUDGET: ${{ inputs.token_budget }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+      run: bash "$GITHUB_ACTION_PATH/scripts/run-action.sh"
+
+    - name: Upload review reports
+      if: ${{ always() && inputs.upload_artifact == 'true' && steps.review.outputs.report-dir != '' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ steps.review.outputs.report-dir }}
+        if-no-files-found: warn
+
+    - name: Apply review verdict
+      if: ${{ always() && steps.review.outputs.exit-code != '' }}
+      shell: bash
+      env:
+        REVIEW_EXIT_CODE: ${{ steps.review.outputs.exit-code }}
+      run: exit "$REVIEW_EXIT_CODE"
 
 branding:
   icon: 'check-circle'

--- a/crates/clausura-cli/src/commands/run.rs
+++ b/crates/clausura-cli/src/commands/run.rs
@@ -43,6 +43,10 @@ pub struct RunArgs {
     #[arg(long)]
     pub workspace: Option<PathBuf>,
 
+    /// Review merge-base(BASE, HEAD)..HEAD; overrides sharding.base when sharding is enabled
+    #[arg(long)]
+    pub base: Option<String>,
+
     /// Output path for SARIF
     #[arg(long)]
     pub output: Option<PathBuf>,
@@ -130,6 +134,22 @@ pub async fn execute(args: RunArgs) -> i32 {
         return 0;
     }
 
+    if let Some(base) = &args.base {
+        match clausura_core::executor::resolve_review_range(&config.workspace, base).await {
+            Ok(range) => {
+                eprintln!("  Review range: {}..{}", range.0, range.1);
+                if let Some(sharding) = &mut config.task.sharding {
+                    sharding.base = range.0.clone();
+                }
+                config.review_range = Some(range);
+            }
+            Err(e) => {
+                eprintln!("Error: Cannot resolve review base {base}: {e}. Fetch the base ref and full history before running.");
+                return 2;
+            }
+        }
+    }
+
     if args.dry_run {
         step(2, total_steps, "Planning execution...");
         eprintln!();
@@ -172,7 +192,8 @@ pub async fn execute(args: RunArgs) -> i32 {
                     );
                 }
                 Err(e) => {
-                    eprintln!("    {} plan unavailable: {}", "Warning:".yellow().bold(), e);
+                    eprintln!("    {} plan unavailable: {}", "Error:".red().bold(), e);
+                    return 2;
                 }
             }
         } else {

--- a/crates/clausura-cli/tests/cli_tests.rs
+++ b/crates/clausura-cli/tests/cli_tests.rs
@@ -20,7 +20,8 @@ fn test_run_help() {
         .stdout(predicate::str::contains("--config"))
         .stdout(predicate::str::contains("--model"))
         .stdout(predicate::str::contains("--vendor"))
-        .stdout(predicate::str::contains("--dry-run"));
+        .stdout(predicate::str::contains("--dry-run"))
+        .stdout(predicate::str::contains("--base"));
 }
 
 #[test]

--- a/crates/clausura-core/src/config.rs
+++ b/crates/clausura-core/src/config.rs
@@ -44,6 +44,8 @@ pub struct Config {
     /// `status`, `reason`, findings count, exit code, token usage, and
     /// duration. `None` disables the summary (non-sharded default).
     pub summary: Option<PathBuf>,
+    /// Explicit committed review range (merge-base SHA, head SHA), set by `--base`.
+    pub review_range: Option<(String, String)>,
     /// Whether to resume from a previous checkpoint.
     pub resume: bool,
     /// Log output format.
@@ -641,6 +643,7 @@ impl Config {
             workspace,
             output,
             summary: None,
+            review_range: None,
             resume,
             log_format,
         })

--- a/crates/clausura-core/src/executor.rs
+++ b/crates/clausura-core/src/executor.rs
@@ -80,6 +80,28 @@ async fn run_git_output(workspace: &Path, args: &[&str]) -> Result<String, Strin
     }
 }
 
+/// Resolve the PR's committed range before making any model requests.
+/// Missing refs/history are errors, never an empty successful review.
+pub async fn resolve_review_range(
+    workspace: &Path,
+    base: &str,
+) -> Result<(String, String), String> {
+    let base_sha = run_git_output(
+        workspace,
+        &[
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            &format!("{base}^{{commit}}"),
+        ],
+    )
+    .await?;
+    let head = run_git_output(workspace, &["rev-parse", "--verify", "HEAD^{commit}"]).await?;
+    let merge_base =
+        run_git_output(workspace, &["merge-base", base_sha.trim(), head.trim()]).await?;
+    Ok((merge_base.trim().to_string(), head.trim().to_string()))
+}
+
 /// Collect per-file diffs between `sharding.base` (via merge-base) and HEAD,
 /// run the deterministic risk scan, and plan shards.
 async fn collect_shard_plan(
@@ -610,8 +632,16 @@ async fn execute_single_task(config: &Config) -> ExecutionReport {
         &config.task.tool_allowlist,
         config.task.shell_timeout_secs,
         &config.task.shell_env_passthrough,
-        Some(spill_store),
+        Some(spill_store.clone()),
     );
+
+    if let Some(range) = &config.review_range {
+        tools.register(
+            crate::tools::GitDiffTool::new(config.workspace.clone())
+                .with_review_range(range.clone())
+                .with_spill_maybe(Some(spill_store)),
+        );
+    }
 
     // Progressive skill disclosure: bodies served by read_skill on demand.
     if !config.task.skills.is_empty() {
@@ -721,6 +751,17 @@ async fn execute_single_task(config: &Config) -> ExecutionReport {
             config.task.prompt_template.clone(),
         )]
     };
+
+    if let Some((base, head)) = &config.review_range {
+        initial_messages.push(Message::new(
+            Role::User,
+            format!(
+                "Review committed changes from {base} to {head}. Start with git_diff; \
+                     it is pinned to this range even in a clean checkout. Read surrounding \
+                     files only as needed to validate findings."
+            ),
+        ));
+    }
 
     // Inject preflight summary into agent context (if any findings).
     if let Some(summary) = preflight_summary {

--- a/crates/clausura-core/src/tools.rs
+++ b/crates/clausura-core/src/tools.rs
@@ -315,6 +315,7 @@ impl Tool for ReadFileTool {
 /// Runs git diff to get code changes.
 pub struct GitDiffTool {
     workspace_root: PathBuf,
+    review_range: Option<(String, String)>,
     spill: Option<Arc<SpillStore>>,
 }
 
@@ -323,7 +324,15 @@ impl GitDiffTool {
         Self {
             workspace_root,
             spill: None,
+            review_range: None,
         }
+    }
+
+    /// Pin review diffs to committed changes, independent of worktree edits and
+    /// model-supplied base/staged arguments. Path and context remain available.
+    pub fn with_review_range(mut self, range: (String, String)) -> Self {
+        self.review_range = Some(range);
+        self
     }
 
     /// Attach a spill store (if any) so oversized outputs are saved to disk
@@ -360,6 +369,11 @@ impl Tool for GitDiffTool {
     }
 
     fn description(&self) -> &str {
+        if self.review_range.is_some() {
+            return "Get committed changes in the configured PR range. The range is fixed; \
+                    base and staged arguments do not override it. Use path to select a file \
+                    and context for surrounding lines.";
+        }
         "Get the git diff. Use 'base' to diff against a branch, or 'staged' for staged \
          changes only. Prefer 'path' to scope the diff to a single file (much cheaper \
          than diffing the whole repo), and 'context' to request more surrounding \
@@ -400,7 +414,10 @@ impl Tool for GitDiffTool {
         if let Some(c) = context {
             git_args.push(format!("--unified={c}"));
         }
-        if let Some(base_ref) = base {
+        if let Some((merge_base, head)) = &self.review_range {
+            git_args.push(merge_base.clone());
+            git_args.push(head.clone());
+        } else if let Some(base_ref) = base {
             git_args.push(base_ref.to_string());
         } else if staged {
             git_args.push("--cached".to_string());
@@ -1614,6 +1631,56 @@ mod tests {
             .output()
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_review_range_in_clean_diverged_checkout() {
+        let (_tmp, root) = setup_workspace();
+        init_git_repo(&root).await;
+        std::fs::write(root.join("shared.txt"), "original\n").unwrap();
+        run_git_in(&root, &["add", "."]).await;
+        run_git_in(&root, &["commit", "-m", "initial"]).await;
+        run_git_in(&root, &["branch", "review-base"]).await;
+        run_git_in(&root, &["checkout", "-b", "feature"]).await;
+        std::fs::write(root.join("feature.txt"), "PR change\n").unwrap();
+        run_git_in(&root, &["add", "."]).await;
+        run_git_in(&root, &["commit", "-m", "feature"]).await;
+        run_git_in(&root, &["checkout", "review-base"]).await;
+        std::fs::write(root.join("base-only.txt"), "unrelated base change\n").unwrap();
+        run_git_in(&root, &["add", "."]).await;
+        run_git_in(&root, &["commit", "-m", "base advanced"]).await;
+        run_git_in(&root, &["checkout", "feature"]).await;
+
+        assert!(GitDiffTool::new(root.clone())
+            .execute(serde_json::json!({}))
+            .await
+            .unwrap()
+            .is_empty());
+        let range = crate::executor::resolve_review_range(&root, "review-base")
+            .await
+            .unwrap();
+        let tool = GitDiffTool::new(root.clone()).with_review_range(range);
+        let diff = tool.execute(serde_json::json!({})).await.unwrap();
+        assert!(diff.contains("PR change"));
+        assert!(!diff.contains("base-only"));
+        // Dirty worktrees and model-supplied arguments cannot change the PR scope.
+        std::fs::write(root.join("shared.txt"), "local edit\n").unwrap();
+        let fixed = tool
+            .execute(serde_json::json!({"base": "HEAD", "staged": true}))
+            .await
+            .unwrap();
+        assert_eq!(diff, fixed);
+        assert!(tool
+            .execute(serde_json::json!({"path": "shared.txt"}))
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(crate::executor::resolve_review_range(&root, "missing-ref")
+            .await
+            .is_err());
+        assert!(crate::executor::resolve_review_range(&root, "--help")
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/docs/guide/ci-integration.md
+++ b/docs/guide/ci-integration.md
@@ -16,78 +16,123 @@ When detected, Clausura gathers repository, PR number, commit SHA, and branch co
 
 ## GitHub Actions
 
-### Option A: Composite Action (Simplest)
+### Complete PR workflow
+
+Copy [`examples/github-actions-review.yml`](../../examples/github-actions-review.yml)
+to `.github/workflows/clausura.yml`. The updated Action and `--base` CLI option
+require a release containing these changes (after v1.7.0); until released,
+build this branch and use the direct-binary steps below.
 
 ```yaml
-name: Code Review
+# Copy to .github/workflows/clausura.yml in the repository to review.
+# Use an Action ref and binary release containing --base (after v1.7.0).
+name: Clausura Review
 on: [pull_request]
-
+permissions:
+  contents: read
 jobs:
   review:
+    # Fork PRs and Dependabot do not receive the model secret in this workflow.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 2          # Required for git diff
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
-      - uses: liuyanghejerry/Clausura@v1
+      # Install configured MCP servers / language servers here, before review.
+      - name: Review committed PR changes
+        id: clausura
+        uses: liuyanghejerry/Clausura@v1
         with:
           config: .clausura.yaml
           api_key: ${{ secrets.LLM_API_KEY }}
-          model: gpt-4o           # Optional overrides
-          vendor: openai
-          token_budget: 32000
-          timeout: 300
-          version: latest         # Or pin: "1.2.1"
+          base: ${{ github.event.pull_request.base.sha }}
 ```
 
-The composite action:
-1. Downloads the matching release binary for the runner's OS/arch
-2. Verifies the binary against the release's SHA256 checksums
-3. Runs `clausura run` with your config
+The checkout uses the PR head commit, with full history to resolve the common
+ancestor with the PR base. `fetch-depth: 2` is not sufficient for arbitrary
+multi-commit or diverged PRs. The Action defaults `base` to the PR's base SHA;
+an explicit `base` input overrides it. It does not fetch or change your checkout.
+An unavailable base/history fails with exit 2 before calling the model.
 
-### Option B: Direct Binary
+The Action downloads and verifies the release binary, runs the review, writes a
+job summary, uploads reports, then applies the original exit code. Artifacts
+include SARIF, summary JSON (when produced), the execution log and `exit-code.txt`.
+Setup/config errors can occur before SARIF/JSON exists. Installation failures are
+reported in the installation step's log. Gate violations remain failures even
+when report upload succeeds.
 
-```yaml
-name: Code Review
-on: [pull_request]
+Use `artifact_name` to give each invocation a unique name in matrix jobs or when
+running multiple reviews in one job. Set `upload_artifact: 'false'` to manage
+artifacts yourself (for example on GitHub Enterprise Server). Outputs `exit_code`,
+`sarif`, and `summary` are available to subsequent steps. Omitted model/vendor/
+budget inputs preserve the caller's environment and YAML settings.
 
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
+This example reviews same-repository PRs with a model secret. Fork and Dependabot
+PRs are skipped because they do not receive that secret; a skipped job is not
+proof that those changes were reviewed. Arrange a separate trusted review before
+requiring coverage of those PRs. Do not switch to `pull_request_target` to expose
+secrets to untrusted PR code.
 
-      - name: Install Clausura
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
+### Direct binary (or build from source)
 
-      - name: Run Clausura
-        run: clausura run
-        env:
-          CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
-
-      - name: Upload SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: clausura-output.sarif
-```
-
-Uploading SARIF to GitHub integrates findings directly into the PR diff view and the Security tab.
-
-### Option C: Docker
+Build `cargo build --release --package clausura-cli` in a trusted Clausura source
+checkout and put the resulting binary on the runner PATH. In the target repository,
+use the same checkout and dependency ordering as above, replacing the Action with:
 
 ```yaml
 - name: Run Clausura
-  run: |
-    docker run --rm \
-      -v ${{ github.workspace }}:/workspace \
-      -e CLAUSURA_API_KEY=${{ secrets.LLM_API_KEY }} \
-      ghcr.io/liuyanghejerry/clausura:latest run
+  env:
+    CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+    REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
+  run: clausura run --base "$REVIEW_BASE" --summary clausura-summary.json
+
+- name: Upload reports
+  if: always()
+  uses: actions/upload-artifact@v7
+  with:
+    name: clausura-review
+    path: |
+      clausura-output.sarif
+      clausura-summary.json
+    if-no-files-found: warn
 ```
+
+After release, install a matching released binary instead of building from source.
+For Docker, pass `--base` too, mount the checkout with its Git history, and forward
+secrets by environment name rather than inserting their value into the command:
+
+```yaml
+- name: Review with Docker
+  env:
+    CLAUSURA_API_KEY: ${{ secrets.LLM_API_KEY }}
+    REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
+  run: |
+    docker run --rm -v "$GITHUB_WORKSPACE:/workspace" \
+      -e CLAUSURA_API_KEY ghcr.io/liuyanghejerry/clausura:latest \
+      run --base "$REVIEW_BASE" --summary /workspace/clausura-summary.json
+```
+
+### Optional GitHub code scanning
+
+Artifact upload works without enabling code scanning. To additionally publish
+SARIF to code scanning, enable it for the repository, add `security-events: write`
+to job permissions, and place this step after the Action:
+
+```yaml
+- name: Publish SARIF to code scanning
+  if: ${{ always() && steps.clausura.outputs.sarif_exists == 'true' }}
+  uses: github/codeql-action/upload-sarif@v4
+  with:
+    sarif_file: ${{ steps.clausura.outputs.sarif }}
+```
+
+Availability depends on repository visibility and enabled GitHub security
+features; see [GitHub's SARIF upload requirements](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/upload-sarif-file).
 
 ### Branch Protection
 
@@ -99,7 +144,8 @@ After setting up the workflow, configure branch protection rules to require the 
 4. Search for and select the `review` job
 5. Save
 
-Now PRs can't be merged unless Clausura passes.
+For jobs that execute, a gate violation or incomplete review blocks merging.
+The fork/Dependabot skip policy above still needs a separate review policy.
 
 ## GitLab CI
 
@@ -108,14 +154,16 @@ clausura-review:
   image: ghcr.io/liuyanghejerry/clausura:latest
   stage: review
   script:
-    - clausura run
+    - clausura run --base "$CI_MERGE_REQUEST_DIFF_BASE_SHA" --summary clausura-summary.json
   variables:
     CLAUSURA_API_KEY: $LLM_API_KEY
+    GIT_DEPTH: "0"
     CLAUSURA_MODEL: "gpt-4o"
   artifacts:
     when: always
     paths:
       - clausura-output.sarif
+      - clausura-summary.json
     expire_in: 30 days
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -128,9 +176,10 @@ clausura-review:
   stage: review
   script:
     - curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
-    - clausura run
+    - clausura run --base "$CI_MERGE_REQUEST_DIFF_BASE_SHA" --summary clausura-summary.json
   variables:
     CLAUSURA_API_KEY: $LLM_API_KEY
+    GIT_DEPTH: "0"
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 ```
@@ -152,7 +201,7 @@ pipeline {
             steps {
                 sh '''
                     curl -fsSL https://raw.githubusercontent.com/liuyanghejerry/Clausura/main/install.sh | bash
-                    clausura run --model gpt-4o
+                    clausura run --model gpt-4o --base "origin/$CHANGE_TARGET" --summary clausura-summary.json
                 '''
             }
         }
@@ -160,7 +209,7 @@ pipeline {
 
     post {
         always {
-            archiveArtifacts artifacts: 'clausura-output.sarif', fingerprint: true
+            archiveArtifacts artifacts: 'clausura-output.sarif,clausura-summary.json', allowEmptyArchive: true, fingerprint: true
         }
     }
 }
@@ -168,7 +217,7 @@ pipeline {
 
 ### GitHub Branch Source / Multibranch Pipeline
 
-Clausura auto-detects the PR context from Jenkins environment variables when using the GitHub Branch Source plugin.
+Clausura auto-detects PR metadata from Jenkins environment variables. Fetch the target branch and enough history for merge-base before review; this example assumes `origin/$CHANGE_TARGET` exists locally.
 
 ## Generic CI
 
@@ -182,7 +231,7 @@ export CI_COMMIT_SHA="abc123def456"
 export CI_BRANCH="feature/new-login"
 
 export CLAUSURA_API_KEY=sk-...
-clausura run
+clausura run --base origin/main --summary clausura-summary.json
 ```
 
 | Variable | Purpose | Required |
@@ -218,20 +267,20 @@ prompt_template: |
 
 ## SARIF Upload
 
-Clausura always writes `clausura-output.sarif`. In CI, upload it to your platform's security dashboard:
+Completed agent executions write SARIF; setup/config errors may not. Upload existing reports even when review fails:
 
 ### GitHub Advanced Security
 
 ```yaml
-- uses: github/codeql-action/upload-sarif@v3
-  if: always()
+- uses: github/codeql-action/upload-sarif@v4
+  if: ${{ always() && hashFiles('clausura-output.sarif') != '' }}
   with:
     sarif_file: clausura-output.sarif
 ```
 
 ### GitLab
 
-SARIF files can be uploaded as pipeline artifacts and viewed with GitLab's SARIF support (GitLab Ultimate).
+Upload SARIF and summary JSON as pipeline artifacts. This does not automatically populate the GitLab security dashboard.
 
 ### Generic
 
@@ -248,7 +297,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with: { fetch-depth: 2 }
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
       - uses: liuyanghejerry/Clausura@v1
         with:
           config: .clausura/security.yaml
@@ -258,14 +310,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with: { fetch-depth: 2 }
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
       - uses: liuyanghejerry/Clausura@v1
         with:
           config: .clausura/i18n.yaml
           api_key: ${{ secrets.LLM_API_KEY }}
 ```
 
-Each job independently passes or fails. Use branch protection rules to require all review jobs.
+Use the same pull_request trigger, permissions and fork/Dependabot condition as
+the complete workflow. Each job independently passes or fails; require the
+appropriate jobs in branch protection.
 
 ## Checkpoint Persistence
 
@@ -275,15 +332,15 @@ For persistent checkpointing in CI, mount a volume at `$HOME/.clausura/`.
 
 ## Best Practices
 
-1. **`fetch-depth: 2`** — Clausura's `git_diff` tool needs the previous commit for comparison. Always set `fetch-depth: 2` (or higher) in your checkout step.
+1. **Use a committed review range** — Fetch full history and the target ref, then pass `--base <ref-or-sha>`. The normal CLI without `--base` retains local working-tree diff behavior; CI metadata detection alone does not select a PR range.
 
 2. **Use secrets for API keys** — Never commit API keys. Use your CI's secrets manager (`${{ secrets.LLM_API_KEY }}`, GitLab CI/CD variables, Jenkins credentials).
 
 3. **Upload SARIF on failure** — Use `if: always()` so SARIF is available for debugging even when the pipeline fails.
 
-4. **Set realistic timeouts** — The CI job timeout should exceed `task.timeout_secs` by a comfortable margin (add 60s for installation and SARIF writing).
+4. **Set a job timeout** — Allow time for installation and uploads. Sharded runs currently apply budgets per shard/attempt, so the overall CI timeout must bound the aggregate run.
 
-5. **Run on PRs, not pushes to main** — Clausura compares against the base branch; running on pushes to `main` without a PR context may not produce meaningful diffs.
+5. **Choose the intended range** — On push/manual runs, supply an explicit base appropriate to the changes being reviewed.
 
 ## Next
 

--- a/examples/github-actions-review.yml
+++ b/examples/github-actions-review.yml
@@ -1,0 +1,27 @@
+# Copy to .github/workflows/clausura.yml in the repository to review.
+# Use an Action ref and binary release containing --base (after v1.7.0).
+name: Clausura Review
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  review:
+    # Fork PRs and Dependabot do not receive the model secret in this workflow.
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Install configured MCP servers / language servers here, before review.
+      - name: Review committed PR changes
+        id: clausura
+        uses: liuyanghejerry/Clausura@v1
+        with:
+          config: .clausura.yaml
+          api_key: ${{ secrets.LLM_API_KEY }}
+          base: ${{ github.event.pull_request.base.sha }}

--- a/examples/mcp-lsp-review.yaml
+++ b/examples/mcp-lsp-review.yaml
@@ -59,12 +59,14 @@ task:
     # LSP 诊断产生的 finding 自动带 rule_id 前缀 "lsp-"
     # 只要有任何 error 级别的 LSP 诊断，就 fail
     - rule: lsp-error
+      description: Block on LSP errors
       min_severity: error
       max_findings: 0
       action: fail
 
     # warning 级别的 LSP 诊断最多允许 5 个
     - rule: lsp-warning
+      description: Warn on excessive LSP warnings
       min_severity: warning
       max_findings: 5
       action: warn

--- a/scripts/run-action.sh
+++ b/scripts/run-action.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Capture the verdict without failing this step, so report upload runs first.
+set -euo pipefail
+
+report_dir="$(mktemp -d "$RUNNER_TEMP/clausura-report.XXXXXX")"
+printf 'report-dir=%s\n' "$report_dir" >> "$GITHUB_OUTPUT"
+args=(run --config "$INPUT_CONFIG" --output "$report_dir/output.sarif" --summary "$report_dir/summary.json")
+if [[ -n "${INPUT_BASE:-}" ]]; then args+=(--base "$INPUT_BASE"); fi
+# Omitted Action inputs must not mask the caller's YAML or environment values.
+if [[ -n "${INPUT_API_KEY:-}" ]]; then export CLAUSURA_API_KEY="$INPUT_API_KEY"; fi
+if [[ -n "${INPUT_MODEL:-}" ]]; then export CLAUSURA_MODEL="$INPUT_MODEL"; fi
+if [[ -n "${INPUT_VENDOR:-}" ]]; then export CLAUSURA_VENDOR="$INPUT_VENDOR"; fi
+if [[ -n "${INPUT_TOKEN_BUDGET:-}" ]]; then export CLAUSURA_TOKEN_BUDGET="$INPUT_TOKEN_BUDGET"; fi
+if [[ -n "${INPUT_TIMEOUT:-}" ]]; then export CLAUSURA_TIMEOUT="$INPUT_TIMEOUT"; fi
+
+set +e
+clausura "${args[@]}" 2>&1 | tee "$report_dir/run.log"
+review_exit=${PIPESTATUS[0]}
+set -e
+printf '%s\n' "$review_exit" > "$report_dir/exit-code.txt"
+printf 'exit-code=%s\n' "$review_exit" >> "$GITHUB_OUTPUT"
+if [[ -f "$report_dir/output.sarif" ]]; then
+  printf 'sarif-exists=true\n' >> "$GITHUB_OUTPUT"
+fi
+
+case "$review_exit" in
+  0) verdict='Passed' ;;
+  1) verdict='Gate violated' ;;
+  2) verdict='Review incomplete or runtime error' ;;
+  3) verdict='Invalid configuration' ;;
+  *) verdict='Execution failed' ;;
+esac
+{
+  printf '### Clausura review\n\n'
+  printf '**%s** (exit code %s).\n\n' "$verdict" "$review_exit"
+  printf 'Reports are available in the workflow artifacts when upload is enabled. '
+  printf 'The JSON summary contains findings count, token usage and completion status. '
+  printf 'Setup/configuration errors may only produce an execution log and exit code.\n'
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/test_action.py
+++ b/scripts/test_action.py
@@ -1,0 +1,70 @@
+"""Offline tests for the Action's shell orchestration; no API key or runner needed."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("run-action.sh").resolve()
+
+
+class ActionTests(unittest.TestCase):
+    def run_review(self, code, overrides=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            binary = root / "clausura"
+            binary.write_text(
+                f"#!{sys.executable}\n"
+                "import json, os, sys\n"
+                "from pathlib import Path\n"
+                "args = sys.argv[1:]\n"
+                "print(json.dumps({'args': args, 'model': os.environ.get('CLAUSURA_MODEL'), "
+                "'vendor': os.environ.get('CLAUSURA_VENDOR')}))\n"
+                "code = int(os.environ['TEST_EXIT'])\n"
+                "if code != 3:\n"
+                "    Path(args[args.index('--output') + 1]).write_text('{}')\n"
+                "    Path(args[args.index('--summary') + 1]).write_text('{}')\n"
+                "sys.exit(code)\n"
+            )
+            binary.chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}",
+                       RUNNER_TEMP=tmp, GITHUB_OUTPUT=str(root / "outputs"),
+                       GITHUB_STEP_SUMMARY=str(root / "job-summary"),
+                       INPUT_CONFIG="config with spaces; $(touch injected).yaml",
+                       INPUT_BASE="base-ref", INPUT_MODEL="", INPUT_VENDOR="",
+                       CLAUSURA_MODEL="caller-model", CLAUSURA_VENDOR="caller-vendor",
+                       TEST_EXIT=str(code))
+            env.update(overrides or {})
+            result = subprocess.run(["bash", str(SCRIPT)], env=env, cwd=tmp,
+                                    capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            outputs = dict(line.split("=", 1) for line in (root / "outputs").read_text().splitlines())
+            self.assertEqual(outputs["exit-code"], str(code))
+            report = Path(outputs["report-dir"])
+            self.assertEqual((report / "exit-code.txt").read_text().strip(), str(code))
+            self.assertTrue((report / "run.log").exists())
+            self.assertEqual((report / "output.sarif").exists(), code != 3)
+            self.assertIn(f"exit code {code}", (root / "job-summary").read_text())
+            self.assertFalse((root / "injected").exists())
+            invocation = json.loads(result.stdout)
+            self.assertEqual(invocation["args"][2], env["INPUT_CONFIG"])
+            return invocation
+
+    def test_all_verdicts_preserved_for_upload(self):
+        for code in (0, 1, 2, 3):
+            with self.subTest(code=code):
+                call = self.run_review(code)
+                self.assertEqual(call["model"], "caller-model")
+                self.assertEqual(call["vendor"], "caller-vendor")
+                self.assertEqual(call["args"][-2:], ["--base", "base-ref"])
+
+    def test_explicit_override_and_non_pr_run(self):
+        call = self.run_review(0, {"INPUT_MODEL": "override", "INPUT_BASE": ""})
+        self.assertEqual(call["model"], "override")
+        self.assertNotIn("--base", call["args"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_review.py
+++ b/scripts/test_ci_review.py
@@ -1,0 +1,124 @@
+"""Exercise --base through the real CLI and a local mock provider, without billing."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+BINARY = Path(__file__).resolve().parents[1] / "target/debug/clausura"
+
+
+class ReviewTests(unittest.TestCase):
+    def test_clean_pr_review_and_missing_base(self):
+        requests = []
+
+        class Provider(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_POST(self):
+                body = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+                requests.append(body)
+                if len(requests) == 1:
+                    message = {"role": "assistant", "content": None, "tool_calls": [{
+                        "id": "diff", "type": "function", "function": {
+                            "name": "git_diff", "arguments": "{}"}}]}
+                    reason = "tool_calls"
+                else:
+                    finding = {"id": "00000000-0000-0000-0000-000000000001",
+                               "rule_id": "test-rule", "severity": "error",
+                               "message": "Seeded PR issue", "evidence": "PR_MARKER"}
+                    message = {"role": "assistant", "content": json.dumps({"findings": [finding]})}
+                    reason = "stop"
+                response = json.dumps({"id": "mock", "choices": [{"index": 0,
+                                      "message": message, "finish_reason": reason}],
+                                      "usage": {"prompt_tokens": 10, "completion_tokens": 10,
+                                                "total_tokens": 20}}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Provider)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                def git(*args):
+                    return subprocess.run(["git", *args], cwd=tmp, capture_output=True,
+                                          text=True, check=True).stdout
+                git("init")
+                git("config", "user.email", "test@example.invalid")
+                git("config", "user.name", "CI Test")
+                (root / "code.txt").write_text("initial\n")
+                git("add", ".")
+                git("commit", "-m", "base")
+                git("branch", "review-base")
+                (root / "code.txt").write_text("initial\nPR_MARKER\n")
+                git("add", ".")
+                git("commit", "-m", "feature")
+                self.assertEqual(git("diff"), "")
+                config = root / "review.yaml"
+                config.write_text('''version: "1"
+task:
+  name: ci-review-smoke
+  model: mock
+  vendor: openai
+  prompt_template: Review the committed PR diff.
+  timeout_secs: 10
+  gating:
+    - rule: test-rule
+      description: Block seeded issue
+      min_severity: error
+      max_findings: 0
+      action: fail
+''')
+                env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUSURA_")}
+                env["CLAUSURA_API_KEY"] = "mock-key"
+                env["CLAUSURA_BASE_URL"] = f"http://127.0.0.1:{server.server_port}/v1"
+                args = [str(BINARY), "run", "--config", str(config),
+                        "--summary", str(root / "summary.json")]
+                result = subprocess.run([*args, "--base", "review-base"], cwd=tmp, env=env,
+                                        capture_output=True, text=True, timeout=20)
+                self.assertEqual(result.returncode, 1, result.stderr)
+                self.assertEqual(len(requests), 2)
+                tool_messages = [m for m in requests[1]["messages"] if m["role"] == "tool"]
+                self.assertIn("PR_MARKER", tool_messages[0]["content"])
+                summary = json.loads((root / "summary.json").read_text())
+                self.assertEqual(summary["status"], "complete")
+                self.assertEqual(summary["exit_code"], 1)
+                self.assertEqual(summary["findings_count"], 1)
+                sarif = json.loads((root / "clausura-output.sarif").read_text())
+                self.assertEqual(sarif["runs"][0]["results"][0]["ruleId"], "test-rule")
+                result = subprocess.run([*args, "--base", "missing-ref"], cwd=tmp, env=env,
+                                        capture_output=True, text=True, timeout=10)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("Fetch the base ref", result.stderr)
+                self.assertEqual(len(requests), 2, "Invalid base must fail before any model call")
+                # CLI base also overrides an unavailable YAML sharding base.
+                with config.open("a") as out:
+                    out.write("  sharding:\n    base: missing-yaml-base\n")
+                result = subprocess.run([*args, "--base", "review-base", "--dry-run"],
+                                        cwd=tmp, env=env, capture_output=True, text=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("1 file(s)", result.stderr)
+                result = subprocess.run([*args, "--dry-run"], cwd=tmp, env=env,
+                                        capture_output=True, text=True, timeout=10)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("plan unavailable", result.stderr)
+                result = subprocess.run([*args, "--base", "missing-ref", "--dry-run"],
+                                        cwd=tmp, env=env, capture_output=True, text=True, timeout=10)
+                self.assertEqual(result.returncode, 2)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A clean CI checkout can produce an empty working-tree diff, leaving a PR review without the committed changes it should inspect. This change adds `clausura run --base <ref-or-sha>` to review `merge-base(base, HEAD)..HEAD`, validates the range before model calls, and makes the GitHub Action preserve reports before applying the review verdict.

- Pin non-sharded `git_diff` calls to the committed range; use `--base` to override `sharding.base`, and fail dry-run planning when the base/history is unavailable.
- Default the Action base to the PR base SHA, upload reports and an execution log, expose the verdict/report outputs, and write a job summary. Preserve caller environment settings when optional Action inputs are omitted.
- Provide a complete PR workflow and correct checkout history, MCP/LSP installation ordering, report upload instructions, and the LSP example's required rule descriptions.
- Add offline Action orchestration and real-CLI/mock-provider tests to CI.

Validation: 409 Rust tests passed; Action orchestration and real-CLI/mock-provider tests passed; LSP config validation, formatting, Clippy, YAML parsing, and `git diff --check` passed. The mock-provider test verifies committed changes in a clean checkout, gate failure with SARIF/summary, missing-base rejection before model calls, and sharding base overrides. Hosted GitHub Actions execution has not yet been verified.

Release compatibility: the updated Action requires a binary release containing `--base` (after v1.7.0). Publish the matching binary before updating the public Action tag; this requirement is documented in the examples and CI guide.
